### PR TITLE
MIX-281 fix: cancel orphaned server sessions when no local save exists and extract useGameIndex hook

### DIFF
--- a/front-mobile/app/(tabs)/games/blurchette/index.tsx
+++ b/front-mobile/app/(tabs)/games/blurchette/index.tsx
@@ -1,5 +1,3 @@
-import { useCallback, useState } from "react";
-import { router, useFocusEffect } from "expo-router";
 import {
   ActivityIndicator,
   ScrollView,
@@ -7,114 +5,30 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { router } from "expo-router";
 import { MaterialIcons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/ThemedText";
 import Button from "@/components/Button";
 import Header from "@/components/Header";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import { Colors } from "@/constants/Colors";
-import { getAllGames } from "@/services/gameService";
-import { hasGameState } from "@/services/gameStorageService";
-import {
-  getMyActiveSession,
-  updateGameSession,
-} from "@/services/gameSessionService";
-import { GameSession } from "@/types/gameSession";
-import * as Haptics from "expo-haptics";
+import { useGameIndex } from "@/hooks/useGameIndex";
 
 export default function BlurchetteIndexScreen() {
-  const [gameId, setGameId] = useState<number | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
-  const [hasSavedGame, setHasSavedGame] = useState(false);
-  const [activeSession, setActiveSession] = useState<GameSession | null>(null);
-  const [isResumeModalVisible, setIsResumeModalVisible] = useState(false);
-
-  useFocusEffect(
-    useCallback(() => {
-      loadGameId();
-    }, []),
-  );
-
-  const loadGameId = async () => {
-    try {
-      const games = await getAllGames();
-      const blurchette = games.find(
-        (g) => g.name.toLowerCase() === "blurchette",
-      );
-      if (blurchette) {
-        setGameId(blurchette.id);
-        const savedStateExists = await hasGameState(blurchette.id.toString());
-        setHasSavedGame(savedStateExists);
-      } else {
-        setError(true);
-      }
-    } catch (err) {
-      console.error("Failed to load game ID:", err);
-      setError(true);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleStartGame = async (resume: boolean = false) => {
-    if (!gameId) return;
-
-    if (resume) {
-      Haptics.selectionAsync().catch(() => {});
-      navigateToGame(true);
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const session = await getMyActiveSession(gameId);
-
-      if (session && session.status === "active") {
-        setActiveSession(session);
-        setIsResumeModalVisible(true);
-      } else {
-        navigateToGame(false);
-      }
-    } catch (err) {
-      console.error("Error checking active session:", err);
-      navigateToGame(false);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleConfirmResume = () => {
-    setIsResumeModalVisible(false);
-    navigateToGame(true);
-  };
-
-  const handleStartNewGame = async () => {
-    setIsResumeModalVisible(false);
-    if (activeSession) {
-      setLoading(true);
-      try {
-        await updateGameSession(activeSession.id, { status: "canceled" });
-      } catch (e) {
-        console.error("Failed to cancel session:", e);
-      } finally {
-        setLoading(false);
-      }
-    }
-    navigateToGame(false);
-  };
-
-  const navigateToGame = (resume: boolean) => {
-    if (gameId) {
-      router.push({
-        pathname: "/games/blurchette/game",
-        params: {
-          gameId: gameId.toString(),
-          resume: resume.toString(),
-        },
-      });
-    }
-  };
+  const {
+    gameId,
+    loading,
+    error,
+    hasSavedGame,
+    isResumeModalVisible,
+    setIsResumeModalVisible,
+    handleStartGame,
+    handleConfirmResume,
+    handleStartNewGame,
+  } = useGameIndex({
+    gameName: "blurchette",
+    gamePath: "/games/blurchette/game",
+  });
 
   if (loading && !gameId) {
     return (

--- a/front-mobile/app/(tabs)/games/tracklist/index.tsx
+++ b/front-mobile/app/(tabs)/games/tracklist/index.tsx
@@ -1,5 +1,3 @@
-import { useCallback, useState } from "react";
-import { router, useFocusEffect } from "expo-router";
 import {
   ActivityIndicator,
   ScrollView,
@@ -7,112 +5,30 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { router } from "expo-router";
 import { MaterialIcons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/ThemedText";
 import Button from "@/components/Button";
 import Header from "@/components/Header";
 import ConfirmationModal from "@/components/ConfirmationModal";
 import { Colors } from "@/constants/Colors";
-import { getAllGames } from "@/services/gameService";
-import { hasGameState } from "@/services/gameStorageService";
-import {
-  getMyActiveSession,
-  updateGameSession,
-} from "@/services/gameSessionService";
-import { GameSession } from "@/types/gameSession";
-import * as Haptics from "expo-haptics";
+import { useGameIndex } from "@/hooks/useGameIndex";
 
 export default function TracklistIndexScreen() {
-  const [gameId, setGameId] = useState<number | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
-  const [hasSavedGame, setHasSavedGame] = useState(false);
-  const [activeSession, setActiveSession] = useState<GameSession | null>(null);
-  const [isResumeModalVisible, setIsResumeModalVisible] = useState(false);
-
-  useFocusEffect(
-    useCallback(() => {
-      loadGameId();
-    }, []),
-  );
-
-  const loadGameId = async () => {
-    try {
-      const games = await getAllGames();
-      const tracklist = games.find((g) => g.name.toLowerCase() === "tracklist");
-      if (tracklist) {
-        setGameId(tracklist.id);
-        const savedStateExists = await hasGameState(tracklist.id.toString());
-        setHasSavedGame(savedStateExists);
-      } else {
-        setError(true);
-      }
-    } catch (err) {
-      console.error("Failed to load game ID:", err);
-      setError(true);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleStartGame = async (resume: boolean = false) => {
-    if (!gameId) return;
-
-    if (resume) {
-      Haptics.selectionAsync().catch(() => {});
-      navigateToGame(true);
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const session = await getMyActiveSession(gameId);
-
-      if (session && session.status === "active") {
-        setActiveSession(session);
-        setIsResumeModalVisible(true);
-      } else {
-        navigateToGame(false);
-      }
-    } catch (err) {
-      console.error("Error checking active session:", err);
-      navigateToGame(false);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleConfirmResume = () => {
-    setIsResumeModalVisible(false);
-    navigateToGame(true);
-  };
-
-  const handleStartNewGame = async () => {
-    setIsResumeModalVisible(false);
-    if (activeSession) {
-      setLoading(true);
-      try {
-        await updateGameSession(activeSession.id, { status: "canceled" });
-      } catch (e) {
-        console.error("Failed to cancel session:", e);
-      } finally {
-        setLoading(false);
-      }
-    }
-    navigateToGame(false);
-  };
-
-  const navigateToGame = (resume: boolean) => {
-    if (gameId) {
-      router.push({
-        pathname: "/games/tracklist/game",
-        params: {
-          gameId: gameId.toString(),
-          resume: resume.toString(),
-        },
-      });
-    }
-  };
+  const {
+    gameId,
+    loading,
+    error,
+    hasSavedGame,
+    isResumeModalVisible,
+    setIsResumeModalVisible,
+    handleStartGame,
+    handleConfirmResume,
+    handleStartNewGame,
+  } = useGameIndex({
+    gameName: "tracklist",
+    gamePath: "/games/tracklist/game",
+  });
 
   if (loading && !gameId) {
     return (

--- a/front-mobile/hooks/useGameIndex.ts
+++ b/front-mobile/hooks/useGameIndex.ts
@@ -1,0 +1,132 @@
+import { useCallback, useState } from "react";
+import { router, useFocusEffect } from "expo-router";
+import { getAllGames } from "@/services/gameService";
+import { hasGameState } from "@/services/gameStorageService";
+import {
+  getMyActiveSession,
+  updateGameSession,
+} from "@/services/gameSessionService";
+import { GameSession } from "@/types/gameSession";
+import * as Haptics from "expo-haptics";
+
+interface UseGameIndexOptions {
+  gameName: string;
+  gamePath: string;
+}
+
+export function useGameIndex({ gameName, gamePath }: UseGameIndexOptions) {
+  const [gameId, setGameId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [hasSavedGame, setHasSavedGame] = useState(false);
+  const [activeSession, setActiveSession] = useState<GameSession | null>(null);
+  const [isResumeModalVisible, setIsResumeModalVisible] = useState(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      loadGameId();
+    }, []),
+  );
+
+  const loadGameId = async () => {
+    try {
+      const games = await getAllGames();
+      const game = games.find(
+        (g) => g.name.toLowerCase() === gameName.toLowerCase(),
+      );
+      if (game) {
+        setGameId(game.id);
+        const savedStateExists = await hasGameState(game.id.toString());
+        setHasSavedGame(savedStateExists);
+      } else {
+        setError(true);
+      }
+    } catch (err) {
+      console.error(`Failed to load game ID for ${gameName}:`, err);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const navigateToGame = (resume: boolean) => {
+    if (gameId) {
+      router.push({
+        pathname: gamePath as any,
+        params: {
+          gameId: gameId.toString(),
+          resume: resume.toString(),
+        },
+      });
+    }
+  };
+
+  const handleStartGame = async (resume: boolean = false) => {
+    if (!gameId) return;
+
+    if (resume) {
+      Haptics.selectionAsync().catch(() => {});
+      navigateToGame(true);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const session = await getMyActiveSession(gameId);
+
+      if (session && session.status === "active") {
+        const localSaveExists = await hasGameState(gameId.toString());
+        if (localSaveExists) {
+          setActiveSession(session);
+          setIsResumeModalVisible(true);
+        } else {
+          try {
+            await updateGameSession(session.id, { status: "canceled" });
+          } catch (e) {
+            console.error("Failed to cancel orphaned session:", e);
+          }
+          navigateToGame(false);
+        }
+      } else {
+        navigateToGame(false);
+      }
+    } catch (err) {
+      console.error("Error checking active session:", err);
+      navigateToGame(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleConfirmResume = () => {
+    setIsResumeModalVisible(false);
+    navigateToGame(true);
+  };
+
+  const handleStartNewGame = async () => {
+    setIsResumeModalVisible(false);
+    if (activeSession) {
+      setLoading(true);
+      try {
+        await updateGameSession(activeSession.id, { status: "canceled" });
+      } catch (e) {
+        console.error("Failed to cancel session:", e);
+      } finally {
+        setLoading(false);
+      }
+    }
+    navigateToGame(false);
+  };
+
+  return {
+    gameId,
+    loading,
+    error,
+    hasSavedGame,
+    isResumeModalVisible,
+    setIsResumeModalVisible,
+    handleStartGame,
+    handleConfirmResume,
+    handleStartNewGame,
+  };
+}


### PR DESCRIPTION
## Description

Correction d'un bug où la modal "Partie en cours" s'affichait lors du clic sur "Commencer à jouer" alors qu'aucune sauvegarde locale n'existait. Cela se produisait quand une session active existait côté serveur mais que le save AsyncStorage avait expiré ou été supprimé : cliquer sur "Reprendre" ne faisait rien et l'utilisateur restait bloqué sur la sélection de genre.

Le fix vérifie désormais la présence d'un save local avant d'afficher la modal. Si aucun save local n'existe, la session serveur orpheline est automatiquement annulée et une nouvelle partie démarre directement. La logique de gestion de session, dupliquée entre Tracklist et Blurchette, a été extraite dans un hook `useGameIndex` réutilisable pour tout futur jeu.

## Parcours utilisateur

1. Ouvrir l'application et se connecter
2. Aller dans l'onglet Jeux → Tracklist
3. Lancer une partie, choisir un genre, un artiste et un album
4. Une fois la partie en cours, quitter l'application complètement (kill)
5. Attendre que le save local expire (ou le supprimer manuellement depuis AsyncStorage)
6. Rouvrir l'application → Jeux → Tracklist
7. Cliquer sur "Commencer à jouer"
8. Vérifier qu'aucune modal "Partie en cours" ne s'affiche et qu'une nouvelle partie démarre directement
9. Répéter les étapes 2 à 8 avec Blurchette pour vérifier le même comportement