### PR TITLE
MIX-276 fix: clear error state on stop and harden audio player resilience

### DIFF
--- a/front-mobile/hooks/__tests__/useAudioPlayer.test.ts
+++ b/front-mobile/hooks/__tests__/useAudioPlayer.test.ts
@@ -107,14 +107,17 @@ describe("useAudioPlayer", () => {
       });
     });
 
-    it("should not call player.remove on unmount (expo-audio handles it)", () => {
+    it("should patch player.remove to suppress NativeSharedObjectNotFoundException", () => {
+      mockPlayer.remove.mockImplementation(() => {
+        throw new Error("NativeSharedObjectNotFoundException");
+      });
+
       const { unmount } = renderHook(() => useAudioPlayer());
 
-      unmount();
+      // The patched remove should not throw
+      expect(() => mockPlayer.remove()).not.toThrow();
 
-      // expo-audio's useAudioPlayer gère le cycle de vie natif via son propre cleanup.
-      // Notre hook ne doit pas appeler remove() pour éviter un double remove.
-      expect(mockPlayer.remove).not.toHaveBeenCalled();
+      unmount();
     });
   });
 
@@ -300,6 +303,23 @@ describe("useAudioPlayer", () => {
       expect(mockPlayer.seekTo).toHaveBeenCalledWith(0);
       expect(result.current.isPlaying).toBe(false);
       expect(result.current.position).toBe(0);
+    });
+
+    it("should clear error state when stopping", async () => {
+      const trackWithoutPreview = { ...mockTrack, preview: "" };
+      const { result } = renderHook(() => useAudioPlayer());
+
+      // Trigger an error
+      await act(async () => {
+        await result.current.play(trackWithoutPreview);
+      });
+      expect(result.current.error).toBeTruthy();
+
+      // Stop should clear the error
+      await act(async () => {
+        await result.current.stop();
+      });
+      expect(result.current.error).toBeNull();
     });
 
     it("should handle stop errors", async () => {

--- a/front-mobile/hooks/__tests__/useAudioPlayer.test.ts
+++ b/front-mobile/hooks/__tests__/useAudioPlayer.test.ts
@@ -107,17 +107,26 @@ describe("useAudioPlayer", () => {
       });
     });
 
-    it("should patch player.remove to suppress NativeSharedObjectNotFoundException", () => {
+    it("should suppress NativeSharedObjectNotFoundException on remove", () => {
       mockPlayer.remove.mockImplementation(() => {
         throw new Error("NativeSharedObjectNotFoundException");
       });
 
       const { unmount } = renderHook(() => useAudioPlayer());
 
-      // The patched remove should not throw
       expect(() => mockPlayer.remove()).not.toThrow();
 
       unmount();
+    });
+
+    it("should rethrow unexpected errors on remove", () => {
+      mockPlayer.remove.mockImplementation(() => {
+        throw new Error("SomeOtherError");
+      });
+
+      renderHook(() => useAudioPlayer());
+
+      expect(() => mockPlayer.remove()).toThrow("SomeOtherError");
     });
   });
 

--- a/front-mobile/hooks/useAudioPlayer.ts
+++ b/front-mobile/hooks/useAudioPlayer.ts
@@ -37,6 +37,28 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
   const updateIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const isMountedRef = useRef(true);
   const playRequestIdRef = useRef(0);
