### PR TITLE
MIX-278 feat: add liked-tracks service with types and tests

### DIFF
--- a/backend/app/services/liked_track_service.ts
+++ b/backend/app/services/liked_track_service.ts
@@ -24,15 +24,11 @@ export class LikedTrackService {
     type?: string | null
   }): Promise<LikedTrack | ServiceError> {
     try {
-      return await LikedTrack.create(payload)
+      return await LikedTrack.firstOrCreate(
+        { userId: payload.userId, deezerTrackId: payload.deezerTrackId },
+        { title: payload.title, artist: payload.artist, type: payload.type }
+      )
     } catch (error: any) {
-      // Handle unique / truncation DB errors similarly to other services
-      if (error.code === '23505') {
-        return {
-          error: 'Conflict when creating liked track',
-          status: 409,
-        }
-      }
       if (error.code === '22001') {
         return {
           error: 'One or more fields exceed maximum length',

--- a/backend/tests/unit/liked_track_service.spec.ts
+++ b/backend/tests/unit/liked_track_service.spec.ts
@@ -40,36 +40,23 @@ test.group('LikedTrackService - Unit CRUD', (group) => {
     }
   })
 
-  test('createLikedTrack maps 23505 -> 409', async ({ assert }) => {
-    const user = await createTestUser('dup')
-    const originalCreate = (LikedTrack as any).create
-    ;(LikedTrack as any).create = async () => {
-      const err: any = new Error('duplicate')
-      err.code = '23505'
-      throw err
-    }
-    const result = await service.createLikedTrack({ userId: user.id, deezerTrackId: 'dup' })
-    assert.notInstanceOf(result, LikedTrack)
-    if (isServiceError(result)) {
-      assert.equal(result.status, 409)
-    }
-    ;(LikedTrack as any).create = originalCreate
-  })
-
   test('createLikedTrack maps 22001 -> 400', async ({ assert }) => {
     const user = await createTestUser('too_long')
-    const originalCreate = (LikedTrack as any).create
-    ;(LikedTrack as any).create = async () => {
+    const originalFirstOrCreate = (LikedTrack as any).firstOrCreate
+    ;(LikedTrack as any).firstOrCreate = async () => {
       const err: any = new Error('value too long')
       err.code = '22001'
       throw err
     }
-    const result = await service.createLikedTrack({ userId: user.id, deezerTrackId: 'x' })
-    assert.notInstanceOf(result, LikedTrack)
-    if (isServiceError(result)) {
-      assert.equal(result.status, 400)
+    try {
+      const result = await service.createLikedTrack({ userId: user.id, deezerTrackId: 'x' })
+      assert.notInstanceOf(result, LikedTrack)
+      if (isServiceError(result)) {
+        assert.equal(result.status, 400)
+      }
+    } finally {
+      ;(LikedTrack as any).firstOrCreate = originalFirstOrCreate
     }
-    ;(LikedTrack as any).create = originalCreate
   })
 
   test('getAll increases after insertion', async ({ assert }) => {
@@ -146,12 +133,15 @@ test.group('LikedTrackService - Unit CRUD', (group) => {
         },
       }),
     })
-    const result = await service.updateLikedTrack(rec.id, { deezerTrackId: 'dup' } as any)
-    assert.notInstanceOf(result, LikedTrack)
-    if (isServiceError(result)) {
-      assert.equal(result.status, 409)
+    try {
+      const result = await service.updateLikedTrack(rec.id, { deezerTrackId: 'dup' } as any)
+      assert.notInstanceOf(result, LikedTrack)
+      if (isServiceError(result)) {
+        assert.equal(result.status, 409)
+      }
+    } finally {
+      ;(LikedTrack as any).query = originalQuery
     }
-    ;(LikedTrack as any).query = originalQuery
   })
 
   test('updateLikedTrack maps 22001 -> 400', async ({ assert }) => {
@@ -170,12 +160,15 @@ test.group('LikedTrackService - Unit CRUD', (group) => {
         },
       }),
     })
-    const result = await service.updateLikedTrack(rec.id, { title: 'Y' } as any)
-    assert.notInstanceOf(result, LikedTrack)
-    if (isServiceError(result)) {
-      assert.equal(result.status, 400)
+    try {
+      const result = await service.updateLikedTrack(rec.id, { title: 'Y' } as any)
+      assert.notInstanceOf(result, LikedTrack)
+      if (isServiceError(result)) {
+        assert.equal(result.status, 400)
+      }
+    } finally {
+      ;(LikedTrack as any).query = originalQuery
     }
-    ;(LikedTrack as any).query = originalQuery
   })
 
   test('deleteLikedTrack deletes successfully', async ({ assert }) => {
@@ -228,9 +221,9 @@ test.group('LikedTrackService - Unit CRUD', (group) => {
 
   test('createLikedTrack rethrows on unknown DB error', async ({ assert }) => {
     const user = await createTestUser('unknown_create')
-    const originalCreate = (LikedTrack as any).create
+    const originalFirstOrCreate = (LikedTrack as any).firstOrCreate
 
-    ;(LikedTrack as any).create = async () => {
+    ;(LikedTrack as any).firstOrCreate = async () => {
       const err: any = new Error('weird db failure')
       err.code = '99999' // code non géré -> doit être relancé par le service
       throw err
@@ -243,7 +236,7 @@ test.group('LikedTrackService - Unit CRUD', (group) => {
       assert.instanceOf(e, Error)
       assert.match(String(e.message), /weird db failure/i)
     } finally {
-      ;(LikedTrack as any).create = originalCreate
+      ;(LikedTrack as any).firstOrCreate = originalFirstOrCreate
     }
   })
 

--- a/front-mobile/hooks/__tests__/useSwipeMix.test.ts
+++ b/front-mobile/hooks/__tests__/useSwipeMix.test.ts
@@ -3,12 +3,14 @@ import { useSwipeMix } from "../useSwipeMix";
 import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
 import { useAudioPlayer } from "../useAudioPlayer";
 import { deezerTracksToCardData } from "@/utils/deezer-adapter";
+import { createMyLikedTrack } from "@/services/likedTrackService";
 import { MusicCardData } from "@/components/swipe";
 
 // Mock des dépendances
 jest.mock("@/services/deezer-api");
 jest.mock("../useAudioPlayer");
 jest.mock("@/utils/deezer-adapter");
+jest.mock("@/services/likedTrackService");
 
 const mockDeezerAPI = deezerAPI as jest.Mocked<typeof deezerAPI>;
 const mockUseAudioPlayer = useAudioPlayer as jest.MockedFunction<
@@ -16,6 +18,9 @@ const mockUseAudioPlayer = useAudioPlayer as jest.MockedFunction<
 >;
 const mockDeezerTracksToCardData =
   deezerTracksToCardData as jest.MockedFunction<typeof deezerTracksToCardData>;
+const mockCreateMyLikedTrack = createMyLikedTrack as jest.MockedFunction<
+  typeof createMyLikedTrack
+>;
 
 describe("useSwipeMix", () => {
   // Helper function to create mock tracks
@@ -125,6 +130,14 @@ describe("useSwipeMix", () => {
       data: mockTracks,
       total: mockTracks.length,
     });
+    mockCreateMyLikedTrack.mockResolvedValue({
+      id: "liked-track-uuid",
+      userId: "user-1",
+      deezerTrackId: "1",
+      title: "Track 1",
+      artist: "Artist 1",
+      type: "track",
+    });
   });
 
   describe("initialization", () => {
@@ -210,7 +223,7 @@ describe("useSwipeMix", () => {
       expect(mockAudioPlayer.stop).toHaveBeenCalled();
     });
 
-    it("should handle swipe right", async () => {
+    it("should handle swipe right and call createMyLikedTrack", async () => {
       const { result } = renderHook(() => useSwipeMix());
 
       await waitFor(() => {
@@ -219,6 +232,29 @@ describe("useSwipeMix", () => {
 
       const firstCard = result.current.cards[0];
       await result.current.handlers.onSwipeRight(firstCard);
+
+      expect(mockCreateMyLikedTrack).toHaveBeenCalledWith({
+        deezerTrackId: firstCard.id,
+        title: firstCard.title,
+        artist: firstCard.artist,
+        type: "track",
+      });
+    });
+
+    it("should not block swipe right on API error", async () => {
+      mockCreateMyLikedTrack.mockRejectedValueOnce(new Error("Network error"));
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.cards).toHaveLength(10);
+      });
+
+      const firstCard = result.current.cards[0];
+      // Should not throw
+      await result.current.handlers.onSwipeRight(firstCard);
+
+      expect(mockCreateMyLikedTrack).toHaveBeenCalled();
     });
 
     it("should stop audio on swipe right if current track", async () => {

--- a/front-mobile/hooks/useSwipeMix.ts
+++ b/front-mobile/hooks/useSwipeMix.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
 import { cacheManager } from "@/services/cache-manager";
+import { createMyLikedTrack } from "@/services/likedTrackService";
 import { MusicCardData } from "@/components/swipe";
 import { deezerTracksToCardData } from "@/utils/deezer-adapter";
 import { useAudioPlayer } from "./useAudioPlayer";
@@ -126,8 +127,15 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
   // Handler pour swipe right (like/save)
   const handleSwipeRight = useCallback(
     async (card: MusicCardData) => {
-      // TODO: Enregistrer le like dans le backend
-      // TODO: Ajouter à la playlist de l'utilisateur
+      // Persister le like en arrière-plan sans bloquer l'UX
+      createMyLikedTrack({
+        deezerTrackId: card.id,
+        title: card.title,
+        artist: card.artist,
+        type: "track",
+      }).catch(() => {
+        // Erreurs réseau et 409 (déjà liké) ignorées silencieusement
+      });
 
       // Arrêter la lecture pour passer à la carte suivante
       // (la nouvelle carte démarrera automatiquement via onCardAppear)

--- a/front-mobile/services/__tests__/likedTrackService.test.ts
+++ b/front-mobile/services/__tests__/likedTrackService.test.ts
@@ -1,0 +1,62 @@
+import {
+  createMyLikedTrack,
+  deleteMyLikedTrack,
+  getMyLikedTracks,
+} from "../likedTrackService";
+
+import { get, post, del } from "../api";
+
+jest.mock("../api", () => ({
+  get: jest.fn(),
+  post: jest.fn(),
+  del: jest.fn(),
+}));
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+const mockPost = post as jest.MockedFunction<typeof post>;
+const mockDel = del as jest.MockedFunction<typeof del>;
+
+const mockLikedTrack = {
+  id: "liked-track-uuid",
+  userId: "user-1",
+  deezerTrackId: "123456",
+  title: "Test Song",
+  artist: "Test Artist",
+  type: "track" as const,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("createMyLikedTrack", () => {
+  it("should create and return a liked track", async () => {
+    mockPost.mockResolvedValueOnce({ likedTrack: mockLikedTrack });
+    const request = {
+      deezerTrackId: "123456",
+      title: "Test Song",
+      artist: "Test Artist",
+      type: "track" as const,
+    };
+    const result = await createMyLikedTrack(request);
+    expect(result).toEqual(mockLikedTrack);
+    expect(mockPost).toHaveBeenCalledWith("/api/liked-tracks/me", request);
+  });
+});
+
+describe("deleteMyLikedTrack", () => {
+  it("should call delete with correct endpoint", async () => {
+    mockDel.mockResolvedValueOnce(undefined);
+    await deleteMyLikedTrack("123456");
+    expect(mockDel).toHaveBeenCalledWith("/api/liked-tracks/me/123456");
+  });
+});
+
+describe("getMyLikedTracks", () => {
+  it("should return list of liked tracks", async () => {
+    mockGet.mockResolvedValueOnce({ likedTracks: [mockLikedTrack] });
+    const result = await getMyLikedTracks();
+    expect(result).toEqual([mockLikedTrack]);
+    expect(mockGet).toHaveBeenCalledWith("/api/liked-tracks/me");
+  });
+});

--- a/front-mobile/services/likedTrackService.ts
+++ b/front-mobile/services/likedTrackService.ts
@@ -1,0 +1,28 @@
+import { del, get, post } from "./api";
+import {
+  CreateLikedTrackRequest,
+  CreateLikedTrackResponse,
+  GetMyLikedTracksResponse,
+  LikedTrack,
+} from "@/types/likedTrack";
+
+export const createMyLikedTrack = async (
+  request: CreateLikedTrackRequest,
+): Promise<LikedTrack> => {
+  const data = await post<CreateLikedTrackResponse>(
+    "/api/liked-tracks/me",
+    request,
+  );
+  return data.likedTrack;
+};
+
+export const deleteMyLikedTrack = async (
+  deezerTrackId: string,
+): Promise<void> => {
+  await del(`/api/liked-tracks/me/${deezerTrackId}`);
+};
+
+export const getMyLikedTracks = async (): Promise<LikedTrack[]> => {
+  const data = await get<GetMyLikedTracksResponse>("/api/liked-tracks/me");
+  return data.likedTracks;
+};

--- a/front-mobile/types/likedTrack.ts
+++ b/front-mobile/types/likedTrack.ts
@@ -1,0 +1,23 @@
+export interface LikedTrack {
+  id: string;
+  userId: string;
+  deezerTrackId: string;
+  title: string;
+  artist: string;
+  type: "track";
+}
+
+export interface CreateLikedTrackRequest {
+  deezerTrackId: string;
+  title: string;
+  artist: string;
+  type: "track";
+}
+
+export interface CreateLikedTrackResponse {
+  likedTrack: LikedTrack;
+}
+
+export interface GetMyLikedTracksResponse {
+  likedTracks: LikedTrack[];
+}


### PR DESCRIPTION
## Description

Intégration de l'API liked-tracks au swipe right dans SwipeMix. Quand l'utilisateur swipe une carte vers la droite, le like est persisté en base via `POST /api/liked-tracks/me`. Les erreurs réseau sont gérées silencieusement pour ne pas bloquer l'UX. Côté backend, le service utilise désormais `firstOrCreate` pour empêcher les doublons en base sans lever d'erreur.

## Parcours utilisateur

1. Lancer l'app et se connecter avec un compte authentifié
2. Aller sur l'écran SwipeMix (tab swipe)
3. Swiper une carte vers la droite (like)
4. Vérifier en base de données qu'un enregistrement `liked_tracks` a été créé avec le bon `deezerTrackId`, `title`, `artist` et `type: "track"`
5. Si la même carte réapparaît, la swiper à nouveau vers la droite — vérifier qu'il n'y a toujours qu'un seul enregistrement en DB (pas de doublon)
6. Couper le réseau (mode avion) puis swiper right — le swipe doit fonctionner normalement sans blocage ni erreur affichée
7. Tester sur iOS et Android