### PR TITLE
MIX-226 feat: setup ngrok for the bakend API

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       start_period: 5s
 
   ngrok:
-    image: ngrok/ngrok:3.13.0
+    image: ngrok/ngrok:latest
     restart: unless-stopped
     command: http backend:3333
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,6 @@ services:
 
   ngrok:
     image: ngrok/ngrok:latest
-    restart: unless-stopped
     command: http backend:3333
     environment:
       # NGROK_AUTHTOKEN is required for ngrok to authenticate your tunnel.
@@ -47,12 +46,12 @@ services:
       - backend
     networks:
       - backend
-    healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
-      start_period: 15s
+    # healthcheck:
+    #   test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040"]
+    #   interval: 10s
+    #   timeout: 3s
+    #   retries: 5
+    #   start_period: 15s
 
   database:
     image: postgres:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ services:
     restart: unless-stopped
     command: http backend:3333
     environment:
+      # NGROK_AUTHTOKEN is required for ngrok to authenticate your tunnel.
+      # Set this variable in your shell environment or in a .env file as:
+      # NGROK_AUTHTOKEN=your-token-here
+      # You can obtain an auth token from the ngrok dashboard:
+      # https://dashboard.ngrok.com/get-started/your-authtoken
       - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
     ports:
       - "4040:4040"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,19 @@ services:
       retries: 3
       start_period: 5s
 
+  ngrok:
+    image: ngrok/ngrok:latest
+    restart: unless-stopped
+    command: http backend:3333
+    environment:
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+    ports:
+      - "4040:4040"
+    depends_on:
+      - backend
+    networks:
+      - backend
+
   database:
     image: postgres:alpine
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       start_period: 5s
 
   ngrok:
-    image: ngrok/ngrok:latest
+    image: ngrok/ngrok:3.13.0
     restart: unless-stopped
     command: http backend:3333
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,19 +39,21 @@ services:
       # NGROK_AUTHTOKEN=your-token-here
       # You can obtain an auth token from the ngrok dashboard:
       # https://dashboard.ngrok.com/get-started/your-authtoken
-      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN}
+      - NGROK_AUTHTOKEN=${NGROK_AUTHTOKEN:-} 
+    profiles:
+      - ngrok # Enable ngrok by specifying the 'ngrok' profile when running docker-compose commands (e.g., `docker-compose --profile ngrok up`)
     ports:
       - "4040:4040"
     depends_on:
       - backend
     networks:
       - backend
-    # healthcheck:
-    #   test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040"]
-    #   interval: 10s
-    #   timeout: 3s
-    #   retries: 5
-    #   start_period: 15s
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
 
   database:
     image: postgres:alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,12 @@ services:
       - backend
     networks:
       - backend
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:4040"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 15s
 
   database:
     image: postgres:alpine


### PR DESCRIPTION
This pull request adds a new service to the `docker-compose.yml` file to enable secure tunneling via ngrok. This allows external access to the local `backend` service for development or testing purposes.

New service addition:

* Added an `ngrok` service that uses the official `ngrok/ngrok:latest` image, connects to the `backend` service on port 3333, and exposes the ngrok web interface on port 4040. The service uses the `NGROK_AUTHTOKEN` environment variable for authentication and is configured to restart unless stopped. (`docker-compose.yml`)