+  const lastActionTimeRef = useRef(0);
+  const prevPositionRef = useRef(0);
+  const prevDurationRef = useRef(0);
+  const prevIsPlayingRef = useRef(false);
+
+  // Sécuriser player.remove() contre NativeSharedObjectNotFoundException.
+  // expo-audio appelle remove() en interne au démontage, mais l'objet natif
+  // peut déjà être libéré lors d'une navigation rapide entre tabs.
+  useEffect(() => {
+    const remove = player.remove as { __patched?: boolean };
+    if (remove.__patched) return;
+    const originalRemove = player.remove.bind(player);
+    const patched = (() => {
+      try {
+        originalRemove();
+      } catch {
+        // Objet natif déjà libéré — rien à faire
+      }
+    }) as typeof player.remove & { __patched?: boolean };
+    patched.__patched = true;
+    player.remove = patched;
+  }, [player]);
 
   // Configurer le mode audio au montage
   useEffect(() => {
@@ -52,9 +74,6 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
 
     configureAudio();
 
-    // Cleanup au démontage
-    // Ne pas appeler player.remove() ici : useExpoAudioPlayer gère déjà le cycle
-    // de vie natif. Un double remove provoquerait NativeSharedObjectNotFoundException.
     return () => {
       isMountedRef.current = false;
       if (updateIntervalRef.current) {
@@ -73,9 +92,24 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
     updateIntervalRef.current = setInterval(() => {
       if (!isMountedRef.current) return;
       try {
-        setIsPlaying(player.playing);
-        setPosition(player.currentTime);
-        setDuration(player.duration || 0);
+        const msSinceAction = Date.now() - lastActionTimeRef.current;
+        if (
+          msSinceAction > 1000 &&
+          player.playing !== prevIsPlayingRef.current
+        ) {
+          prevIsPlayingRef.current = player.playing;
+          setIsPlaying(player.playing);
+        }
+        const newPosition = player.currentTime;
+        if (newPosition !== prevPositionRef.current) {
+          prevPositionRef.current = newPosition;
+          setPosition(newPosition);
+        }
+        const newDuration = player.duration || 0;
+        if (newDuration !== prevDurationRef.current) {
+          prevDurationRef.current = newDuration;
+          setDuration(newDuration);
+        }
       } catch {
         // Ignorer les erreurs de lecture des propriétés
       }
@@ -110,11 +144,13 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
 
       player.replace({ uri: track.preview });
       player.play();
+      lastActionTimeRef.current = Date.now();
 
       if (requestId !== playRequestIdRef.current) return;
 
       setCurrentTrack(track);
       setIsPlaying(true);
+      prevIsPlayingRef.current = true;
       setIsLoading(false);
     } catch (err) {
       if (requestId !== playRequestIdRef.current) return;
@@ -147,6 +183,7 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
       setError(error.getUserMessage());
       setIsLoading(false);
       setIsPlaying(false);
+      prevIsPlayingRef.current = false;
       console.error("Error playing track:", error);
     }
   };
@@ -154,8 +191,10 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
   const pause = async (): Promise<void> => {
     if (!isMountedRef.current) return;
     try {
+      lastActionTimeRef.current = Date.now();
       player.pause();
       setIsPlaying(false);
+      prevIsPlayingRef.current = false;
     } catch (err) {
       const error = AudioPlayerError.playbackError(
         "Impossible de mettre en pause",
@@ -168,8 +207,10 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
   const resume = async (): Promise<void> => {
     if (!isMountedRef.current) return;
     try {
+      lastActionTimeRef.current = Date.now();
       player.play();
       setIsPlaying(true);
+      prevIsPlayingRef.current = true;
     } catch (err) {
       const error = AudioPlayerError.playbackError(
         "Impossible de reprendre la lecture",
@@ -182,10 +223,13 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
   const stop = async (): Promise<void> => {
     if (!isMountedRef.current) return;
     try {
+      lastActionTimeRef.current = Date.now();
       player.pause();
       player.seekTo(0);
       setIsPlaying(false);
+      prevIsPlayingRef.current = false;
       setPosition(0);
+      setError(null);
     } catch (err) {
       const error = AudioPlayerError.playbackError(
         "Impossible d'arrêter la lecture",

--- a/front-mobile/hooks/useAudioPlayer.ts
+++ b/front-mobile/hooks/useAudioPlayer.ts
@@ -24,6 +24,9 @@ interface AudioPlayerActions {
 
 export type UseAudioPlayerReturn = AudioPlayerState & AudioPlayerActions;
 
+const POLL_INTERVAL_MS = 250;
+const ACTION_GRACE_PERIOD_MS = 1000;
+
 export const useAudioPlayer = (): UseAudioPlayerReturn => {
   const player = useExpoAudioPlayer();
 
@@ -52,8 +55,15 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
     const patched = (() => {
       try {
         originalRemove();
-      } catch {
-        // Objet natif déjà libéré — rien à faire
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes("NativeSharedObject")) {
+          return;
+        }
+        if (__DEV__) {
+          console.error("Unexpected error in player.remove():", err);
+        }
+        throw err;
       }
     }) as typeof player.remove & { __patched?: boolean };
     patched.__patched = true;
@@ -94,7 +104,7 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
       try {
         const msSinceAction = Date.now() - lastActionTimeRef.current;
         if (
-          msSinceAction > 1000 &&
+          msSinceAction > ACTION_GRACE_PERIOD_MS &&
           player.playing !== prevIsPlayingRef.current
         ) {
           prevIsPlayingRef.current = player.playing;
@@ -113,7 +123,7 @@ export const useAudioPlayer = (): UseAudioPlayerReturn => {
       } catch {
         // Ignorer les erreurs de lecture des propriétés
       }
-    }, 250);
+    }, POLL_INTERVAL_MS);
 
     return () => {
       if (updateIntervalRef.current) {


### PR DESCRIPTION
## Description

Corrige le bug où le message d'erreur audio restait affiché après un swipe sur SwipeMix. La fonction `stop()` dans `useAudioPlayer` ne remettait pas l'état `error` à `null`, causant un affichage stale sur la carte suivante.

En complément, renforce la résilience du player audio :
- Patch sécurisé de `player.remove()` pour supprimer le crash `NativeSharedObjectNotFoundException` lors de la navigation entre tabs
- Grace period de 1s empêchant l'intervalle de polling d'écraser l'état `isPlaying` immédiatement après une action utilisateur (corrige le flicker du bouton play/pause)
- Change-detection refs pour éviter des re-renders inutiles toutes les 250ms quand les valeurs n'ont pas changé

## Parcours utilisateur

1. Ouvrir l'app sur l'onglet SwipeMix
2. Lancer la lecture d'un track
3. Couper le réseau ou provoquer une erreur audio → vérifier que le message d'erreur s'affiche
4. Swiper vers une nouvelle carte → vérifier que le message d'erreur **disparaît**
5. Vérifier que le bouton play/pause ne flicker pas lors de l'apparition d'une nouvelle carte
6. Naviguer rapidement entre les tabs → vérifier qu'il n'y a pas de crash `NativeSharedObjectNotFoundException` dans les logs
7. Tester sur iOS et Android