### PR TITLE
MIX-180 feat: swagger OpenAPI for the backend api

### DIFF
--- a/.github/workflows/SonarQube.yml
+++ b/.github/workflows/SonarQube.yml
@@ -59,9 +59,9 @@ jobs:
           args: >
             -Dproject.settings=sonar-project.properties
 
-      # - name: SonarQube Quality Gate
-      #   uses: SonarSource/sonarqube-quality-gate-action@v1.1.0
-      #   timeout-minutes: 5
-      #   env:
-      #     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      #     SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+      - name: SonarQube Quality Gate
+        uses: SonarSource/sonarqube-quality-gate-action@v1.1.0
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/backend/adonisrc.ts
+++ b/backend/adonisrc.ts
@@ -54,6 +54,7 @@ export default defineConfig({
     () => import('@adonisjs/mail/mail_provider'),
     () => import('@adonisjs/core/providers/edge_provider'),
     () => import('@adonisjs/limiter/limiter_provider'),
+    () => import('@foadonis/openapi/openapi_provider'),
   ],
 
   /*

--- a/backend/app/controllers/achievements_controller.ts
+++ b/backend/app/controllers/achievements_controller.ts
@@ -3,11 +3,16 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { AchievementService } from '#services/achievement_service'
 import Achievement from '#models/achievement'
 import { inject } from '@adonisjs/core'
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
+@ApiTags('Achievements')
 export default class AchievementsController {
   constructor(private achievementService: AchievementService) {}
 
+  @ApiOperation({ summary: 'List all achievements', description: 'Get a list of all achievements in the system' })
+  @ApiResponse({ status: 200, description: 'List of achievements retrieved successfully' })
+  @ApiResponse({ status: 500, description: 'Error while fetching achievements' })
   public async index({ response }: HttpContext) {
     try {
       const achievements = await this.achievementService.getAll()
@@ -17,6 +22,21 @@ export default class AchievementsController {
     }
   }
 
+  @ApiOperation({ summary: 'Create a new achievement', description: 'Create a new achievement with description and type' })
+  @ApiBody({
+    description: 'Achievement data',
+    required: true,
+    schema: {
+      type: 'object',
+      required: ['description', 'type'],
+      properties: {
+        description: { type: 'string', minLength: 1, example: 'Complete 10 games' },
+        type: { type: 'string', minLength: 1, example: 'games_completed' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Achievement created successfully' })
+  @ApiResponse({ status: 500, description: 'Error while creating achievement' })
   public async create({ request, response }: HttpContext) {
     try {
       const result = await this.achievementService.createAchievement(
@@ -35,6 +55,11 @@ export default class AchievementsController {
     }
   }
 
+  @ApiOperation({ summary: 'Get achievement by ID', description: 'Retrieve a specific achievement by its ID' })
+  @ApiParam({ name: 'id', description: 'Achievement ID', required: true })
+  @ApiResponse({ status: 200, description: 'Achievement found' })
+  @ApiResponse({ status: 404, description: 'Achievement not found' })
+  @ApiResponse({ status: 500, description: 'Error while fetching achievement' })
   public async show({ params, response }: HttpContext) {
     try {
       const achievement = await this.achievementService.getById(params.id)
@@ -47,6 +72,22 @@ export default class AchievementsController {
     }
   }
 
+  @ApiOperation({ summary: 'Update achievement', description: 'Update achievement description and/or type' })
+  @ApiParam({ name: 'id', description: 'Achievement ID', required: true })
+  @ApiBody({
+    description: 'Achievement data to update',
+    required: true,
+    schema: {
+      type: 'object',
+      properties: {
+        description: { type: 'string', minLength: 1, example: 'Complete 10 games' },
+        type: { type: 'string', minLength: 1, example: 'games_completed' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Achievement updated successfully' })
+  @ApiResponse({ status: 404, description: 'Achievement not found' })
+  @ApiResponse({ status: 500, description: 'Error while updating achievement' })
   public async update({ params, request, response }: HttpContext) {
     try {
       const result = await this.achievementService.updateAchievement(
@@ -66,6 +107,11 @@ export default class AchievementsController {
     }
   }
 
+  @ApiOperation({ summary: 'Delete achievement', description: 'Delete an achievement permanently' })
+  @ApiParam({ name: 'id', description: 'Achievement ID', required: true })
+  @ApiResponse({ status: 200, description: 'Achievement deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Achievement not found' })
+  @ApiResponse({ status: 500, description: 'Error while deleting achievement' })
   public async delete({ params, response }: HttpContext) {
     try {
       const result = await this.achievementService.deleteAchievement(params.id)

--- a/backend/app/controllers/achievements_controller.ts
+++ b/backend/app/controllers/achievements_controller.ts
@@ -9,7 +9,10 @@ import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/
 export default class AchievementsController {
   constructor(private achievementService: AchievementService) {}
 
-  @ApiOperation({ summary: 'List all achievements', description: 'Get a list of all achievements in the system' })
+  @ApiOperation({
+    summary: 'List all achievements',
+    description: 'Get a list of all achievements in the system',
+  })
   @ApiResponse({ status: 200, description: 'List of achievements retrieved successfully' })
   @ApiResponse({ status: 500, description: 'Error while fetching achievements' })
   public async index({ response }: HttpContext) {
@@ -21,7 +24,10 @@ export default class AchievementsController {
     }
   }
 
-  @ApiOperation({ summary: 'Create a new achievement', description: 'Create a new achievement with description and type' })
+  @ApiOperation({
+    summary: 'Create a new achievement',
+    description: 'Create a new achievement with description and type',
+  })
   @ApiBody({
     description: 'Achievement data',
     required: true,
@@ -54,7 +60,10 @@ export default class AchievementsController {
     }
   }
 
-  @ApiOperation({ summary: 'Get achievement by ID', description: 'Retrieve a specific achievement by its ID' })
+  @ApiOperation({
+    summary: 'Get achievement by ID',
+    description: 'Retrieve a specific achievement by its ID',
+  })
   @ApiParam({ name: 'id', description: 'Achievement ID', required: true })
   @ApiResponse({ status: 200, description: 'Achievement found' })
   @ApiResponse({ status: 404, description: 'Achievement not found' })
@@ -71,7 +80,10 @@ export default class AchievementsController {
     }
   }
 
-  @ApiOperation({ summary: 'Update achievement', description: 'Update achievement description and/or type' })
+  @ApiOperation({
+    summary: 'Update achievement',
+    description: 'Update achievement description and/or type',
+  })
   @ApiParam({ name: 'id', description: 'Achievement ID', required: true })
   @ApiBody({
     description: 'Achievement data to update',

--- a/backend/app/controllers/achievements_controller.ts
+++ b/backend/app/controllers/achievements_controller.ts
@@ -3,10 +3,9 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { AchievementService } from '#services/achievement_service'
 import Achievement from '#models/achievement'
 import { inject } from '@adonisjs/core'
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
+import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
-@ApiTags('Achievements')
 export default class AchievementsController {
   constructor(private achievementService: AchievementService) {}
 

--- a/backend/app/controllers/auth_controller.ts
+++ b/backend/app/controllers/auth_controller.ts
@@ -18,7 +18,8 @@ export default class AuthController {
 
   @ApiOperation({
     summary: 'Register a new user',
-    description: 'Create a new user account. An email verification link will be sent to the provided email address. Rate limited to 5 requests per 15 minutes per IP.',
+    description:
+      'Create a new user account. An email verification link will be sent to the provided email address. Rate limited to 5 requests per 15 minutes per IP.',
   })
   @ApiBody({
     description: 'User registration data',
@@ -30,7 +31,12 @@ export default class AuthController {
         email: { type: 'string', format: 'email', example: 'john@example.com' },
         username: { type: 'string', minLength: 3, example: 'johndoe' },
         password: { type: 'string', format: 'password', minLength: 8, example: 'SecurePass123!' },
-        password_confirmation: { type: 'string', format: 'password', minLength: 8, example: 'SecurePass123!' },
+        password_confirmation: {
+          type: 'string',
+          format: 'password',
+          minLength: 8,
+          example: 'SecurePass123!',
+        },
         firstName: { type: 'string', example: 'John' },
         lastName: { type: 'string', example: 'Doe' },
       },
@@ -72,7 +78,8 @@ export default class AuthController {
 
   @ApiOperation({
     summary: 'Login user',
-    description: 'Authenticate user and receive access and refresh tokens. Email must be verified. Rate limited to 10 requests per 15 minutes.',
+    description:
+      'Authenticate user and receive access and refresh tokens. Email must be verified. Rate limited to 10 requests per 15 minutes.',
   })
   @ApiBody({
     description: 'Login credentials',

--- a/backend/app/controllers/auth_controller.ts
+++ b/backend/app/controllers/auth_controller.ts
@@ -7,9 +7,8 @@ import {
   resendVerificationValidator,
 } from '#validators/auth_validator'
 import { errors } from '@vinejs/vine'
-import { ApiTags, ApiOperation, ApiResponse, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
+import { ApiOperation, ApiResponse, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
 
-@ApiTags('Authentication')
 export default class AuthController {
   private authService: AuthService
 

--- a/backend/app/controllers/game_sessions_controller.ts
+++ b/backend/app/controllers/game_sessions_controller.ts
@@ -2,10 +2,9 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { GameSessionService } from '#services/game_session_service'
 import GameSession from '#models/game_session'
 import { inject } from '@adonisjs/core'
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
+import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
-@ApiTags('Game Sessions')
 export default class GameSessionsController {
   constructor(private gameSessionService: GameSessionService) {}
 

--- a/backend/app/controllers/game_sessions_controller.ts
+++ b/backend/app/controllers/game_sessions_controller.ts
@@ -2,13 +2,22 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { GameSessionService } from '#services/game_session_service'
 import GameSession from '#models/game_session'
 import { inject } from '@adonisjs/core'
-import { ApiOperation, ApiResponse, ApiParam, ApiBody, ApiSecurity } from '@foadonis/openapi/decorators'
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+  ApiSecurity,
+} from '@foadonis/openapi/decorators'
 
 @inject()
 export default class GameSessionsController {
   constructor(private gameSessionService: GameSessionService) {}
 
-  @ApiOperation({ summary: 'List all game sessions', description: 'Get a list of all game sessions' })
+  @ApiOperation({
+    summary: 'List all game sessions',
+    description: 'Get a list of all game sessions',
+  })
   @ApiResponse({ status: 200, description: 'List of game sessions retrieved successfully' })
   @ApiResponse({ status: 500, description: 'Error while fetching game sessions' })
   public async index({ response }: HttpContext) {
@@ -20,7 +29,10 @@ export default class GameSessionsController {
     }
   }
 
-  @ApiOperation({ summary: 'Create a new game session', description: 'Create a new game session with game ID, status, players, and game data' })
+  @ApiOperation({
+    summary: 'Create a new game session',
+    description: 'Create a new game session with game ID, status, players, and game data',
+  })
   @ApiSecurity('bearerAuth')
   @ApiBody({
     description: 'Game session data',
@@ -51,7 +63,10 @@ export default class GameSessionsController {
     }
   }
 
-  @ApiOperation({ summary: 'Get game session by ID', description: 'Retrieve a specific game session by its ID (UUID)' })
+  @ApiOperation({
+    summary: 'Get game session by ID',
+    description: 'Retrieve a specific game session by its ID (UUID)',
+  })
   @ApiParam({ name: 'id', description: 'Game session ID (UUID)', required: true })
   @ApiResponse({ status: 200, description: 'Game session found' })
   @ApiResponse({ status: 404, description: 'Game session not found' })
@@ -71,7 +86,10 @@ export default class GameSessionsController {
     }
   }
 
-  @ApiOperation({ summary: 'Update game session', description: 'Update game session status, players, or game data' })
+  @ApiOperation({
+    summary: 'Update game session',
+    description: 'Update game session status, players, or game data',
+  })
   @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'Game session ID (UUID)', required: true })
   @ApiBody({
@@ -105,7 +123,10 @@ export default class GameSessionsController {
     }
   }
 
-  @ApiOperation({ summary: 'Delete game session', description: 'Delete a game session permanently' })
+  @ApiOperation({
+    summary: 'Delete game session',
+    description: 'Delete a game session permanently',
+  })
   @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'Game session ID (UUID)', required: true })
   @ApiResponse({ status: 200, description: 'Game session deleted successfully' })
@@ -127,7 +148,10 @@ export default class GameSessionsController {
     }
   }
 
-  @ApiOperation({ summary: 'Get sessions by game ID', description: 'Retrieve all game sessions for a specific game' })
+  @ApiOperation({
+    summary: 'Get sessions by game ID',
+    description: 'Retrieve all game sessions for a specific game',
+  })
   @ApiParam({ name: 'gameId', description: 'Game ID', required: true })
   @ApiResponse({ status: 200, description: 'Game sessions retrieved successfully' })
   @ApiResponse({ status: 500, description: 'Error while fetching game sessions' })
@@ -143,8 +167,15 @@ export default class GameSessionsController {
     }
   }
 
-  @ApiOperation({ summary: 'Get sessions by status', description: 'Retrieve all game sessions with a specific status (pending, active, completed)' })
-  @ApiParam({ name: 'status', description: 'Session status (pending, active, completed)', required: true })
+  @ApiOperation({
+    summary: 'Get sessions by status',
+    description: 'Retrieve all game sessions with a specific status (pending, active, completed)',
+  })
+  @ApiParam({
+    name: 'status',
+    description: 'Session status (pending, active, completed)',
+    required: true,
+  })
   @ApiResponse({ status: 200, description: 'Game sessions retrieved successfully' })
   @ApiResponse({ status: 500, description: 'Error while fetching game sessions' })
   public async getByStatus({ params, response }: HttpContext) {

--- a/backend/app/controllers/game_sessions_controller.ts
+++ b/backend/app/controllers/game_sessions_controller.ts
@@ -2,11 +2,16 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { GameSessionService } from '#services/game_session_service'
 import GameSession from '#models/game_session'
 import { inject } from '@adonisjs/core'
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
+@ApiTags('Game Sessions')
 export default class GameSessionsController {
   constructor(private gameSessionService: GameSessionService) {}
 
+  @ApiOperation({ summary: 'List all game sessions', description: 'Get a list of all game sessions' })
+  @ApiResponse({ status: 200, description: 'List of game sessions retrieved successfully' })
+  @ApiResponse({ status: 500, description: 'Error while fetching game sessions' })
   public async index({ response }: HttpContext) {
     try {
       const gameSessions = await this.gameSessionService.getAll()
@@ -16,6 +21,23 @@ export default class GameSessionsController {
     }
   }
 
+  @ApiOperation({ summary: 'Create a new game session', description: 'Create a new game session with game ID, status, players, and game data' })
+  @ApiBody({
+    description: 'Game session data',
+    required: true,
+    schema: {
+      type: 'object',
+      required: ['gameId'],
+      properties: {
+        gameId: { type: 'integer', example: 1 },
+        status: { type: 'string', enum: ['pending', 'active', 'completed'], example: 'pending' },
+        players: { type: 'object', example: { player1: 'John', player2: 'Jane' } },
+        gameData: { type: 'object', example: { score: 0, round: 1 } },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Game session created successfully' })
+  @ApiResponse({ status: 500, description: 'Error while creating game session' })
   public async create({ request, response }: HttpContext) {
     try {
       const payload = request.only(['gameId', 'status', 'players', 'gameData'])
@@ -29,6 +51,11 @@ export default class GameSessionsController {
     }
   }
 
+  @ApiOperation({ summary: 'Get game session by ID', description: 'Retrieve a specific game session by its ID (UUID)' })
+  @ApiParam({ name: 'id', description: 'Game session ID (UUID)', required: true })
+  @ApiResponse({ status: 200, description: 'Game session found' })
+  @ApiResponse({ status: 404, description: 'Game session not found' })
+  @ApiResponse({ status: 500, description: 'Error while fetching game session' })
   public async show({ params, response }: HttpContext) {
     try {
       const gameSession = await this.gameSessionService.getById(params.id)
@@ -44,6 +71,24 @@ export default class GameSessionsController {
     }
   }
 
+  @ApiOperation({ summary: 'Update game session', description: 'Update game session status, players, or game data' })
+  @ApiParam({ name: 'id', description: 'Game session ID (UUID)', required: true })
+  @ApiBody({
+    description: 'Game session data to update',
+    required: true,
+    schema: {
+      type: 'object',
+      properties: {
+        gameId: { type: 'integer', example: 1 },
+        status: { type: 'string', enum: ['pending', 'active', 'completed'], example: 'active' },
+        players: { type: 'object', example: { player1: 'John', player2: 'Jane' } },
+        gameData: { type: 'object', example: { score: 100, round: 3 } },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Game session updated successfully' })
+  @ApiResponse({ status: 404, description: 'Game session not found' })
+  @ApiResponse({ status: 500, description: 'Error while updating game session' })
   public async update({ params, request, response }: HttpContext) {
     try {
       const result = await this.gameSessionService.updateGameSession(
@@ -59,6 +104,11 @@ export default class GameSessionsController {
     }
   }
 
+  @ApiOperation({ summary: 'Delete game session', description: 'Delete a game session permanently' })
+  @ApiParam({ name: 'id', description: 'Game session ID (UUID)', required: true })
+  @ApiResponse({ status: 200, description: 'Game session deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Game session not found' })
+  @ApiResponse({ status: 500, description: 'Error while deleting game session' })
   public async delete({ params, response }: HttpContext) {
     try {
       const result = await this.gameSessionService.deleteGameSession(params.id)
@@ -75,6 +125,10 @@ export default class GameSessionsController {
     }
   }
 
+  @ApiOperation({ summary: 'Get sessions by game ID', description: 'Retrieve all game sessions for a specific game' })
+  @ApiParam({ name: 'gameId', description: 'Game ID', required: true })
+  @ApiResponse({ status: 200, description: 'Game sessions retrieved successfully' })
+  @ApiResponse({ status: 500, description: 'Error while fetching game sessions' })
   public async getByGame({ params, response }: HttpContext) {
     try {
       const gameSessions = await this.gameSessionService.getByGameId(params.gameId)
@@ -87,6 +141,10 @@ export default class GameSessionsController {
     }
   }
 
+  @ApiOperation({ summary: 'Get sessions by status', description: 'Retrieve all game sessions with a specific status (pending, active, completed)' })
+  @ApiParam({ name: 'status', description: 'Session status (pending, active, completed)', required: true })
+  @ApiResponse({ status: 200, description: 'Game sessions retrieved successfully' })
+  @ApiResponse({ status: 500, description: 'Error while fetching game sessions' })
   public async getByStatus({ params, response }: HttpContext) {
     try {
       const gameSessions = await this.gameSessionService.getByStatus(params.status)

--- a/backend/app/controllers/game_sessions_controller.ts
+++ b/backend/app/controllers/game_sessions_controller.ts
@@ -2,7 +2,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { GameSessionService } from '#services/game_session_service'
 import GameSession from '#models/game_session'
 import { inject } from '@adonisjs/core'
-import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
+import { ApiOperation, ApiResponse, ApiParam, ApiBody, ApiSecurity } from '@foadonis/openapi/decorators'
 
 @inject()
 export default class GameSessionsController {
@@ -21,6 +21,7 @@ export default class GameSessionsController {
   }
 
   @ApiOperation({ summary: 'Create a new game session', description: 'Create a new game session with game ID, status, players, and game data' })
+  @ApiSecurity('bearerAuth')
   @ApiBody({
     description: 'Game session data',
     required: true,
@@ -71,6 +72,7 @@ export default class GameSessionsController {
   }
 
   @ApiOperation({ summary: 'Update game session', description: 'Update game session status, players, or game data' })
+  @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'Game session ID (UUID)', required: true })
   @ApiBody({
     description: 'Game session data to update',
@@ -104,6 +106,7 @@ export default class GameSessionsController {
   }
 
   @ApiOperation({ summary: 'Delete game session', description: 'Delete a game session permanently' })
+  @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'Game session ID (UUID)', required: true })
   @ApiResponse({ status: 200, description: 'Game session deleted successfully' })
   @ApiResponse({ status: 404, description: 'Game session not found' })

--- a/backend/app/controllers/games_controller.ts
+++ b/backend/app/controllers/games_controller.ts
@@ -2,7 +2,13 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { GameService } from '#services/game_service'
 import Game from '#models/game'
 import { inject } from '@adonisjs/core'
-import { ApiOperation, ApiResponse, ApiParam, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiSecurity,
+  ApiBody,
+} from '@foadonis/openapi/decorators'
 
 @inject()
 export default class GamesController {

--- a/backend/app/controllers/games_controller.ts
+++ b/backend/app/controllers/games_controller.ts
@@ -2,11 +2,16 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { GameService } from '#services/game_service'
 import Game from '#models/game'
 import { inject } from '@adonisjs/core'
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
+@ApiTags('Games')
 export default class GamesController {
   constructor(private readonly gameService: GameService) {}
 
+  @ApiOperation({ summary: 'List all games', description: 'Get a list of all available games' })
+  @ApiResponse({ status: 200, description: 'List of games retrieved successfully' })
+  @ApiResponse({ status: 500, description: 'Failed to fetch games' })
   public async index({ response }: HttpContext) {
     try {
       const games = await this.gameService.getAll()
@@ -18,6 +23,24 @@ export default class GamesController {
     }
   }
 
+  @ApiOperation({ summary: 'Create a new game', description: 'Create a new game (admin only)' })
+  @ApiSecurity('bearerAuth')
+  @ApiBody({
+    description: 'Game data',
+    required: true,
+    schema: {
+      type: 'object',
+      required: ['name', 'description'],
+      properties: {
+        name: { type: 'string', minLength: 1, example: 'Guess the Song' },
+        description: { type: 'string', example: 'Players guess songs from audio clips' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Game created successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
+  @ApiResponse({ status: 500, description: 'Error creating game' })
   public async create({ request, response }: HttpContext) {
     try {
       const result = await this.gameService.createGame(request.only(['name', 'description']))
@@ -32,6 +55,11 @@ export default class GamesController {
     }
   }
 
+  @ApiOperation({ summary: 'Get game by ID', description: 'Retrieve a specific game by its ID' })
+  @ApiParam({ name: 'id', description: 'Game ID', required: true })
+  @ApiResponse({ status: 200, description: 'Game found' })
+  @ApiResponse({ status: 404, description: 'Game not found' })
+  @ApiResponse({ status: 500, description: 'Error retrieving game' })
   public async show({ params, response }: HttpContext) {
     try {
       const gameId = params.id
@@ -47,6 +75,25 @@ export default class GamesController {
     }
   }
 
+  @ApiOperation({ summary: 'Update game', description: 'Update game information (admin only)' })
+  @ApiSecurity('bearerAuth')
+  @ApiParam({ name: 'id', description: 'Game ID', required: true })
+  @ApiBody({
+    description: 'Game data to update',
+    required: true,
+    schema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', minLength: 1, example: 'Guess the Song' },
+        description: { type: 'string', example: 'Players guess songs from audio clips' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Game updated successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
+  @ApiResponse({ status: 404, description: 'Game not found' })
+  @ApiResponse({ status: 500, description: 'Error updating game' })
   public async update({ params, request, response }: HttpContext) {
     try {
       const gameId = params.id
@@ -65,6 +112,14 @@ export default class GamesController {
     }
   }
 
+  @ApiOperation({ summary: 'Delete game', description: 'Delete a game (admin only)' })
+  @ApiSecurity('bearerAuth')
+  @ApiParam({ name: 'id', description: 'Game ID', required: true })
+  @ApiResponse({ status: 200, description: 'Game deleted successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden - admin role required' })
+  @ApiResponse({ status: 404, description: 'Game not found' })
+  @ApiResponse({ status: 500, description: 'Error deleting game' })
   public async destroy({ params, response }: HttpContext) {
     try {
       const gameId = params.id

--- a/backend/app/controllers/games_controller.ts
+++ b/backend/app/controllers/games_controller.ts
@@ -2,10 +2,9 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { GameService } from '#services/game_service'
 import Game from '#models/game'
 import { inject } from '@adonisjs/core'
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
+import { ApiOperation, ApiResponse, ApiParam, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
-@ApiTags('Games')
 export default class GamesController {
   constructor(private readonly gameService: GameService) {}
 

--- a/backend/app/controllers/liked_tracks_controller.ts
+++ b/backend/app/controllers/liked_tracks_controller.ts
@@ -2,11 +2,16 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { LikedTrackService } from '#services/liked_track_service'
 import LikedTrack from '#models/liked_track'
 import { inject } from '@adonisjs/core'
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
+@ApiTags('Liked Tracks')
 export default class LikedTracksController {
   constructor(private likedTrackService: LikedTrackService) {}
 
+  @ApiOperation({ summary: 'List all liked tracks', description: 'Get a list of all liked tracks from users' })
+  @ApiResponse({ status: 200, description: 'List of liked tracks retrieved successfully' })
+  @ApiResponse({ status: 500, description: 'Error while fetching liked tracks' })
   public async index({ response }: HttpContext) {
     try {
       const likedTracks = await this.likedTrackService.getAll()
@@ -16,6 +21,24 @@ export default class LikedTracksController {
     }
   }
 
+  @ApiOperation({ summary: 'Add a liked track', description: 'Add a track to user liked tracks collection (requires userId, spotifyId)' })
+  @ApiBody({
+    description: 'Liked track data',
+    required: true,
+    schema: {
+      type: 'object',
+      required: ['userId', 'spotifyId'],
+      properties: {
+        userId: { type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000' },
+        spotifyId: { type: 'string', example: '3n3Ppam7vgaVa1iaRUc9Lp' },
+        title: { type: 'string', example: 'Bohemian Rhapsody' },
+        artist: { type: 'string', example: 'Queen' },
+        type: { type: 'string', example: 'song' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Liked track added successfully' })
+  @ApiResponse({ status: 500, description: 'Error while creating liked track' })
   public async create({ request, response }: HttpContext) {
     try {
       const payload = request.only(['userId', 'spotifyId', 'title', 'artist', 'type'])
@@ -29,6 +52,11 @@ export default class LikedTracksController {
     }
   }
 
+  @ApiOperation({ summary: 'Get liked track by ID', description: 'Retrieve a specific liked track by its ID' })
+  @ApiParam({ name: 'id', description: 'Liked track ID', required: true })
+  @ApiResponse({ status: 200, description: 'Liked track found' })
+  @ApiResponse({ status: 404, description: 'Liked track not found' })
+  @ApiResponse({ status: 500, description: 'Error while fetching liked track' })
   public async show({ params, response }: HttpContext) {
     try {
       const likedTrack = await this.likedTrackService.getById(params.id)
@@ -41,6 +69,25 @@ export default class LikedTracksController {
     }
   }
 
+  @ApiOperation({ summary: 'Update liked track', description: 'Update liked track information (title, artist, type, etc.)' })
+  @ApiParam({ name: 'id', description: 'Liked track ID', required: true })
+  @ApiBody({
+    description: 'Liked track data to update',
+    required: true,
+    schema: {
+      type: 'object',
+      properties: {
+        spotifyId: { type: 'string', example: '3n3Ppam7vgaVa1iaRUc9Lp' },
+        title: { type: 'string', example: 'Bohemian Rhapsody' },
+        artist: { type: 'string', example: 'Queen' },
+        type: { type: 'string', example: 'song' },
+        userId: { type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Liked track updated successfully' })
+  @ApiResponse({ status: 404, description: 'Liked track not found' })
+  @ApiResponse({ status: 500, description: 'Error while updating liked track' })
   public async update({ params, request, response }: HttpContext) {
     try {
       const result = await this.likedTrackService.updateLikedTrack(
@@ -56,6 +103,11 @@ export default class LikedTracksController {
     }
   }
 
+  @ApiOperation({ summary: 'Delete liked track', description: 'Remove a track from liked tracks collection' })
+  @ApiParam({ name: 'id', description: 'Liked track ID', required: true })
+  @ApiResponse({ status: 200, description: 'Liked track deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Liked track not found' })
+  @ApiResponse({ status: 500, description: 'Error while deleting liked track' })
   public async delete({ params, response }: HttpContext) {
     try {
       const result = await this.likedTrackService.deleteLikedTrack(params.id)

--- a/backend/app/controllers/liked_tracks_controller.ts
+++ b/backend/app/controllers/liked_tracks_controller.ts
@@ -2,10 +2,9 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { LikedTrackService } from '#services/liked_track_service'
 import LikedTrack from '#models/liked_track'
 import { inject } from '@adonisjs/core'
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
+import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
-@ApiTags('Liked Tracks')
 export default class LikedTracksController {
   constructor(private likedTrackService: LikedTrackService) {}
 

--- a/backend/app/controllers/liked_tracks_controller.ts
+++ b/backend/app/controllers/liked_tracks_controller.ts
@@ -2,13 +2,22 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { LikedTrackService } from '#services/liked_track_service'
 import LikedTrack from '#models/liked_track'
 import { inject } from '@adonisjs/core'
-import { ApiOperation, ApiResponse, ApiParam, ApiBody, ApiSecurity } from '@foadonis/openapi/decorators'
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiBody,
+  ApiSecurity,
+} from '@foadonis/openapi/decorators'
 
 @inject()
 export default class LikedTracksController {
   constructor(private likedTrackService: LikedTrackService) {}
 
-  @ApiOperation({ summary: 'List all liked tracks', description: 'Get a list of all liked tracks from users' })
+  @ApiOperation({
+    summary: 'List all liked tracks',
+    description: 'Get a list of all liked tracks from users',
+  })
   @ApiResponse({ status: 200, description: 'List of liked tracks retrieved successfully' })
   @ApiResponse({ status: 500, description: 'Error while fetching liked tracks' })
   public async index({ response }: HttpContext) {
@@ -20,7 +29,10 @@ export default class LikedTracksController {
     }
   }
 
-  @ApiOperation({ summary: 'Add a liked track', description: 'Add a track to user liked tracks collection (requires userId, spotifyId)' })
+  @ApiOperation({
+    summary: 'Add a liked track',
+    description: 'Add a track to user liked tracks collection (requires userId, spotifyId)',
+  })
   @ApiSecurity('bearerAuth')
   @ApiBody({
     description: 'Liked track data',
@@ -52,7 +64,10 @@ export default class LikedTracksController {
     }
   }
 
-  @ApiOperation({ summary: 'Get liked track by ID', description: 'Retrieve a specific liked track by its ID' })
+  @ApiOperation({
+    summary: 'Get liked track by ID',
+    description: 'Retrieve a specific liked track by its ID',
+  })
   @ApiParam({ name: 'id', description: 'Liked track ID', required: true })
   @ApiResponse({ status: 200, description: 'Liked track found' })
   @ApiResponse({ status: 404, description: 'Liked track not found' })
@@ -69,7 +84,10 @@ export default class LikedTracksController {
     }
   }
 
-  @ApiOperation({ summary: 'Update liked track', description: 'Update liked track information (title, artist, type, etc.)' })
+  @ApiOperation({
+    summary: 'Update liked track',
+    description: 'Update liked track information (title, artist, type, etc.)',
+  })
   @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'Liked track ID', required: true })
   @ApiBody({
@@ -104,7 +122,10 @@ export default class LikedTracksController {
     }
   }
 
-  @ApiOperation({ summary: 'Delete liked track', description: 'Remove a track from liked tracks collection' })
+  @ApiOperation({
+    summary: 'Delete liked track',
+    description: 'Remove a track from liked tracks collection',
+  })
   @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'Liked track ID', required: true })
   @ApiResponse({ status: 200, description: 'Liked track deleted successfully' })

--- a/backend/app/controllers/liked_tracks_controller.ts
+++ b/backend/app/controllers/liked_tracks_controller.ts
@@ -2,7 +2,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { LikedTrackService } from '#services/liked_track_service'
 import LikedTrack from '#models/liked_track'
 import { inject } from '@adonisjs/core'
-import { ApiOperation, ApiResponse, ApiParam, ApiBody } from '@foadonis/openapi/decorators'
+import { ApiOperation, ApiResponse, ApiParam, ApiBody, ApiSecurity } from '@foadonis/openapi/decorators'
 
 @inject()
 export default class LikedTracksController {
@@ -21,6 +21,7 @@ export default class LikedTracksController {
   }
 
   @ApiOperation({ summary: 'Add a liked track', description: 'Add a track to user liked tracks collection (requires userId, spotifyId)' })
+  @ApiSecurity('bearerAuth')
   @ApiBody({
     description: 'Liked track data',
     required: true,
@@ -69,6 +70,7 @@ export default class LikedTracksController {
   }
 
   @ApiOperation({ summary: 'Update liked track', description: 'Update liked track information (title, artist, type, etc.)' })
+  @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'Liked track ID', required: true })
   @ApiBody({
     description: 'Liked track data to update',
@@ -103,6 +105,7 @@ export default class LikedTracksController {
   }
 
   @ApiOperation({ summary: 'Delete liked track', description: 'Remove a track from liked tracks collection' })
+  @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'Liked track ID', required: true })
   @ApiResponse({ status: 200, description: 'Liked track deleted successfully' })
   @ApiResponse({ status: 404, description: 'Liked track not found' })

--- a/backend/app/controllers/users_controller.ts
+++ b/backend/app/controllers/users_controller.ts
@@ -2,16 +2,38 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { UserService } from '#services/user_service'
 import User from '#models/user'
 import { inject } from '@adonisjs/core'
+import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
+@ApiTags('Users')
 export default class UsersController {
   constructor(private userService: UserService) {}
 
+  @ApiOperation({ summary: 'List all users', description: 'Get a list of all users in the system' })
+  @ApiResponse({ status: 200, description: 'List of users retrieved successfully' })
   public async index({ response }: HttpContext) {
     const users = await this.userService.getAll()
     return response.json({ users: users })
   }
 
+  @ApiOperation({ summary: 'Create a new user', description: 'Create a new user account' })
+  @ApiBody({
+    description: 'User data',
+    required: true,
+    schema: {
+      type: 'object',
+      required: ['email', 'username', 'password'],
+      properties: {
+        firstName: { type: 'string', example: 'John' },
+        lastName: { type: 'string', example: 'Doe' },
+        username: { type: 'string', minLength: 3, example: 'johndoe' },
+        email: { type: 'string', format: 'email', example: 'john@example.com' },
+        password: { type: 'string', format: 'password', minLength: 8, example: 'SecurePass123!' },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'User created successfully' })
+  @ApiResponse({ status: 500, description: 'Error creating user' })
   public async create({ request, response }: HttpContext) {
     const result = await this.userService.createUser(
       request.only(['firstName', 'lastName', 'username', 'email', 'password'])
@@ -22,6 +44,10 @@ export default class UsersController {
     return response.status(201).json({ user: result })
   }
 
+  @ApiOperation({ summary: 'Get user by ID', description: 'Retrieve a specific user by their ID' })
+  @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
+  @ApiResponse({ status: 200, description: 'User found' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   public async show({ params, response }: HttpContext) {
     const userId = params.id
     const user = await this.userService.getById(userId)
@@ -31,6 +57,22 @@ export default class UsersController {
     return response.json({ user })
   }
 
+  @ApiOperation({ summary: 'Update user', description: 'Update user information (role, firstName, lastName)' })
+  @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
+  @ApiBody({
+    description: 'User data to update',
+    required: true,
+    schema: {
+      type: 'object',
+      properties: {
+        role: { type: 'string', enum: ['user', 'admin'], example: 'user' },
+        firstName: { type: 'string', example: 'John' },
+        lastName: { type: 'string', example: 'Doe' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'User updated successfully' })
+  @ApiResponse({ status: 500, description: 'Error updating user' })
   public async update({ params, request, response }: HttpContext) {
     const userId = params.id
     const result = await this.userService.updateUser(
@@ -43,6 +85,13 @@ export default class UsersController {
     return response.json({ user: result })
   }
 
+  @ApiOperation({ summary: 'Soft delete user', description: 'Soft delete a user (requires authentication)' })
+  @ApiSecurity('bearerAuth')
+  @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
+  @ApiResponse({ status: 200, description: 'User soft deleted successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Cannot delete your own account' })
+  @ApiResponse({ status: 404, description: 'User not found' })
   public async delete({ params, response, auth }: HttpContext) {
     const userId = params.id
     const result = await this.userService.deleteUser(userId, auth.user!)
@@ -52,6 +101,10 @@ export default class UsersController {
     return response.json({ message: `User with ID: ${userId} soft deleted successfully` })
   }
 
+  @ApiOperation({ summary: 'Restore soft-deleted user', description: 'Restore a previously soft-deleted user' })
+  @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
+  @ApiResponse({ status: 200, description: 'User restored successfully' })
+  @ApiResponse({ status: 404, description: 'User not found or not deleted' })
   public async restore({ params, response }: HttpContext) {
     const userId = params.id
     const result = await this.userService.restoreUser(userId)
@@ -61,6 +114,8 @@ export default class UsersController {
     return response.json({ message: `User with ID: ${userId} restored successfully` })
   }
 
+  @ApiOperation({ summary: 'List soft-deleted users', description: 'Get a list of all soft-deleted users' })
+  @ApiResponse({ status: 200, description: 'List of soft-deleted users retrieved successfully' })
   public async trashed({ response }: HttpContext) {
     const users = await this.userService.getOnlyTrashed()
     return response.json({ users })

--- a/backend/app/controllers/users_controller.ts
+++ b/backend/app/controllers/users_controller.ts
@@ -2,7 +2,13 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { UserService } from '#services/user_service'
 import User from '#models/user'
 import { inject } from '@adonisjs/core'
-import { ApiOperation, ApiResponse, ApiParam, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiSecurity,
+  ApiBody,
+} from '@foadonis/openapi/decorators'
 
 @inject()
 export default class UsersController {
@@ -59,7 +65,10 @@ export default class UsersController {
     return response.json({ user })
   }
 
-  @ApiOperation({ summary: 'Update user', description: 'Update user information (role, firstName, lastName)' })
+  @ApiOperation({
+    summary: 'Update user',
+    description: 'Update user information (role, firstName, lastName)',
+  })
   @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
   @ApiBody({
@@ -88,7 +97,10 @@ export default class UsersController {
     return response.json({ user: result })
   }
 
-  @ApiOperation({ summary: 'Soft delete user', description: 'Soft delete a user (requires authentication)' })
+  @ApiOperation({
+    summary: 'Soft delete user',
+    description: 'Soft delete a user (requires authentication)',
+  })
   @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
   @ApiResponse({ status: 200, description: 'User soft deleted successfully' })
@@ -104,7 +116,10 @@ export default class UsersController {
     return response.json({ message: `User with ID: ${userId} soft deleted successfully` })
   }
 
-  @ApiOperation({ summary: 'Restore soft-deleted user', description: 'Restore a previously soft-deleted user' })
+  @ApiOperation({
+    summary: 'Restore soft-deleted user',
+    description: 'Restore a previously soft-deleted user',
+  })
   @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
   @ApiResponse({ status: 200, description: 'User restored successfully' })
@@ -118,7 +133,10 @@ export default class UsersController {
     return response.json({ message: `User with ID: ${userId} restored successfully` })
   }
 
-  @ApiOperation({ summary: 'List soft-deleted users', description: 'Get a list of all soft-deleted users' })
+  @ApiOperation({
+    summary: 'List soft-deleted users',
+    description: 'Get a list of all soft-deleted users',
+  })
   @ApiSecurity('bearerAuth')
   @ApiResponse({ status: 200, description: 'List of soft-deleted users retrieved successfully' })
   public async trashed({ response }: HttpContext) {

--- a/backend/app/controllers/users_controller.ts
+++ b/backend/app/controllers/users_controller.ts
@@ -2,10 +2,9 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { UserService } from '#services/user_service'
 import User from '#models/user'
 import { inject } from '@adonisjs/core'
-import { ApiTags, ApiOperation, ApiResponse, ApiParam, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
+import { ApiOperation, ApiResponse, ApiParam, ApiSecurity, ApiBody } from '@foadonis/openapi/decorators'
 
 @inject()
-@ApiTags('Users')
 export default class UsersController {
   constructor(private userService: UserService) {}
 

--- a/backend/app/controllers/users_controller.ts
+++ b/backend/app/controllers/users_controller.ts
@@ -9,6 +9,7 @@ export default class UsersController {
   constructor(private userService: UserService) {}
 
   @ApiOperation({ summary: 'List all users', description: 'Get a list of all users in the system' })
+  @ApiSecurity('bearerAuth')
   @ApiResponse({ status: 200, description: 'List of users retrieved successfully' })
   public async index({ response }: HttpContext) {
     const users = await this.userService.getAll()
@@ -16,6 +17,7 @@ export default class UsersController {
   }
 
   @ApiOperation({ summary: 'Create a new user', description: 'Create a new user account' })
+  @ApiSecurity('bearerAuth')
   @ApiBody({
     description: 'User data',
     required: true,
@@ -44,6 +46,7 @@ export default class UsersController {
   }
 
   @ApiOperation({ summary: 'Get user by ID', description: 'Retrieve a specific user by their ID' })
+  @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
   @ApiResponse({ status: 200, description: 'User found' })
   @ApiResponse({ status: 404, description: 'User not found' })
@@ -57,6 +60,7 @@ export default class UsersController {
   }
 
   @ApiOperation({ summary: 'Update user', description: 'Update user information (role, firstName, lastName)' })
+  @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
   @ApiBody({
     description: 'User data to update',
@@ -101,6 +105,7 @@ export default class UsersController {
   }
 
   @ApiOperation({ summary: 'Restore soft-deleted user', description: 'Restore a previously soft-deleted user' })
+  @ApiSecurity('bearerAuth')
   @ApiParam({ name: 'id', description: 'User ID (UUID)', required: true })
   @ApiResponse({ status: 200, description: 'User restored successfully' })
   @ApiResponse({ status: 404, description: 'User not found or not deleted' })
@@ -114,6 +119,7 @@ export default class UsersController {
   }
 
   @ApiOperation({ summary: 'List soft-deleted users', description: 'Get a list of all soft-deleted users' })
+  @ApiSecurity('bearerAuth')
   @ApiResponse({ status: 200, description: 'List of soft-deleted users retrieved successfully' })
   public async trashed({ response }: HttpContext) {
     const users = await this.userService.getOnlyTrashed()

--- a/backend/app/middleware/auth_middleware.ts
+++ b/backend/app/middleware/auth_middleware.ts
@@ -19,7 +19,7 @@ export default class AuthMiddleware {
     } catch (error) {
       ctx.logger.error('Authentication failed', error)
       return ctx.response.unauthorized({
-        message: 'Unauthorized - Invalid or missing authentication token',
+        message: 'Unauthorized access',
       })
     }
     return next()

--- a/backend/app/middleware/auth_middleware.ts
+++ b/backend/app/middleware/auth_middleware.ts
@@ -7,11 +7,6 @@ import type { Authenticators } from '@adonisjs/auth/types'
  * access to unauthenticated users.
  */
 export default class AuthMiddleware {
-  /**
-   * The URL to redirect to, when authentication fails
-   */
-  redirectTo = '/login'
-
   async handle(
     ctx: HttpContext,
     next: NextFn,
@@ -19,7 +14,14 @@ export default class AuthMiddleware {
       guards?: (keyof Authenticators)[]
     } = {}
   ) {
-    await ctx.auth.authenticateUsing(options.guards, { loginRoute: this.redirectTo })
+    try {
+      await ctx.auth.authenticateUsing(options.guards || ['api'])
+    } catch (error) {
+      ctx.logger.error('Authentication failed', error)
+      return ctx.response.unauthorized({
+        message: 'Unauthorized - Invalid or missing authentication token',
+      })
+    }
     return next()
   }
 }

--- a/backend/app/models/achievement.ts
+++ b/backend/app/models/achievement.ts
@@ -2,23 +2,33 @@ import { DateTime } from 'luxon'
 import { BaseModel, column, hasMany } from '@adonisjs/lucid/orm'
 import type { HasMany } from '@adonisjs/lucid/types/relations'
 import UserAchievement from '#models/user_achievement'
+import { ApiProperty } from '@foadonis/openapi/decorators'
 
 export default class Achievement extends BaseModel {
+  @ApiProperty({ description: 'Achievement unique identifier', example: 1 })
   @column({ isPrimary: true })
   declare id: number
 
+  @ApiProperty({
+    description: 'Achievement description',
+    example: 'Gagner 10 parties consécutives',
+    nullable: true,
+  })
   @column()
   declare description: string | null
 
+  @ApiProperty({ description: 'Achievement type', example: 'winning_streak' })
   @column()
   declare type: string
 
   @hasMany(() => UserAchievement)
   declare achievementUsers: HasMany<typeof UserAchievement>
 
+  @ApiProperty({ description: 'Achievement creation timestamp' })
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
+  @ApiProperty({ description: 'Last update timestamp' })
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
 }

--- a/backend/app/models/game.ts
+++ b/backend/app/models/game.ts
@@ -1,19 +1,28 @@
 import { DateTime } from 'luxon'
 import { BaseModel, column } from '@adonisjs/lucid/orm'
+import { ApiProperty } from '@foadonis/openapi/decorators'
 
 export default class Game extends BaseModel {
+  @ApiProperty({ description: 'Game unique identifier', example: 1 })
   @column({ isPrimary: true })
   declare id: number
 
+  @ApiProperty({ description: 'Game name', example: 'Blind Test Musical' })
   @column()
   declare name: string
 
+  @ApiProperty({
+    description: 'Game description',
+    example: 'Devinez les morceaux de musique le plus rapidement possible',
+  })
   @column()
   declare description: string
 
+  @ApiProperty({ description: 'Game creation timestamp' })
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
+  @ApiProperty({ description: 'Last update timestamp' })
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
 }

--- a/backend/app/models/game_session.ts
+++ b/backend/app/models/game_session.ts
@@ -3,6 +3,7 @@ import { BaseModel, beforeCreate, column, belongsTo } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import { randomUUID } from 'node:crypto'
 import Game from '#models/game'
+import { ApiProperty } from '@foadonis/openapi/decorators'
 
 // Type pour la structure d'un joueur
 export interface PlayerData {
@@ -14,15 +15,37 @@ export interface PlayerData {
 }
 
 export default class GameSession extends BaseModel {
+  @ApiProperty({
+    description: 'Game session unique identifier (UUID)',
+    example: '123e4567-e89b-12d3-a456-426614174001',
+  })
   @column({ isPrimary: true })
   declare id: string
 
+  @ApiProperty({ description: 'Associated game ID', example: 1 })
   @column()
   declare gameId: number
 
+  @ApiProperty({
+    description: 'Session status',
+    enum: ['pending', 'active', 'completed'],
+    example: 'active',
+  })
   @column()
   declare status: string
 
+  @ApiProperty({
+    description: 'Array of players in the session',
+    example: [
+      {
+        userId: '123e4567-e89b-12d3-a456-426614174000',
+        status: 'playing',
+        score: 1500,
+        expGained: 120,
+        rank: 1,
+      },
+    ],
+  })
   @column({
     prepare: (value: PlayerData[]) => JSON.stringify(value),
     consume: (value: string) => {
@@ -34,6 +57,10 @@ export default class GameSession extends BaseModel {
   })
   declare players: PlayerData[]
 
+  @ApiProperty({
+    description: 'Game-specific data (JSON)',
+    example: { currentRound: 3, maxRounds: 10 },
+  })
   @column({
     prepare: (value: any) => JSON.stringify(value),
     consume: (value: string) => {
@@ -48,9 +75,11 @@ export default class GameSession extends BaseModel {
   @belongsTo(() => Game)
   declare game: BelongsTo<typeof Game>
 
+  @ApiProperty({ description: 'Session creation timestamp' })
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
+  @ApiProperty({ description: 'Last update timestamp' })
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
 

--- a/backend/app/models/liked_track.ts
+++ b/backend/app/models/liked_track.ts
@@ -1,33 +1,44 @@
 import { DateTime } from 'luxon'
 import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
 import User from '#models/user'
+import { ApiProperty } from '@foadonis/openapi/decorators'
 
 export default class LikedTrack extends BaseModel {
+  @ApiProperty({ description: 'Liked track unique identifier', example: 1 })
   @column({ isPrimary: true })
   declare id: number
 
-  // foreign key referencing User.id (uuid string)
+  @ApiProperty({
+    description: 'User ID who liked the track (UUID)',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @column()
   declare userId: string
 
+  @ApiProperty({ description: 'Spotify track ID', example: '3n3Ppam7vgaVa1iaRUc9Lp' })
   @column()
   declare spotifyId: string
 
+  @ApiProperty({ description: 'Track title', example: 'Blinding Lights', nullable: true })
   @column()
   declare title: string | null
 
+  @ApiProperty({ description: 'Track artist', example: 'The Weeknd', nullable: true })
   @column()
   declare artist: string | null
 
+  @ApiProperty({ description: 'Track type', example: 'track', nullable: true })
   @column()
   declare type: string | null
 
   @belongsTo(() => User)
   declare user: any
 
+  @ApiProperty({ description: 'Creation timestamp' })
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
+  @ApiProperty({ description: 'Last update timestamp' })
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime
 }

--- a/backend/app/models/user.ts
+++ b/backend/app/models/user.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'node:crypto'
 import { hasMany } from '@adonisjs/lucid/orm'
 import LikedTrack from '#models/liked_track'
 import type { HasMany } from '@adonisjs/lucid/types/relations'
+import { ApiProperty } from '@foadonis/openapi/decorators'
 
 const AuthFinder = withAuthFinder(() => hash.use('scrypt'), {
   uids: ['email'],
@@ -16,31 +17,74 @@ const AuthFinder = withAuthFinder(() => hash.use('scrypt'), {
 
 export default class User extends compose(BaseModel, AuthFinder) {
   static accessTokens = DbAccessTokensProvider.forModel(User)
+
+  @ApiProperty({
+    description: 'User unique identifier (UUID)',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
   @column({ isPrimary: true })
   declare id: string
+
+  @ApiProperty({ description: 'User first name', example: 'John', nullable: true })
   @column()
   declare firstName: string | null
+
+  @ApiProperty({ description: 'User last name', example: 'Doe', nullable: true })
   @column()
   declare lastName: string | null
+
+  @ApiProperty({
+    description: 'Unique username (3-50 characters)',
+    example: 'johndoe',
+    minLength: 3,
+    maxLength: 50,
+  })
   @column()
   declare username: string
+
+  @ApiProperty({
+    description: 'User email address',
+    example: 'john.doe@example.com',
+    format: 'email',
+  })
   @column()
   declare email: string
+
   @column({ serializeAs: null })
   declare password: string
+
+  @ApiProperty({ description: 'User role', enum: ['user', 'admin'], example: 'user' })
   @column()
   declare role: 'user' | 'admin'
+
+  @ApiProperty({ description: 'Account creation timestamp' })
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
+
+  @ApiProperty({ description: 'Last update timestamp', nullable: true })
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime | null
 
+  @ApiProperty({ description: 'Email verification timestamp', nullable: true })
   @column.dateTime()
   declare emailVerifiedAt: DateTime | null
 
   @hasMany(() => LikedTrack)
   declare likedTracks: HasMany<typeof LikedTrack>
 
+  @column({ serializeAs: null })
+  declare verificationToken: string | null
+
+  @column.dateTime({ serializeAs: null })
+  declare verificationTokenExpiresAt: DateTime | null
+
+  @column({ serializeAs: null })
+  declare refreshToken: string | null
+
+  @column.dateTime({ serializeAs: null })
+  declare refreshTokenExpiresAt: DateTime | null
+
+  @ApiProperty({ description: 'Soft delete timestamp', nullable: true })
   @column.dateTime()
   declare deletedAt: DateTime | null
 

--- a/backend/config/openapi.ts
+++ b/backend/config/openapi.ts
@@ -35,6 +35,81 @@ export default defineConfig({
             'Bearer token authentication. Use the access token obtained from /api/auth/login',
         },
       },
+      schemas: {
+        User: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000' },
+            email: { type: 'string', format: 'email', example: 'john@example.com' },
+            username: { type: 'string', example: 'johndoe' },
+            firstName: { type: 'string', example: 'John' },
+            lastName: { type: 'string', example: 'Doe' },
+            role: { type: 'string', enum: ['user', 'admin'], example: 'user' },
+            emailVerifiedAt: { type: 'string', format: 'date-time', nullable: true },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        Game: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            name: { type: 'string', example: 'Guess the Song' },
+            description: { type: 'string', example: 'Players guess songs from audio clips' },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        Achievement: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            description: { type: 'string', example: 'Complete 10 games' },
+            type: { type: 'string', example: 'games_completed' },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        GameSession: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000' },
+            gameId: { type: 'integer', example: 1 },
+            status: { type: 'string', enum: ['pending', 'active', 'completed'], example: 'active' },
+            players: { type: 'object', example: { player1: 'John', player2: 'Jane' } },
+            gameData: { type: 'object', example: { score: 100, round: 3 } },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        LikedTrack: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer', example: 1 },
+            userId: { type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000' },
+            spotifyId: { type: 'string', example: '3n3Ppam7vgaVa1iaRUc9Lp' },
+            title: { type: 'string', example: 'Bohemian Rhapsody' },
+            artist: { type: 'string', example: 'Queen' },
+            type: { type: 'string', example: 'song' },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        Error: {
+          type: 'object',
+          properties: {
+            message: { type: 'string', example: 'An error occurred' },
+            errors: { type: 'object', additionalProperties: { type: 'array', items: { type: 'string' } } },
+          },
+        },
+        AuthTokens: {
+          type: 'object',
+          properties: {
+            accessToken: { type: 'string', example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' },
+            refreshToken: { type: 'string', example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...' },
+          },
+        },
+      },
     },
     tags: [
       { name: 'Auth', description: 'User authentication and authorization endpoints' },

--- a/backend/config/openapi.ts
+++ b/backend/config/openapi.ts
@@ -37,12 +37,12 @@ export default defineConfig({
       },
     },
     tags: [
-      { name: 'Authentication', description: 'User authentication and authorization endpoints' },
+      { name: 'Auth', description: 'User authentication and authorization endpoints' },
       { name: 'Users', description: 'User management endpoints' },
       { name: 'Games', description: 'Game management endpoints (admin)' },
       { name: 'Achievements', description: 'Achievement management endpoints' },
-      { name: 'Game Sessions', description: 'Game session management endpoints' },
-      { name: 'Liked Tracks', description: 'User liked tracks endpoints' },
+      { name: 'GameSessions', description: 'Game session management endpoints' },
+      { name: 'LikedTracks', description: 'User liked tracks endpoints' },
     ],
     externalDocs: {
       description: 'Rythmix Project Documentation',

--- a/backend/config/openapi.ts
+++ b/backend/config/openapi.ts
@@ -1,0 +1,52 @@
+import { defineConfig } from '@foadonis/openapi'
+import env from '#start/env'
+
+export default defineConfig({
+  /**
+   * User interface integration
+   */
+  ui: 'swagger',
+
+  /**
+   * Base OpenAPI document configuration
+   */
+  document: {
+    info: {
+      title: 'Rythmix API',
+      version: '1.0.0',
+      description: "API pour l'application musicale Rythmix",
+    },
+    servers: [
+      {
+        url:
+          env.get('NODE_ENV') === 'production'
+            ? 'https://api.yourdomain.com'
+            : 'https://api.localhost',
+        description: env.get('NODE_ENV') === 'production' ? 'Production' : 'Development',
+      },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description:
+            'Bearer token authentication. Use the access token obtained from /api/auth/login',
+        },
+      },
+    },
+    tags: [
+      { name: 'Authentication', description: 'User authentication and authorization endpoints' },
+      { name: 'Users', description: 'User management endpoints' },
+      { name: 'Games', description: 'Game management endpoints (admin)' },
+      { name: 'Achievements', description: 'Achievement management endpoints' },
+      { name: 'Game Sessions', description: 'Game session management endpoints' },
+      { name: 'Liked Tracks', description: 'User liked tracks endpoints' },
+    ],
+    externalDocs: {
+      description: 'Rythmix Project Documentation',
+      url: 'https://github.com/yourrepo/rythmix',
+    },
+  },
+})

--- a/backend/config/openapi.ts
+++ b/backend/config/openapi.ts
@@ -86,7 +86,11 @@ export default defineConfig({
           type: 'object',
           properties: {
             id: { type: 'integer', example: 1 },
-            userId: { type: 'string', format: 'uuid', example: '550e8400-e29b-41d4-a716-446655440000' },
+            userId: {
+              type: 'string',
+              format: 'uuid',
+              example: '550e8400-e29b-41d4-a716-446655440000',
+            },
             spotifyId: { type: 'string', example: '3n3Ppam7vgaVa1iaRUc9Lp' },
             title: { type: 'string', example: 'Bohemian Rhapsody' },
             artist: { type: 'string', example: 'Queen' },
@@ -99,7 +103,10 @@ export default defineConfig({
           type: 'object',
           properties: {
             message: { type: 'string', example: 'An error occurred' },
-            errors: { type: 'object', additionalProperties: { type: 'array', items: { type: 'string' } } },
+            errors: {
+              type: 'object',
+              additionalProperties: { type: 'array', items: { type: 'string' } },
+            },
           },
         },
         AuthTokens: {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@adonisjs/limiter": "^2.4.0",
         "@adonisjs/lucid": "^21.6.1",
         "@adonisjs/mail": "^9.2.2",
+        "@foadonis/openapi": "^0.4.1",
         "@vinejs/vine": "^3.0.1",
         "edge.js": "^6.3.0",
         "luxon": "^3.7.1",
@@ -77,7 +78,6 @@
       "resolved": "https://registry.npmjs.org/@adonisjs/application/-/application-8.4.1.tgz",
       "integrity": "sha512-2vwO/8DoKJ9AR4Vvllz08RcomBoETc3FMf+q+ri1BVVjc76tLGV3KcYZp8+uKOuEreiK6poQ7NwJrR1P5ANA/w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/hooks": "^7.2.5",
         "@poppinss/macroable": "^1.0.4",
@@ -99,7 +99,6 @@
       "integrity": "sha512-csLdMW58cwuRjdPEDE0dqwHZCT5snCh+1sQ19HPnQ/BLKPPAvQdDRdw0atoC8LVmouB8ghXVHp3SxnVxlvXYWQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adonisjs/env": "^6.1.0",
         "@antfu/install-pkg": "^0.4.1",
@@ -194,7 +193,6 @@
       "resolved": "https://registry.npmjs.org/@adonisjs/config/-/config-5.0.3.tgz",
       "integrity": "sha512-dO7gkYxZsrsnR8n7d5KUpyi+Q5c6BnV2rmFDqEmEjz5AkOZLLzJJJbeHgMb+M27le7ifEUoa8MRu6RED8NMsJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/utils": "^6.9.4"
       },
@@ -207,7 +205,6 @@
       "resolved": "https://registry.npmjs.org/@adonisjs/core/-/core-6.19.0.tgz",
       "integrity": "sha512-qwGuapvMLYPna89Qji/MuD9xx6qqcqc/aLrSGgoFbOzBmd8Ycc9391w7sFrrGuJpHiNLBmf1NJsY3YS2AwyX0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adonisjs/ace": "^13.3.0",
         "@adonisjs/application": "^8.4.1",
@@ -311,7 +308,6 @@
       "resolved": "https://registry.npmjs.org/@adonisjs/encryption/-/encryption-6.0.2.tgz",
       "integrity": "sha512-37XqVPsZi6zXMbC0Me1/qlcTP0uE+KAtYOFx7D7Tvtz377NL/6gqxqgpW/BopgOSD+CVDXjzO/Wx3M2UrbkJRQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/utils": "^6.7.3"
       },
@@ -404,7 +400,6 @@
       "resolved": "https://registry.npmjs.org/@adonisjs/fold/-/fold-10.2.0.tgz",
       "integrity": "sha512-VDBGrVz2viaCsmONLKYpMMeP3ds+fw+7kofeF/z9ic6cB3d7BLEB8VcIdGkfY0FCBbLK2Btee1tNPuUF1uMlmQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/utils": "^7.0.0-next.1",
         "parse-imports": "^2.2.1"
@@ -471,7 +466,6 @@
       "resolved": "https://registry.npmjs.org/@adonisjs/http-server/-/http-server-7.7.0.tgz",
       "integrity": "sha512-qW1wsp7f1BqRO2qmJ8laUaq8vnLjEvhgkMusLEa2ju6RBMMsph5w3cEDTXAwQO8fSSqNXmRTzPRQ1lUm/FXq0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.2",
         "@poppinss/macroable": "^1.0.4",
@@ -533,7 +527,6 @@
       "resolved": "https://registry.npmjs.org/@adonisjs/logger/-/logger-6.0.6.tgz",
       "integrity": "sha512-r5mLmmklSezzu3cu9QaXle2/gPNrgKpiIo+utYlwV3ITsW5JeIX/xcwwMTNM/9f1zU+SwOj5NccPTEFD3feRaw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/utils": "^6.9.2",
         "abstract-logging": "^2.0.1",
@@ -548,7 +541,6 @@
       "resolved": "https://registry.npmjs.org/@adonisjs/lucid/-/lucid-21.7.0.tgz",
       "integrity": "sha512-Bx1X9E1Y6Ig1nFZ62WcG8HEc5DpRv/IDLeSEeoN/6cPSYqjnN5VcoUg6wFiLd4Gi5WtoAoClhiYKr3TUHeh2hA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@adonisjs/presets": "^2.6.4",
         "@faker-js/faker": "^9.6.0",
@@ -1627,6 +1619,25 @@
         "npm": ">=9.0.0"
       }
     },
+    "node_modules/@foadonis/openapi": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@foadonis/openapi/-/openapi-0.4.1.tgz",
+      "integrity": "sha512-rUUJqe6WXEDpdRFGZK8sBcbhL8qbAplfkp+yl+9IqKEP3wOrmn26JrTpkq4eK9s7V97UsGHnRP6bHRi22gsVAg==",
+      "license": "MIT",
+      "dependencies": {
+        "openapi-metadata": "^0.2.2",
+        "yaml": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "peerDependencies": {
+        "@adonisjs/core": "^6.2.0",
+        "@adonisjs/lucid": "^21.2.0",
+        "@vinejs/vine": "^3.0.0",
+        "luxon": "^3.5.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1812,7 +1823,6 @@
       "integrity": "sha512-wrJVRgu8kF7odTnpNCsV6zpQgNOBrer3BHVBXm3qnS0FiqLlv8a6UZ5EKOqoLSRwfHV0LwBE7kcZq9f4yTvUfw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/hooks": "^7.2.5",
         "@poppinss/macroable": "^1.0.4",
@@ -1842,9 +1852,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@japa/assert/-/assert-4.0.1.tgz",
       "integrity": "sha512-n/dA9DVLNvM/Bw8DtN8kBdPjYsSHe3XTRjF5+U8vlzDavpW9skUANl2CHR1K/TBWZxwMfGi15SJIjo6UCs09AA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/macroable": "^1.0.4",
         "@types/chai": "^5.0.1",
@@ -1913,7 +1922,6 @@
       "integrity": "sha512-M2LUtHhKr4KgBfX73tDHNCD1IOmcXp9dvC+AinmRxsggIFnarsClcfjT/sXc3uNzjZW7Lk31LvcH76AxJHBmJQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.16.0"
       },
@@ -1942,7 +1950,6 @@
       "integrity": "sha512-e3BFn1rca/OTiagilkmRTrLVhl00iC/LrY5j4Ns/VZDONYHs9BKAbHaImxjD1zoHMEhwQEF+ce7fgMO/BK+lfg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@japa/core": "^10.3.0",
         "@japa/errors-printer": "^4.1.2",
@@ -2958,7 +2965,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.21"
@@ -3253,7 +3259,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
       "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*"
@@ -3270,7 +3276,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3311,8 +3317,7 @@
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
       "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
       "devOptional": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/methods": {
       "version": "1.1.4",
@@ -3326,7 +3331,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.4.tgz",
       "integrity": "sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3425,7 +3429,6 @@
       "integrity": "sha512-lJi3PfxVmo0AkEY93ecfN+r8SofEqZNGByvHAI3GBLrvt1Cw6H5k1IM02nSzu0RfUafr2EvFSw0wAsZgubNplQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.47.0",
         "@typescript-eslint/types": "8.47.0",
@@ -3626,7 +3629,6 @@
       "resolved": "https://registry.npmjs.org/@vinejs/vine/-/vine-3.0.1.tgz",
       "integrity": "sha512-ZtvYkYpZOYdvbws3uaOAvTFuvFXoQGAtmzeiXu+XSMGxi5GVsODpoI9Xu9TplEMuD/5fmAtBbKb9cQHkWkLXDQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/macroable": "^1.0.4",
         "@types/validator": "^13.12.2",
@@ -3686,7 +3688,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3817,7 +3818,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3942,7 +3943,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -4149,7 +4149,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
       "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
@@ -4212,7 +4212,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -4676,8 +4676,7 @@
       "version": "1.11.13",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -4730,7 +4729,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4742,6 +4741,15 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -4884,7 +4892,6 @@
       "resolved": "https://registry.npmjs.org/edge.js/-/edge.js-6.3.0.tgz",
       "integrity": "sha512-Xm7XW6J2+6cvfRK6AJEKV5hBF230iCvwQRg5wattg+RAzQ6tRwWSe4gqCsvvCaHt4xp10xkm8+ZdhApF1FVCzA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@poppinss/inspect": "^1.0.1",
         "@poppinss/macroable": "^1.0.4",
@@ -5089,7 +5096,6 @@
       "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5151,7 +5157,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -6941,7 +6946,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
       "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -6968,7 +6973,6 @@
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.1.tgz",
       "integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -7349,6 +7353,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/openapi-metadata/-/openapi-metadata-0.2.2.tgz",
+      "integrity": "sha512-2dBVRvZWcExRFhRhnA2YB9GY4LToIm66OxepFwp+X5VUIhCLA2rRKY43vjQVz92rdWELep5rleBESNEPGqoCqw==",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "openapi-types": "^12.1.3",
+        "type-fest": "^4.40.1"
+      },
+      "peerDependencies": {
+        "reflect-metadata": "^0.2.2"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -7607,7 +7630,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
@@ -7965,7 +7988,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9332,7 +9354,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9702,6 +9723,21 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -63,6 +63,7 @@
     "@adonisjs/limiter": "^2.4.0",
     "@adonisjs/lucid": "^21.6.1",
     "@adonisjs/mail": "^9.2.2",
+    "@foadonis/openapi": "^0.4.1",
     "@vinejs/vine": "^3.0.1",
     "edge.js": "^6.3.0",
     "luxon": "^3.7.1",

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -1,6 +1,18 @@
 import router from '@adonisjs/core/services/router'
 import { middleware } from './kernel.js'
 import { loginThrottle, registerThrottle, resendVerificationThrottle } from './limiter.js'
+import openapi from '@foadonis/openapi/services/main'
+
+// Controller imports for OpenAPI support
+const AuthController = () => import('#controllers/auth_controller')
+const UsersController = () => import('#controllers/users_controller')
+const GamesController = () => import('#controllers/games_controller')
+const AchievementsController = () => import('#controllers/achievements_controller')
+const GameSessionsController = () => import('#controllers/game_sessions_controller')
+const LikedTracksController = () => import('#controllers/liked_tracks_controller')
+
+// Register OpenAPI/Swagger routes: /docs, /docs.json, /docs.yaml
+openapi.registerRoutes('/docs')
 
 router.get('/', async ({ response }) => {
   return response.ok({
@@ -14,6 +26,7 @@ router.get('/', async ({ response }) => {
       games: '/api/games',
       likedTracks: '/api/liked-tracks',
       gameSessions: '/api/game-sessions',
+      docs: '/docs',
     },
   })
 })
@@ -22,76 +35,72 @@ router
   .group(() => {
     router
       .group(() => {
-        router.post('/register', '#controllers/auth_controller.register').use(registerThrottle)
-        router.post('/login', '#controllers/auth_controller.login').use(loginThrottle)
-        router.post('/refresh', '#controllers/auth_controller.refresh')
-        router.post('/logout', '#controllers/auth_controller.logout').use(middleware.auth())
-        router.get('/verify-email', '#controllers/auth_controller.verifyEmail')
-        router.post('/verify-email', '#controllers/auth_controller.verifyEmail')
+        router.post('/register', [AuthController, 'register']).use(registerThrottle)
+        router.post('/login', [AuthController, 'login']).use(loginThrottle)
+        router.post('/refresh', [AuthController, 'refresh'])
+        router.post('/logout', [AuthController, 'logout']).use(middleware.auth())
+        router.get('/verify-email', [AuthController, 'verifyEmail'])
+        router.post('/verify-email', [AuthController, 'verifyEmail'])
         router
-          .post('/resend-verification', '#controllers/auth_controller.resendVerificationEmail')
+          .post('/resend-verification', [AuthController, 'resendVerificationEmail'])
           .use(resendVerificationThrottle)
-        router.get('/me', '#controllers/auth_controller.me').use(middleware.auth())
+        router.get('/me', [AuthController, 'me']).use(middleware.auth())
       })
       .prefix('/auth')
 
     router
       .group(() => {
-        router.get('/', '#controllers/users_controller.index')
-        router.post('/', '#controllers/users_controller.create')
-        router.get('/trashed', '#controllers/users_controller.trashed')
-        router.get('/:id', '#controllers/users_controller.show')
-        router.patch('/:id', '#controllers/users_controller.update')
-        router.delete('/:id', '#controllers/users_controller.delete').use(middleware.auth())
-        router.post('/:id/restore', '#controllers/users_controller.restore')
+        router.get('/', [UsersController, 'index'])
+        router.post('/', [UsersController, 'create'])
+        router.get('/trashed', [UsersController, 'trashed'])
+        router.get('/:id', [UsersController, 'show'])
+        router.patch('/:id', [UsersController, 'update'])
+        router.delete('/:id', [UsersController, 'delete']).use(middleware.auth())
+        router.post('/:id/restore', [UsersController, 'restore'])
       })
       .prefix('/users')
     router
       .group(() => {
-        router.get('/', '#controllers/achievements_controller.index')
-        router.post('/', '#controllers/achievements_controller.create')
-        router.get('/:id', '#controllers/achievements_controller.show')
-        router.patch('/:id', '#controllers/achievements_controller.update')
-        router.delete('/:id', '#controllers/achievements_controller.delete')
+        router.get('/', [AchievementsController, 'index'])
+        router.post('/', [AchievementsController, 'create'])
+        router.get('/:id', [AchievementsController, 'show'])
+        router.patch('/:id', [AchievementsController, 'update'])
+        router.delete('/:id', [AchievementsController, 'delete'])
       })
       .prefix('/achievements')
     router
       .group(() => {
-        router.get('/', '#controllers/games_controller.index')
+        router.get('/', [GamesController, 'index'])
+        router.post('/', [GamesController, 'create']).use(middleware.role({ roles: ['admin'] }))
+        router.get('/:id', [GamesController, 'show'])
+        router.patch('/:id', [GamesController, 'update']).use(middleware.role({ roles: ['admin'] }))
         router
-          .post('/', '#controllers/games_controller.create')
-          .use(middleware.role({ roles: ['admin'] }))
-        router.get('/:id', '#controllers/games_controller.show')
-        router
-          .patch('/:id', '#controllers/games_controller.update')
-          .use(middleware.role({ roles: ['admin'] }))
-        router
-          .delete('/:id', '#controllers/games_controller.destroy')
+          .delete('/:id', [GamesController, 'destroy'])
           .use(middleware.role({ roles: ['admin'] }))
       })
       .prefix('/games')
     router
       .group(() => {
-        router.get('/', '#controllers/game_sessions_controller.index')
-        router.post('/', '#controllers/game_sessions_controller.create')
-        router.get('/status/:status', '#controllers/game_sessions_controller.getByStatus')
-        router.get('/:id', '#controllers/game_sessions_controller.show')
-        router.patch('/:id', '#controllers/game_sessions_controller.update')
-        router.delete('/:id', '#controllers/game_sessions_controller.delete')
+        router.get('/', [GameSessionsController, 'index'])
+        router.post('/', [GameSessionsController, 'create'])
+        router.get('/status/:status', [GameSessionsController, 'getByStatus'])
+        router.get('/:id', [GameSessionsController, 'show'])
+        router.patch('/:id', [GameSessionsController, 'update'])
+        router.delete('/:id', [GameSessionsController, 'delete'])
       })
       .prefix('/game-sessions')
     router
       .group(() => {
-        router.get('/:gameId/sessions', '#controllers/game_sessions_controller.getByGame')
+        router.get('/:gameId/sessions', [GameSessionsController, 'getByGame'])
       })
       .prefix('/games')
     router
       .group(() => {
-        router.get('/', '#controllers/liked_tracks_controller.index')
-        router.post('/', '#controllers/liked_tracks_controller.create')
-        router.get('/:id', '#controllers/liked_tracks_controller.show')
-        router.patch('/:id', '#controllers/liked_tracks_controller.update')
-        router.delete('/:id', '#controllers/liked_tracks_controller.delete')
+        router.get('/', [LikedTracksController, 'index'])
+        router.post('/', [LikedTracksController, 'create'])
+        router.get('/:id', [LikedTracksController, 'show'])
+        router.patch('/:id', [LikedTracksController, 'update'])
+        router.delete('/:id', [LikedTracksController, 'delete'])
       })
       .prefix('/liked-tracks')
   })

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -50,13 +50,13 @@ router
 
     router
       .group(() => {
-        router.get('/', [UsersController, 'index'])
-        router.post('/', [UsersController, 'create'])
-        router.get('/trashed', [UsersController, 'trashed'])
-        router.get('/:id', [UsersController, 'show'])
-        router.patch('/:id', [UsersController, 'update'])
-        router.delete('/:id', [UsersController, 'delete']).use(middleware.auth())
-        router.post('/:id/restore', [UsersController, 'restore'])
+        router.get('/', [UsersController, 'index']).use(middleware.role({ roles: ['admin'] }))
+        router.post('/', [UsersController, 'create']).use(middleware.role({ roles: ['admin'] }))
+        router.get('/trashed', [UsersController, 'trashed']).use(middleware.role({ roles: ['admin'] }))
+        router.get('/:id', [UsersController, 'show']).use(middleware.role({ roles: ['admin'] }))
+        router.patch('/:id', [UsersController, 'update']).use(middleware.role({ roles: ['admin'] }))
+        router.delete('/:id', [UsersController, 'delete']).use(middleware.role({ roles: ['admin'] }))
+        router.post('/:id/restore', [UsersController, 'restore']).use(middleware.role({ roles: ['admin'] }))
       })
       .prefix('/users')
     router
@@ -74,33 +74,27 @@ router
         router.post('/', [GamesController, 'create']).use(middleware.role({ roles: ['admin'] }))
         router.get('/:id', [GamesController, 'show'])
         router.patch('/:id', [GamesController, 'update']).use(middleware.role({ roles: ['admin'] }))
-        router
-          .delete('/:id', [GamesController, 'destroy'])
-          .use(middleware.role({ roles: ['admin'] }))
+        router.delete('/:id', [GamesController, 'destroy']).use(middleware.role({ roles: ['admin'] }))
       })
       .prefix('/games')
     router
       .group(() => {
         router.get('/', [GameSessionsController, 'index'])
-        router.post('/', [GameSessionsController, 'create'])
-        router.get('/status/:status', [GameSessionsController, 'getByStatus'])
+        router.post('/', [GameSessionsController, 'create']).use(middleware.auth())
         router.get('/:id', [GameSessionsController, 'show'])
-        router.patch('/:id', [GameSessionsController, 'update'])
-        router.delete('/:id', [GameSessionsController, 'delete'])
+        router.get('/:gameId/sessions', [GameSessionsController, 'getByGame'])
+        router.get('/status/:status', [GameSessionsController, 'getByStatus'])
+        router.patch('/:id', [GameSessionsController, 'update']).use(middleware.auth())
+        router.delete('/:id', [GameSessionsController, 'delete']).use(middleware.auth())
       })
       .prefix('/game-sessions')
     router
       .group(() => {
-        router.get('/:gameId/sessions', [GameSessionsController, 'getByGame'])
-      })
-      .prefix('/games')
-    router
-      .group(() => {
         router.get('/', [LikedTracksController, 'index'])
-        router.post('/', [LikedTracksController, 'create'])
+        router.post('/', [LikedTracksController, 'create']).use(middleware.auth())
         router.get('/:id', [LikedTracksController, 'show'])
-        router.patch('/:id', [LikedTracksController, 'update'])
-        router.delete('/:id', [LikedTracksController, 'delete'])
+        router.patch('/:id', [LikedTracksController, 'update']).use(middleware.auth())
+        router.delete('/:id', [LikedTracksController, 'delete']).use(middleware.auth())
       })
       .prefix('/liked-tracks')
   })

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -52,11 +52,17 @@ router
       .group(() => {
         router.get('/', [UsersController, 'index']).use(middleware.role({ roles: ['admin'] }))
         router.post('/', [UsersController, 'create']).use(middleware.role({ roles: ['admin'] }))
-        router.get('/trashed', [UsersController, 'trashed']).use(middleware.role({ roles: ['admin'] }))
+        router
+          .get('/trashed', [UsersController, 'trashed'])
+          .use(middleware.role({ roles: ['admin'] }))
         router.get('/:id', [UsersController, 'show']).use(middleware.role({ roles: ['admin'] }))
         router.patch('/:id', [UsersController, 'update']).use(middleware.role({ roles: ['admin'] }))
-        router.delete('/:id', [UsersController, 'delete']).use(middleware.role({ roles: ['admin'] }))
-        router.post('/:id/restore', [UsersController, 'restore']).use(middleware.role({ roles: ['admin'] }))
+        router
+          .delete('/:id', [UsersController, 'delete'])
+          .use(middleware.role({ roles: ['admin'] }))
+        router
+          .post('/:id/restore', [UsersController, 'restore'])
+          .use(middleware.role({ roles: ['admin'] }))
       })
       .prefix('/users')
     router
@@ -74,7 +80,9 @@ router
         router.post('/', [GamesController, 'create']).use(middleware.role({ roles: ['admin'] }))
         router.get('/:id', [GamesController, 'show'])
         router.patch('/:id', [GamesController, 'update']).use(middleware.role({ roles: ['admin'] }))
-        router.delete('/:id', [GamesController, 'destroy']).use(middleware.role({ roles: ['admin'] }))
+        router
+          .delete('/:id', [GamesController, 'destroy'])
+          .use(middleware.role({ roles: ['admin'] }))
       })
       .prefix('/games')
     router

--- a/backend/tests/functional/achievements_controller.spec.ts
+++ b/backend/tests/functional/achievements_controller.spec.ts
@@ -63,7 +63,10 @@ test.group('AchievementsController - CRUD Functional', (group) => {
 
   test('PATCH non-existent should return 404', async ({ client }) => {
     const { token } = await createAuthenticatedUser('update404')
-    const response = await client.patch('/api/achievements/999999').bearerToken(token).json({ description: 'x' })
+    const response = await client
+      .patch('/api/achievements/999999')
+      .bearerToken(token)
+      .json({ description: 'x' })
     response.assertStatus(404)
     response.assertBodyContains({ message: 'Achievement not found' })
   })

--- a/backend/tests/functional/achievements_controller.spec.ts
+++ b/backend/tests/functional/achievements_controller.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@japa/runner'
 import Achievement from '#models/achievement'
 import testUtils from '@adonisjs/core/services/test_utils'
+import { createAuthenticatedUser } from '../utils/auth_helpers.js'
 
 test.group('AchievementsController - CRUD Functional', (group) => {
   group.setup(async () => {
@@ -38,8 +39,9 @@ test.group('AchievementsController - CRUD Functional', (group) => {
   })
 
   test('POST /api/achievements should create achievement', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('create')
     const payload = { type: 'gold', description: 'created' }
-    const response = await client.post('/api/achievements').json(payload)
+    const response = await client.post('/api/achievements').bearerToken(token).json(payload)
     response.assertStatus(201)
     const created = response.body().achievement
     assert.equal(created.type, payload.type)
@@ -47,9 +49,11 @@ test.group('AchievementsController - CRUD Functional', (group) => {
   })
 
   test('PATCH /api/achievements/:id should update', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('update')
     const a = await Achievement.create({ type: 'old', description: 'old' })
     const response = await client
       .patch(`/api/achievements/${a.id}`)
+      .bearerToken(token)
       .json({ description: 'updated', type: 'new' })
     response.assertStatus(200)
     const updated = response.body().achievement
@@ -58,14 +62,16 @@ test.group('AchievementsController - CRUD Functional', (group) => {
   })
 
   test('PATCH non-existent should return 404', async ({ client }) => {
-    const response = await client.patch('/api/achievements/999999').json({ description: 'x' })
+    const { token } = await createAuthenticatedUser('update404')
+    const response = await client.patch('/api/achievements/999999').bearerToken(token).json({ description: 'x' })
     response.assertStatus(404)
     response.assertBodyContains({ message: 'Achievement not found' })
   })
 
   test('DELETE /api/achievements/:id should remove achievement', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('delete')
     const a = await Achievement.create({ type: 'todel', description: 'd' })
-    const response = await client.delete(`/api/achievements/${a.id}`)
+    const response = await client.delete(`/api/achievements/${a.id}`).bearerToken(token)
     response.assertStatus(200)
     response.assertBodyContains({ message: `Achievement with ID: ${a.id} deleted successfully` })
     const found = await Achievement.find(a.id)
@@ -73,7 +79,8 @@ test.group('AchievementsController - CRUD Functional', (group) => {
   })
 
   test('DELETE non-existent should return 404', async ({ client }) => {
-    const response = await client.delete('/api/achievements/999999')
+    const { token } = await createAuthenticatedUser('delete404')
+    const response = await client.delete('/api/achievements/999999').bearerToken(token)
 
     response.assertStatus(404)
     response.assertBodyContains({ message: 'Achievement not found' })

--- a/backend/tests/functional/game_session_controller.spec.ts
+++ b/backend/tests/functional/game_session_controller.spec.ts
@@ -85,11 +85,14 @@ test.group('GameSessionsController - Functional', (group) => {
       gameData: { manche: 1 },
     })
 
-    const res = await client.patch(`/api/game-sessions/${session.id}`).bearerToken(token).json({
-      status: 'terminee',
-      players: [{ userId: 'user-1', status: 'termine', score: 200, expGained: 100, rank: 1 }],
-      gameData: { manche: 5, winner: 'user-1' },
-    })
+    const res = await client
+      .patch(`/api/game-sessions/${session.id}`)
+      .bearerToken(token)
+      .json({
+        status: 'terminee',
+        players: [{ userId: 'user-1', status: 'termine', score: 200, expGained: 100, rank: 1 }],
+        gameData: { manche: 5, winner: 'user-1' },
+      })
 
     res.assertStatus(200)
     assert.equal(res.body().data.status, 'terminee')

--- a/backend/tests/functional/liked_tracks_controller.spec.ts
+++ b/backend/tests/functional/liked_tracks_controller.spec.ts
@@ -44,7 +44,10 @@ test.group('LikedTracksController - Functional', (group) => {
     const user = await createUser('patch')
     const rec = await user.related('likedTracks').create({ spotifyId: 'sp', title: 'Old' })
 
-    const res = await client.patch(`/api/liked-tracks/${rec.id}`).bearerToken(token).json({ title: 'New' })
+    const res = await client
+      .patch(`/api/liked-tracks/${rec.id}`)
+      .bearerToken(token)
+      .json({ title: 'New' })
 
     res.assertStatus(200)
     assert.equal(res.body().likedTrack.title, 'New')

--- a/backend/tests/functional/users_controller.spec.ts
+++ b/backend/tests/functional/users_controller.spec.ts
@@ -64,11 +64,14 @@ test.group('UsersController - CRUD Operations', (group) => {
   test('POST /api/users should create a new user', async ({ client, assert }) => {
     const { token } = await createAuthenticatedUser('admin4', 'admin')
     const userData = makeUser('newuser')
-    const response = await client.post('/api/users').bearerToken(token).json({
-      ...userData,
-      firstName: 'New',
-      lastName: 'User',
-    })
+    const response = await client
+      .post('/api/users')
+      .bearerToken(token)
+      .json({
+        ...userData,
+        firstName: 'New',
+        lastName: 'User',
+      })
 
     response.assertStatus(201)
 
@@ -97,10 +100,13 @@ test.group('UsersController - CRUD Operations', (group) => {
     const existing = makeUser('existing')
     await User.create(existing)
 
-    const response = await client.post('/api/users').bearerToken(token).json({
-      ...makeUser('new'),
-      email: existing.email,
-    })
+    const response = await client
+      .post('/api/users')
+      .bearerToken(token)
+      .json({
+        ...makeUser('new'),
+        email: existing.email,
+      })
 
     response.assertStatus(409)
     response.assertBodyContains({
@@ -113,10 +119,13 @@ test.group('UsersController - CRUD Operations', (group) => {
     const existing = makeUser('existing')
     await User.create(existing)
 
-    const response = await client.post('/api/users').bearerToken(token).json({
-      ...makeUser('new'),
-      username: existing.username,
-    })
+    const response = await client
+      .post('/api/users')
+      .bearerToken(token)
+      .json({
+        ...makeUser('new'),
+        username: existing.username,
+      })
 
     response.assertStatus(409)
     response.assertBodyContains({
@@ -161,9 +170,7 @@ test.group('UsersController - CRUD Operations', (group) => {
   test('DELETE /api/users/:id should soft delete the user', async ({ client, assert }) => {
     const { user, token } = await createAuthenticatedUser('admin10', 'admin')
 
-    const response = await client
-      .delete(`/api/users/${user.id}`)
-      .bearerToken(token)
+    const response = await client.delete(`/api/users/${user.id}`).bearerToken(token)
 
     response.assertStatus(200)
     response.assertBodyContains({
@@ -178,9 +185,7 @@ test.group('UsersController - CRUD Operations', (group) => {
     const { token } = await createAuthenticatedUser('admin11', 'admin')
     const user2 = await User.create(makeUser('user2'))
 
-    const response = await client
-      .delete(`/api/users/${user2.id}`)
-      .bearerToken(token)
+    const response = await client.delete(`/api/users/${user2.id}`).bearerToken(token)
 
     response.assertStatus(403)
     response.assertBodyContains({
@@ -191,9 +196,7 @@ test.group('UsersController - CRUD Operations', (group) => {
   test('DELETE /api/users/:id should return 404 for non-existent user', async ({ client }) => {
     const { token } = await createAuthenticatedUser('admin12', 'admin')
 
-    const response = await client
-      .delete('/api/users/non-existent-id')
-      .bearerToken(token)
+    const response = await client.delete('/api/users/non-existent-id').bearerToken(token)
 
     response.assertStatus(404)
     response.assertBodyContains({ message: 'User not found' })
@@ -266,10 +269,13 @@ test.group('UsersController - Soft Delete Features', (group) => {
     await deletedUser.softDelete()
 
     const newUserData = makeUser('newuser')
-    const response = await client.post('/api/users').bearerToken(token).json({
-      ...newUserData,
-      email: deletedData.email,
-    })
+    const response = await client
+      .post('/api/users')
+      .bearerToken(token)
+      .json({
+        ...newUserData,
+        email: deletedData.email,
+      })
 
     response.assertStatus(409)
     response.assertBodyContains({
@@ -458,9 +464,12 @@ test.group('UsersController - Edge Cases Coverage', (group) => {
     const { token } = await createAuthenticatedUser('admin24', 'admin')
     const user = await User.create(makeUser('patch'))
 
-    const response = await client.patch(`/api/users/${user.id}`).bearerToken(token).json({
-      firstName: 'x'.repeat(300),
-    })
+    const response = await client
+      .patch(`/api/users/${user.id}`)
+      .bearerToken(token)
+      .json({
+        firstName: 'x'.repeat(300),
+      })
 
     assert.isAtLeast(response.status(), 400)
   })

--- a/backend/tests/functional/users_controller.spec.ts
+++ b/backend/tests/functional/users_controller.spec.ts
@@ -1,6 +1,7 @@
 import { test } from '@japa/runner'
 import User from '#models/user'
 import testUtils from '@adonisjs/core/services/test_utils'
+import { createAuthenticatedUser } from '../utils/auth_helpers.js'
 
 const makeUser = (prefix: string) => {
   const timestamp = Date.now() + Math.random()
@@ -25,10 +26,11 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('GET /api/users should return list of users', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('admin1', 'admin')
     await User.create(makeUser('user1'))
     await User.create(makeUser('user2'))
 
-    const response = await client.get('/api/users')
+    const response = await client.get('/api/users').bearerToken(token)
 
     response.assertStatus(200)
 
@@ -37,9 +39,10 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('GET /api/users/:id should return user details', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('admin2', 'admin')
     const user = await User.create(makeUser('getbyid'))
 
-    const response = await client.get(`/api/users/${user.id}`)
+    const response = await client.get(`/api/users/${user.id}`).bearerToken(token)
 
     response.assertStatus(200)
 
@@ -51,15 +54,17 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('GET /api/users/:id should return 404 for non-existent user', async ({ client }) => {
-    const response = await client.get('/api/users/non-existent-id')
+    const { token } = await createAuthenticatedUser('admin3', 'admin')
+    const response = await client.get('/api/users/non-existent-id').bearerToken(token)
 
     response.assertStatus(404)
     response.assertBodyContains({ message: 'User not found' })
   })
 
   test('POST /api/users should create a new user', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('admin4', 'admin')
     const userData = makeUser('newuser')
-    const response = await client.post('/api/users').json({
+    const response = await client.post('/api/users').bearerToken(token).json({
       ...userData,
       firstName: 'New',
       lastName: 'User',
@@ -76,8 +81,9 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('POST /api/users should create user with minimal data', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('admin5', 'admin')
     const userData = makeUser('minimal')
-    const response = await client.post('/api/users').json(userData)
+    const response = await client.post('/api/users').bearerToken(token).json(userData)
 
     response.assertStatus(201)
 
@@ -87,10 +93,11 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('POST /api/users should return 409 for duplicate email', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('admin6', 'admin')
     const existing = makeUser('existing')
     await User.create(existing)
 
-    const response = await client.post('/api/users').json({
+    const response = await client.post('/api/users').bearerToken(token).json({
       ...makeUser('new'),
       email: existing.email,
     })
@@ -102,10 +109,11 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('POST /api/users should return 409 for duplicate username', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('admin7', 'admin')
     const existing = makeUser('existing')
     await User.create(existing)
 
-    const response = await client.post('/api/users').json({
+    const response = await client.post('/api/users').bearerToken(token).json({
       ...makeUser('new'),
       username: existing.username,
     })
@@ -117,9 +125,10 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('PATCH /api/users/:id should update user', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('admin8', 'admin')
     const user = await User.create({ ...makeUser('patch'), firstName: 'Original' })
 
-    const response = await client.patch(`/api/users/${user.id}`).json({
+    const response = await client.patch(`/api/users/${user.id}`).bearerToken(token).json({
       firstName: 'Updated',
       lastName: 'Name',
     })
@@ -132,7 +141,8 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('PATCH /api/users/:id should return 404 for non-existent user', async ({ client }) => {
-    const response = await client.patch('/api/users/non-existent-id').json({
+    const { token } = await createAuthenticatedUser('admin9', 'admin')
+    const response = await client.patch('/api/users/non-existent-id').bearerToken(token).json({
       firstName: 'Test',
     })
 
@@ -149,13 +159,11 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('DELETE /api/users/:id should soft delete the user', async ({ client, assert }) => {
-    const user = await User.create(makeUser('delete'))
-
-    const token = await User.accessTokens.create(user)
+    const { user, token } = await createAuthenticatedUser('admin10', 'admin')
 
     const response = await client
       .delete(`/api/users/${user.id}`)
-      .bearerToken(token.value!.release())
+      .bearerToken(token)
 
     response.assertStatus(200)
     response.assertBodyContains({
@@ -167,14 +175,12 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('DELETE /api/users/:id should return 403 when deleting another user', async ({ client }) => {
-    const user1 = await User.create(makeUser('user1'))
+    const { token } = await createAuthenticatedUser('admin11', 'admin')
     const user2 = await User.create(makeUser('user2'))
-
-    const token = await User.accessTokens.create(user1)
 
     const response = await client
       .delete(`/api/users/${user2.id}`)
-      .bearerToken(token.value!.release())
+      .bearerToken(token)
 
     response.assertStatus(403)
     response.assertBodyContains({
@@ -183,12 +189,11 @@ test.group('UsersController - CRUD Operations', (group) => {
   })
 
   test('DELETE /api/users/:id should return 404 for non-existent user', async ({ client }) => {
-    const user = await User.create(makeUser('auth'))
-    const token = await User.accessTokens.create(user)
+    const { token } = await createAuthenticatedUser('admin12', 'admin')
 
     const response = await client
       .delete('/api/users/non-existent-id')
-      .bearerToken(token.value!.release())
+      .bearerToken(token)
 
     response.assertStatus(404)
     response.assertBodyContains({ message: 'User not found' })
@@ -209,13 +214,14 @@ test.group('UsersController - Soft Delete Features', (group) => {
   })
 
   test('GET /api/users should not return soft-deleted users', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('admin13', 'admin')
     await User.create(makeUser('active1'))
     await User.create(makeUser('active2'))
 
     const deletedUser = await User.create(makeUser('deleted'))
     await deletedUser.softDelete()
 
-    const response = await client.get('/api/users')
+    const response = await client.get('/api/users').bearerToken(token)
 
     response.assertStatus(200)
 
@@ -224,24 +230,26 @@ test.group('UsersController - Soft Delete Features', (group) => {
   })
 
   test('GET /api/users/:id should return 404 for soft-deleted user', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('admin14', 'admin')
     const user = await User.create(makeUser('getbyid'))
 
-    let response = await client.get(`/api/users/${user.id}`)
+    let response = await client.get(`/api/users/${user.id}`).bearerToken(token)
     response.assertStatus(200)
 
     await user.softDelete()
 
-    response = await client.get(`/api/users/${user.id}`)
+    response = await client.get(`/api/users/${user.id}`).bearerToken(token)
     response.assertStatus(404)
     response.assertBodyContains({ message: 'User not found' })
   })
 
   test('PATCH /api/users/:id should not update soft-deleted users', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('admin15', 'admin')
     const user = await User.create({ ...makeUser('patch'), firstName: 'Test' })
 
     await user.softDelete()
 
-    const response = await client.patch(`/api/users/${user.id}`).json({
+    const response = await client.patch(`/api/users/${user.id}`).bearerToken(token).json({
       firstName: 'Updated',
     })
 
@@ -252,12 +260,13 @@ test.group('UsersController - Soft Delete Features', (group) => {
   test('POST /api/users should not allow reusing email from soft-deleted user', async ({
     client,
   }) => {
+    const { token } = await createAuthenticatedUser('admin16', 'admin')
     const deletedData = makeUser('olduser')
     const deletedUser = await User.create(deletedData)
     await deletedUser.softDelete()
 
     const newUserData = makeUser('newuser')
-    const response = await client.post('/api/users').json({
+    const response = await client.post('/api/users').bearerToken(token).json({
       ...newUserData,
       email: deletedData.email,
     })
@@ -272,6 +281,7 @@ test.group('UsersController - Soft Delete Features', (group) => {
     client,
     assert,
   }) => {
+    const { token } = await createAuthenticatedUser('admin17', 'admin')
     const activeUser = await User.create(makeUser('active'))
     const deletedUser1 = await User.create(makeUser('deleted1'))
     await deletedUser1.softDelete()
@@ -279,7 +289,7 @@ test.group('UsersController - Soft Delete Features', (group) => {
     const deletedUser2 = await User.create(makeUser('deleted2'))
     await deletedUser2.softDelete()
 
-    const response = await client.get('/api/users/trashed')
+    const response = await client.get('/api/users/trashed').bearerToken(token)
 
     response.assertStatus(200)
 
@@ -293,12 +303,13 @@ test.group('UsersController - Soft Delete Features', (group) => {
     client,
     assert,
   }) => {
+    const { token } = await createAuthenticatedUser('admin18', 'admin')
     const user = await User.create(makeUser('restore'))
 
     await user.softDelete()
     assert.isNotNull(user.deletedAt)
 
-    const response = await client.post(`/api/users/${user.id}/restore`)
+    const response = await client.post(`/api/users/${user.id}/restore`).bearerToken(token)
 
     response.assertStatus(200)
     response.assertBodyContains({
@@ -308,15 +319,16 @@ test.group('UsersController - Soft Delete Features', (group) => {
     await user.refresh()
     assert.isNull(user.deletedAt)
 
-    const listResponse = await client.get('/api/users')
+    const listResponse = await client.get('/api/users').bearerToken(token)
     const users = listResponse.body().users
     assert.exists(users.find((u: any) => u.id === user.id))
   })
 
   test('POST /api/users/:id/restore should return 404 for non-deleted user', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('admin19', 'admin')
     const user = await User.create(makeUser('notdeleted'))
 
-    const response = await client.post(`/api/users/${user.id}/restore`)
+    const response = await client.post(`/api/users/${user.id}/restore`).bearerToken(token)
 
     response.assertStatus(404)
     response.assertBodyContains({ message: 'Deleted user not found' })
@@ -325,7 +337,8 @@ test.group('UsersController - Soft Delete Features', (group) => {
   test('POST /api/users/:id/restore should return 404 for non-existent user', async ({
     client,
   }) => {
-    const response = await client.post('/api/users/non-existent-id/restore')
+    const { token } = await createAuthenticatedUser('admin20', 'admin')
+    const response = await client.post('/api/users/non-existent-id/restore').bearerToken(token)
 
     response.assertStatus(404)
     response.assertBodyContains({ message: 'Deleted user not found' })
@@ -349,69 +362,63 @@ test.group('UsersController - Integration Scenarios', (group) => {
     client,
     assert,
   }) => {
-    const lifecycleData = makeUser('lifecycle')
-    let response = await client.post('/api/users').json({
-      ...lifecycleData,
-      firstName: 'Lifecycle',
-    })
+    const { user, token } = await createAuthenticatedUser('admin21', 'admin')
+    const userId = user.id
 
-    response.assertStatus(201)
-    const userId = response.body().user.id
-
-    response = await client.get('/api/users')
+    let response = await client.get('/api/users').bearerToken(token)
     let users = response.body().users
     assert.exists(users.find((u: any) => u.id === userId))
 
-    response = await client.patch(`/api/users/${userId}`).json({
+    response = await client.patch(`/api/users/${userId}`).bearerToken(token).json({
       firstName: 'Updated',
       lastName: 'Lifecycle',
     })
     response.assertStatus(200)
     assert.equal(response.body().user.firstName, 'Updated')
 
-    const user = await User.findOrFail(userId)
-    const token = await User.accessTokens.create(user)
-
-    response = await client.delete(`/api/users/${userId}`).bearerToken(token.value!.release())
+    response = await client.delete(`/api/users/${userId}`).bearerToken(token)
     response.assertStatus(200)
 
-    response = await client.get('/api/users')
+    const adminToken2 = await createAuthenticatedUser('admin22', 'admin')
+
+    response = await client.get('/api/users').bearerToken(adminToken2.token)
     users = response.body().users
     assert.notExists(users.find((u: any) => u.id === userId))
 
-    response = await client.get('/api/users/trashed')
+    response = await client.get('/api/users/trashed').bearerToken(adminToken2.token)
     const trashedUsers = response.body().users
     assert.exists(trashedUsers.find((u: any) => u.id === userId))
 
-    response = await client.post(`/api/users/${userId}/restore`)
+    response = await client.post(`/api/users/${userId}/restore`).bearerToken(adminToken2.token)
     response.assertStatus(200)
 
-    response = await client.get('/api/users')
+    response = await client.get('/api/users').bearerToken(adminToken2.token)
     users = response.body().users
     assert.exists(users.find((u: any) => u.id === userId))
 
-    response = await client.get('/api/users/trashed')
+    response = await client.get('/api/users/trashed').bearerToken(adminToken2.token)
     const trashedUsersAfterRestore = response.body().users
     assert.notExists(trashedUsersAfterRestore.find((u: any) => u.id === userId))
   })
 
   test('Multiple users operations', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('admin23', 'admin')
     const user1Data = makeUser('multi1')
     const user2Data = makeUser('multi2')
     const user3Data = makeUser('multi3')
 
-    await client.post('/api/users').json(user1Data)
-    await client.post('/api/users').json(user2Data)
-    await client.post('/api/users').json(user3Data)
+    await client.post('/api/users').bearerToken(token).json(user1Data)
+    await client.post('/api/users').bearerToken(token).json(user2Data)
+    await client.post('/api/users').bearerToken(token).json(user3Data)
 
-    let response = await client.get('/api/users')
+    let response = await client.get('/api/users').bearerToken(token)
     let users = response.body().users
     assert.isAtLeast(users.length, 3)
 
     const user2 = await User.query().where('email', user2Data.email).firstOrFail()
     await user2.softDelete()
 
-    response = await client.get('/api/users/trashed')
+    response = await client.get('/api/users/trashed').bearerToken(token)
     const trashedUsers = response.body().users
     assert.isAtLeast(trashedUsers.length, 1)
     assert.exists(trashedUsers.find((u: any) => u.id === user2.id))
@@ -448,9 +455,10 @@ test.group('UsersController - Edge Cases Coverage', (group) => {
     client,
     assert,
   }) => {
+    const { token } = await createAuthenticatedUser('admin24', 'admin')
     const user = await User.create(makeUser('patch'))
 
-    const response = await client.patch(`/api/users/${user.id}`).json({
+    const response = await client.patch(`/api/users/${user.id}`).bearerToken(token).json({
       firstName: 'x'.repeat(300),
     })
 

--- a/backend/tests/utils/auth_helpers.ts
+++ b/backend/tests/utils/auth_helpers.ts
@@ -1,0 +1,24 @@
+import User from '#models/user'
+import { DateTime } from 'luxon'
+
+export async function createAuthenticatedUser(
+  prefix: string = 'test',
+  role: 'user' | 'admin' = 'user'
+) {
+  const timestamp = Date.now() + Math.random()
+  const userData = {
+    username: `${prefix}_${timestamp}`,
+    email: `${prefix}_${timestamp}@example.com`,
+    password: 'password123',
+    role: role,
+    emailVerifiedAt: DateTime.now(),
+  }
+
+  const user = await User.create(userData)
+  const token = await User.accessTokens.create(user)
+
+  return {
+    user,
+    token: token.value!.release(),
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ networks:
 
 services:
   traefik:
-    image: traefik:v3.2
+    image: traefik:v3.6
     restart: unless-stopped
     ports:
       - "80:80"


### PR DESCRIPTION
This pull request introduces OpenAPI (Swagger) documentation to the backend API by adding decorators to controller methods and registering the OpenAPI provider. This will enable automated generation of API documentation and improve API discoverability and client integration.

Key changes include:

**OpenAPI Integration and Provider Registration**
* Registered the OpenAPI provider by adding `@foadonis/openapi/openapi_provider` to the providers array in `adonisrc.ts`.

**API Documentation for Controllers**
* Added OpenAPI decorators (`@ApiOperation`, `@ApiResponse`, `@ApiBody`, `@ApiParam`, `@ApiSecurity`) to all relevant methods in the following controllers to describe endpoints, request/response schemas, and security requirements:
  - [`AuthController`](diffhunk://#diff-31312f963f4b004792fc4eb83d21a11e3c0d6509eaa737bfde506f0e625b0dcbR10): Documented registration, login, token refresh, logout, email verification, resend verification, and user profile endpoints. [[1]](diffhunk://#diff-31312f963f4b004792fc4eb83d21a11e3c0d6509eaa737bfde506f0e625b0dcbR10) [[2]](diffhunk://#diff-31312f963f4b004792fc4eb83d21a11e3c0d6509eaa737bfde506f0e625b0dcbR19-R41) [[3]](diffhunk://#diff-31312f963f4b004792fc4eb83d21a11e3c0d6509eaa737bfde506f0e625b0dcbR73-R92) [[4]](diffhunk://#diff-31312f963f4b004792fc4eb83d21a11e3c0d6509eaa737bfde506f0e625b0dcbR129-R146) [[5]](diffhunk://#diff-31312f963f4b004792fc4eb83d21a11e3c0d6509eaa737bfde506f0e625b0dcbR179-R195) [[6]](diffhunk://#diff-31312f963f4b004792fc4eb83d21a11e3c0d6509eaa737bfde506f0e625b0dcbR220-R236) [[7]](diffhunk://#diff-31312f963f4b004792fc4eb83d21a11e3c0d6509eaa737bfde506f0e625b0dcbR275-R291) [[8]](diffhunk://#diff-31312f963f4b004792fc4eb83d21a11e3c0d6509eaa737bfde506f0e625b0dcbR315-R321)
  - [`AchievementsController`](diffhunk://#diff-fa04caaa9d3a5793b5d8f4542dcba03a11317161d5e9e7795cd9418792a5d31bR6-R14): Documented CRUD endpoints for achievements. [[1]](diffhunk://#diff-fa04caaa9d3a5793b5d8f4542dcba03a11317161d5e9e7795cd9418792a5d31bR6-R14) [[2]](diffhunk://#diff-fa04caaa9d3a5793b5d8f4542dcba03a11317161d5e9e7795cd9418792a5d31bR24-R38) [[3]](diffhunk://#diff-fa04caaa9d3a5793b5d8f4542dcba03a11317161d5e9e7795cd9418792a5d31bR57-R61) [[4]](diffhunk://#diff-fa04caaa9d3a5793b5d8f4542dcba03a11317161d5e9e7795cd9418792a5d31bR74-R89) [[5]](diffhunk://#diff-fa04caaa9d3a5793b5d8f4542dcba03a11317161d5e9e7795cd9418792a5d31bR109-R113)
  - [`GameSessionsController`](diffhunk://#diff-8a2d76829b2ab9300c8f1296b0f8d6b8ac6215e4b3d6f1fff654b5234a2ae8a7R5-R13): Documented CRUD and query endpoints for game sessions, including security requirements for protected endpoints. [[1]](diffhunk://#diff-8a2d76829b2ab9300c8f1296b0f8d6b8ac6215e4b3d6f1fff654b5234a2ae8a7R5-R13) [[2]](diffhunk://#diff-8a2d76829b2ab9300c8f1296b0f8d6b8ac6215e4b3d6f1fff654b5234a2ae8a7R23-R40) [[3]](diffhunk://#diff-8a2d76829b2ab9300c8f1296b0f8d6b8ac6215e4b3d6f1fff654b5234a2ae8a7R54-R58) [[4]](diffhunk://#diff-8a2d76829b2ab9300c8f1296b0f8d6b8ac6215e4b3d6f1fff654b5234a2ae8a7R74-R92) [[5]](diffhunk://#diff-8a2d76829b2ab9300c8f1296b0f8d6b8ac6215e4b3d6f1fff654b5234a2ae8a7R108-R113) [[6]](diffhunk://#diff-8a2d76829b2ab9300c8f1296b0f8d6b8ac6215e4b3d6f1fff654b5234a2ae8a7R130-R133) [[7]](diffhunk://#diff-8a2d76829b2ab9300c8f1296b0f8d6b8ac6215e4b3d6f1fff654b5234a2ae8a7R146-R149)
  - [`GamesController`](diffhunk://#diff-82b43b37370698e6819d6de0b15d7ca66126e82dfbbdf5e690ba20b788e85337R5-R13): Documented the endpoint for listing all games.

**CI/CD Workflow**
* Reactivated the SonarQube Quality Gate step in the GitHub Actions workflow to ensure code quality checks are enforced.