### PR TITLE
MIX-271 feat: add GET /me/game/:gameId route for game session history

### DIFF
--- a/backend/app/controllers/game_sessions_controller.ts
+++ b/backend/app/controllers/game_sessions_controller.ts
@@ -225,6 +225,46 @@ export default class GameSessionsController {
   }
 
   @ApiOperation({
+    summary: 'Get my game history for a specific game',
+    description:
+      'Retrieve completed and canceled game sessions of the authenticated user for a specific game, sorted by most recent first. Supports optional status filter and pagination.',
+  })
+  @ApiSecurity('bearerAuth')
+  @ApiParam({ name: 'gameId', description: 'Game ID', required: true })
+  @ApiResponse({ status: 200, description: 'Game session history retrieved successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 500, description: 'Error while fetching game session history' })
+  public async myGameHistory({ auth, params, request, response }: HttpContext) {
+    try {
+      const userId = auth.user!.id
+      const gameId = Number(params.gameId)
+      const status = request.qs().status as string | undefined
+      if (
+        status &&
+        ![GameSessionStatus.Completed, GameSessionStatus.Canceled].includes(
+          status as GameSessionStatus
+        )
+      ) {
+        return response
+          .status(400)
+          .json({ message: 'Invalid status filter. Allowed values: completed, canceled' })
+      }
+      const page = Math.max(1, Number(request.qs().page) || 1)
+      const limit = Math.min(100, Math.max(1, Number(request.qs().limit) || 20))
+      const gameSessions = await this.gameSessionService.getMyGameHistory(
+        userId,
+        gameId,
+        status,
+        page,
+        limit
+      )
+      return response.json(gameSessions)
+    } catch (error) {
+      return response.status(500).json({ message: 'Error while fetching game session history' })
+    }
+  }
+
+  @ApiOperation({
     summary: 'Get my active session for a game',
     description:
       'Retrieve the active game session of the authenticated user for a specific game, or null if none exists. If multiple active sessions exist, returns the most recent one.',

--- a/backend/app/services/game_session_service.ts
+++ b/backend/app/services/game_session_service.ts
@@ -130,6 +130,29 @@ export class GameSessionService {
     return query.orderBy('created_at', 'desc')
   }
 
+  public async getMyGameHistory(
+    userId: string,
+    gameId: number,
+    status?: string,
+    page: number = 1,
+    limit: number = 20
+  ) {
+    const allowedStatuses = [GameSessionStatus.Completed, GameSessionStatus.Canceled]
+    const query = GameSession.query()
+      .whereRaw('players::jsonb @> ?::jsonb', [JSON.stringify([{ userId }])])
+      .where('game_id', gameId)
+      .preload('game')
+      .orderBy('created_at', 'desc')
+
+    if (status) {
+      query.where('status', status)
+    } else {
+      query.whereIn('status', allowedStatuses)
+    }
+
+    return query.paginate(page, limit)
+  }
+
   public async getMyActiveSessionByGameId(userId: string, gameId: number) {
     return GameSession.query()
       .whereRaw('players::jsonb @> ?::jsonb', [JSON.stringify([{ userId }])])

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -102,6 +102,9 @@ router
         router.get('/', [GameSessionsController, 'index'])
         router.get('/me', [GameSessionsController, 'mySessions']).use(middleware.auth())
         router
+          .get('/me/game/:gameId', [GameSessionsController, 'myGameHistory'])
+          .use(middleware.auth())
+        router
           .get('/me/game/:gameId/active', [GameSessionsController, 'myActiveSession'])
           .use(middleware.auth())
         router.post('/', [GameSessionsController, 'create']).use(middleware.auth())

--- a/front-mobile/services/__tests__/gameSessionService.test.ts
+++ b/front-mobile/services/__tests__/gameSessionService.test.ts
@@ -7,6 +7,7 @@ import {
   getGameSessionsByGameId,
   getGameSessionsByStatus,
   getMyGameSessions,
+  getMyGameHistory,
   getMyActiveSession,
 } from "../gameSessionService";
 
@@ -131,6 +132,48 @@ describe("getMyGameSessions", () => {
     const result = await getMyGameSessions("active");
     expect(result).toEqual([mockSession]);
     expect(mockGet).toHaveBeenCalledWith("/api/game-sessions/me?status=active");
+  });
+});
+
+describe("getMyGameHistory", () => {
+  it("should return paginated history without options", async () => {
+    const mockResponse = {
+      meta: {
+        total: 1,
+        perPage: 20,
+        currentPage: 1,
+        lastPage: 1,
+        firstPage: 1,
+      },
+      data: [mockSession],
+    };
+    mockGet.mockResolvedValueOnce(mockResponse);
+    const result = await getMyGameHistory(1);
+    expect(result).toEqual(mockResponse);
+    expect(mockGet).toHaveBeenCalledWith("/api/game-sessions/me/game/1");
+  });
+
+  it("should append query params when options are provided", async () => {
+    const mockResponse = {
+      meta: {
+        total: 1,
+        perPage: 10,
+        currentPage: 2,
+        lastPage: 3,
+        firstPage: 1,
+      },
+      data: [mockSession],
+    };
+    mockGet.mockResolvedValueOnce(mockResponse);
+    const result = await getMyGameHistory(1, {
+      status: "completed",
+      page: 2,
+      limit: 10,
+    });
+    expect(result).toEqual(mockResponse);
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/game-sessions/me/game/1?status=completed&page=2&limit=10",
+    );
   });
 });
 

--- a/front-mobile/services/gameSessionService.ts
+++ b/front-mobile/services/gameSessionService.ts
@@ -9,6 +9,7 @@ import {
   GetGameSessionsByGameIdResponse,
   GetGameSessionsByStatusResponse,
   GetMyActiveGameSessionResponse,
+  GetMyGameHistoryResponse,
   GetMyGameSessionsResponse,
   UpdateGameSessionRequest,
 } from "@/types/gameSession";
@@ -82,6 +83,20 @@ export const getMyGameSessions = async (
     : "/api/game-sessions/me";
   const data = await get<GetMyGameSessionsResponse>(url);
   return data.gameSessions;
+};
+
+export const getMyGameHistory = async (
+  gameId: number,
+  options?: { status?: GameSessionStatus; page?: number; limit?: number },
+): Promise<GetMyGameHistoryResponse> => {
+  const params = new URLSearchParams();
+  if (options?.status) params.append("status", options.status);
+  if (options?.page) params.append("page", String(options.page));
+  if (options?.limit) params.append("limit", String(options.limit));
+  const query = params.toString() ? `?${params.toString()}` : "";
+  return await get<GetMyGameHistoryResponse>(
+    `/api/game-sessions/me/game/${gameId}${query}`,
+  );
 };
 
 export const getMyActiveSession = async (

--- a/front-mobile/types/gameSession.ts
+++ b/front-mobile/types/gameSession.ts
@@ -52,6 +52,17 @@ export interface GetMyGameSessionsResponse {
   gameSessions: GameSession[];
 }
 
+export interface GetMyGameHistoryResponse {
+  meta: {
+    total: number;
+    perPage: number;
+    currentPage: number;
+    lastPage: number;
+    firstPage: number;
+  };
+  data: GameSession[];
+}
+
 export interface GetMyActiveGameSessionResponse {
   gameSession: GameSession | null;
 }


### PR DESCRIPTION
This pull request introduces a new feature that allows authenticated users to retrieve their game session history for a specific game, including support for filtering by status and pagination. The changes span backend controller, service, route configuration, and corresponding frontend service and tests.

**Backend API additions:**

- Added a new controller method `myGameHistory` in `GameSessionsController` to fetch a user's completed or canceled game sessions for a specific game, with support for optional status filtering and pagination.
- Implemented the `getMyGameHistory` method in `GameSessionService` to query the database for the relevant sessions, supporting filtering and pagination.
- Registered the new route `/api/game-sessions/me/game/:gameId` in the router, protected by authentication middleware.

**Frontend support and testing:**

- Added the `getMyGameHistory` function to `gameSessionService.ts` to call the new backend endpoint, supporting optional query parameters for status, page, and limit.
- Defined the `GetMyGameHistoryResponse` type for the frontend to handle the paginated response.
- Added unit tests for `getMyGameHistory` to verify correct API calls and response handling, including query parameter support.