### PR TITLE
MIX-244 feat: add previous card button with slide-in animation in swipemix

### DIFF
--- a/front-mobile/components/swipe/CardStack.tsx
+++ b/front-mobile/components/swipe/CardStack.tsx
@@ -8,7 +8,7 @@ import {
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import * as Haptics from "expo-haptics";
-import SwipeCard from "./SwipeCard";
+import SwipeCard, { SwipeDirection } from "./SwipeCard";
 import { MusicCardData } from "./MusicCard";
 import SwipeButton from "@/components/swipe/SwipeButton";
 import { Colors } from "@/constants/Colors";
@@ -40,6 +40,7 @@ export default function CardStack({
 }: CardStackProps) {
   const cards = initialCards;
   const [currentIndex, setCurrentIndex] = useState(0);
+  const swipeDirectionsRef = useRef<Record<string, SwipeDirection>>({});
   const lastPlayedCardIdRef = useRef<string | null>(null);
   const hasLoadedMoreRef = useRef(false);
   const onLoadMoreRef = useRef(onLoadMore);
@@ -90,6 +91,7 @@ export default function CardStack({
 
   const handleSwipeLeft = (card: MusicCardData) => {
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    swipeDirectionsRef.current[card.id] = "left";
     onSwipeLeft?.(card);
 
     setCurrentIndex((prev: number) => {
@@ -103,6 +105,7 @@ export default function CardStack({
 
   const handleSwipeRight = (card: MusicCardData) => {
     Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+    swipeDirectionsRef.current[card.id] = "right";
     onSwipeRight?.(card);
 
     setCurrentIndex((prev: number) => {
@@ -118,6 +121,12 @@ export default function CardStack({
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     lastPlayedCardIdRef.current = null; // Reset pour permettre de rejouer la première carte
     setCurrentIndex(0);
+  };
+
+  const handlePrevious = () => {
+    if (currentIndex === 0) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setCurrentIndex((prev: number) => Math.max(0, prev - 1));
   };
 
   const visibleCards = cards.slice(currentIndex, currentIndex + 3);
@@ -159,6 +168,7 @@ export default function CardStack({
               index={actualIndex}
               isPlaying={isTop && currentTrackId === card.id && isPlaying}
               onTogglePlay={onTogglePlay}
+              entryDirection={swipeDirectionsRef.current[card.id]}
             />
           );
         })}
@@ -176,10 +186,9 @@ export default function CardStack({
         />
         <SwipeButton
           type={"replay"}
-          onPress={() => {
-            // TODO: Implement replay functionality (e.g., show the previous card again)
-          }}
+          onPress={handlePrevious}
           size={"small"}
+          disabled={currentIndex === 0}
         />
         <SwipeButton
           type={"like"}

--- a/front-mobile/components/swipe/CardStack.tsx
+++ b/front-mobile/components/swipe/CardStack.tsx
@@ -120,6 +120,7 @@ export default function CardStack({
   const handleReload = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     lastPlayedCardIdRef.current = null; // Reset pour permettre de rejouer la première carte
+    swipeDirectionsRef.current = {};
     setCurrentIndex(0);
   };
 
@@ -185,7 +186,7 @@ export default function CardStack({
           }}
         />
         <SwipeButton
-          type={"replay"}
+          type={"previous"}
           onPress={handlePrevious}
           size={"small"}
           disabled={currentIndex === 0}

--- a/front-mobile/components/swipe/SwipeButton.tsx
+++ b/front-mobile/components/swipe/SwipeButton.tsx
@@ -9,7 +9,7 @@ import React from "react";
 import { Pressable, StyleSheet, View } from "react-native";
 
 type SwipeButtonProps = {
-  type: "like" | "dislike" | "replay";
+  type: "like" | "dislike" | "previous";
   size?: "medium" | "small";
   onPress?: () => void;
   disabled?: boolean;
@@ -29,13 +29,13 @@ const SIZES = {
 const GRADIENTS: Record<SwipeButtonProps["type"], [string, string]> = {
   like: ["#40D400", "#216E00"],
   dislike: ["#D40000", "#6E0000"],
-  replay: ["#0D7377", "#18D6DD"],
+  previous: ["#0D7377", "#18D6DD"],
 };
 
 const BORDER = {
   like: "#40D400",
   dislike: "#D40000",
-  replay: "#18D6DD",
+  previous: "#18D6DD",
 };
 
 const ICONS = {
@@ -43,7 +43,7 @@ const ICONS = {
     <FontAwesome name="heart" size={size} />
   ),
   dislike: ({ size }: { size: number }) => <Entypo name="cross" size={size} />,
-  replay: ({ size }: { size: number }) => (
+  previous: ({ size }: { size: number }) => (
     <MaterialCommunityIcons name="skip-previous" size={size} />
   ),
 };

--- a/front-mobile/components/swipe/SwipeButton.tsx
+++ b/front-mobile/components/swipe/SwipeButton.tsx
@@ -12,6 +12,7 @@ type SwipeButtonProps = {
   type: "like" | "dislike" | "replay";
   size?: "medium" | "small";
   onPress?: () => void;
+  disabled?: boolean;
 };
 
 const SIZES = {
@@ -43,7 +44,7 @@ const ICONS = {
   ),
   dislike: ({ size }: { size: number }) => <Entypo name="cross" size={size} />,
   replay: ({ size }: { size: number }) => (
-    <MaterialCommunityIcons name="replay" size={size} />
+    <MaterialCommunityIcons name="skip-previous" size={size} />
   ),
 };
 
@@ -51,6 +52,7 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
   type,
   size = "medium",
   onPress,
+  disabled = false,
 }) => {
   const dimensions = SIZES[size];
   const gradientColors = GRADIENTS[type];
@@ -60,6 +62,7 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
   return (
     <Pressable
       onPress={onPress}
+      disabled={disabled}
       style={({ pressed }) => [
         styles.container,
         {
@@ -70,6 +73,7 @@ const SwipeButton: React.FC<SwipeButtonProps> = ({
           borderWidth: 2,
         },
         pressed && styles.pressed,
+        disabled && styles.disabled,
       ]}
     >
       <MaskedView
@@ -102,6 +106,9 @@ const styles = StyleSheet.create({
   },
   pressed: {
     opacity: 0.8,
+  },
+  disabled: {
+    opacity: 0.5,
   },
   iconMask: {
     flex: 1,

--- a/front-mobile/components/swipe/SwipeCard.tsx
+++ b/front-mobile/components/swipe/SwipeCard.tsx
@@ -50,18 +50,19 @@ export default function SwipeCard({
   onTogglePlay,
   entryDirection,
 }: SwipeCardProps) {
-  const initialTranslateX =
+  const initialEntryOffset =
     entryDirection === "right"
       ? SCREEN_WIDTH * 1.5
       : entryDirection === "left"
         ? -SCREEN_WIDTH * 1.5
         : 0;
-  const translateX = useSharedValue(initialTranslateX);
+  const translateX = useSharedValue(0);
   const translateY = useSharedValue(0);
+  const entryOffset = useSharedValue(initialEntryOffset);
 
   useEffect(() => {
-    if (initialTranslateX !== 0) {
-      translateX.value = withSpring(0, SWIPE_CONFIG.springConfig);
+    if (initialEntryOffset !== 0) {
+      entryOffset.value = withSpring(0, SWIPE_CONFIG.springConfig);
     }
     // Entry animation runs once on mount; subsequent prop changes are ignored intentionally.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -138,7 +139,7 @@ export default function SwipeCard({
 
     return {
       transform: [
-        { translateX: translateX.value },
+        { translateX: translateX.value + entryOffset.value },
         { translateY: translateY.value },
         { rotate: `${rotation}deg` },
       ],

--- a/front-mobile/components/swipe/SwipeCard.tsx
+++ b/front-mobile/components/swipe/SwipeCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { StyleSheet, Dimensions } from "react-native";
 import Animated, {
   useSharedValue,
@@ -26,6 +27,8 @@ const SWIPE_CONFIG = {
   snapBackDuration: 250,
 };
 
+export type SwipeDirection = "left" | "right";
+
 interface SwipeCardProps {
   data: MusicCardData;
   onSwipeLeft?: (data: MusicCardData) => void;
@@ -34,6 +37,7 @@ interface SwipeCardProps {
   index?: number;
   isPlaying?: boolean;
   onTogglePlay?: (data: MusicCardData) => void;
+  entryDirection?: SwipeDirection;
 }
 
 export default function SwipeCard({
@@ -44,9 +48,24 @@ export default function SwipeCard({
   index = 0,
   isPlaying = false,
   onTogglePlay,
+  entryDirection,
 }: SwipeCardProps) {
-  const translateX = useSharedValue(0);
+  const initialTranslateX =
+    entryDirection === "right"
+      ? SCREEN_WIDTH * 1.5
+      : entryDirection === "left"
+        ? -SCREEN_WIDTH * 1.5
+        : 0;
+  const translateX = useSharedValue(initialTranslateX);
   const translateY = useSharedValue(0);
+
+  useEffect(() => {
+    if (initialTranslateX !== 0) {
+      translateX.value = withSpring(0, SWIPE_CONFIG.springConfig);
+    }
+    // Entry animation runs once on mount; subsequent prop changes are ignored intentionally.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const startX = useSharedValue(0);
   const startY = useSharedValue(0);
   const isSwipingHorizontal = useSharedValue(false);

--- a/front-mobile/hooks/__tests__/useSwipeMix.test.ts
+++ b/front-mobile/hooks/__tests__/useSwipeMix.test.ts
@@ -3,7 +3,10 @@ import { useSwipeMix } from "../useSwipeMix";
 import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
 import { useAudioPlayer } from "../useAudioPlayer";
 import { deezerTracksToCardData } from "@/utils/deezer-adapter";
-import { createMyLikedTrack } from "@/services/likedTrackService";
+import {
+  createMyLikedTrack,
+  deleteMyLikedTrack,
+} from "@/services/likedTrackService";
 import { MusicCardData } from "@/components/swipe";
 
 // Mock des dépendances
@@ -20,6 +23,9 @@ const mockDeezerTracksToCardData =
   deezerTracksToCardData as jest.MockedFunction<typeof deezerTracksToCardData>;
 const mockCreateMyLikedTrack = createMyLikedTrack as jest.MockedFunction<
   typeof createMyLikedTrack
+>;
+const mockDeleteMyLikedTrack = deleteMyLikedTrack as jest.MockedFunction<
+  typeof deleteMyLikedTrack
 >;
 
 describe("useSwipeMix", () => {
@@ -138,6 +144,7 @@ describe("useSwipeMix", () => {
       artist: "Artist 1",
       type: "track",
     });
+    mockDeleteMyLikedTrack.mockResolvedValue(undefined);
   });
 
   describe("initialization", () => {
@@ -270,6 +277,65 @@ describe("useSwipeMix", () => {
       await result.current.handlers.onSwipeRight(firstCard);
 
       expect(mockAudioPlayer.stop).toHaveBeenCalled();
+    });
+
+    it("should not call deleteMyLikedTrack on swipe left if track was never liked", async () => {
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.cards).toHaveLength(10);
+      });
+
+      const firstCard = result.current.cards[0];
+      result.current.handlers.onSwipeLeft(firstCard);
+
+      expect(mockDeleteMyLikedTrack).not.toHaveBeenCalled();
+    });
+
+    it("should call deleteMyLikedTrack on swipe left if track was previously liked", async () => {
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.cards).toHaveLength(10);
+      });
+
+      const firstCard = result.current.cards[0];
+      await result.current.handlers.onSwipeRight(firstCard);
+      result.current.handlers.onSwipeLeft(firstCard);
+
+      expect(mockDeleteMyLikedTrack).toHaveBeenCalledWith(firstCard.id);
+    });
+
+    it("should only delete once even on multiple consecutive swipe lefts", async () => {
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.cards).toHaveLength(10);
+      });
+
+      const firstCard = result.current.cards[0];
+      await result.current.handlers.onSwipeRight(firstCard);
+      result.current.handlers.onSwipeLeft(firstCard);
+      result.current.handlers.onSwipeLeft(firstCard);
+
+      expect(mockDeleteMyLikedTrack).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not block swipe left on delete API error", async () => {
+      mockDeleteMyLikedTrack.mockRejectedValueOnce(new Error("Network error"));
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.cards).toHaveLength(10);
+      });
+
+      const firstCard = result.current.cards[0];
+      await result.current.handlers.onSwipeRight(firstCard);
+      // Should not throw
+      result.current.handlers.onSwipeLeft(firstCard);
+
+      expect(mockDeleteMyLikedTrack).toHaveBeenCalled();
     });
   });
 

--- a/front-mobile/hooks/useSwipeMix.ts
+++ b/front-mobile/hooks/useSwipeMix.ts
@@ -1,7 +1,10 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
 import { cacheManager } from "@/services/cache-manager";
-import { createMyLikedTrack } from "@/services/likedTrackService";
+import {
+  createMyLikedTrack,
+  deleteMyLikedTrack,
+} from "@/services/likedTrackService";
 import { MusicCardData } from "@/components/swipe";
 import { deezerTracksToCardData } from "@/utils/deezer-adapter";
 import { useAudioPlayer } from "./useAudioPlayer";
@@ -23,6 +26,8 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
   const currentPageIndexRef = useRef(0);
   // Verrou synchrone pour éviter les appels concurrents à loadTracks
   const isLoadingRef = useRef(false);
+  // Tracks likés persistés en DB — utilisé pour rollback sur un dislike qui suit un like
+  const likedTrackIdsRef = useRef<Set<string>>(new Set());
 
   const handleRetry = useCallback(
     async (track: DeezerTrack): Promise<DeezerTrack | null> => {
@@ -113,8 +118,13 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
   // Handler pour swipe left (skip/dislike)
   const handleSwipeLeft = useCallback(
     (card: MusicCardData) => {
-      // TODO: Enregistrer le dislike dans le backend
-      // TODO: Utiliser pour améliorer les recommandations
+      // Rollback d'un like précédent si l'utilisateur change d'avis via le bouton précédent
+      if (likedTrackIdsRef.current.has(card.id)) {
+        likedTrackIdsRef.current.delete(card.id);
+        deleteMyLikedTrack(card.id).catch(() => {
+          // Erreurs réseau ignorées silencieusement
+        });
+      }
 
       // Arrêter la lecture si c'est le morceau actuel
       if (audioPlayer.currentTrack?.id.toString() === card.id) {
@@ -128,6 +138,7 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
   const handleSwipeRight = useCallback(
     async (card: MusicCardData) => {
       // Persister le like en arrière-plan sans bloquer l'UX
+      likedTrackIdsRef.current.add(card.id);
       createMyLikedTrack({
         deezerTrackId: card.id,
         title: card.title,
@@ -135,6 +146,7 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
         type: "track",
       }).catch(() => {
         // Erreurs réseau et 409 (déjà liké) ignorées silencieusement
+        likedTrackIdsRef.current.delete(card.id);
       });
 
       // Arrêter la lecture pour passer à la carte suivante


### PR DESCRIPTION
## Description

Ajout d'un bouton "précédent" dans le SwipeMix permettant de revenir à la carte qui vient d'être swipée. Le bouton (icône `skip-previous`) est désactivé sur la première carte, et la carte qui revient s'anime depuis le côté correspondant à son swipe précédent (like → depuis la droite, dislike → depuis la gauche) via un ressort Reanimated cohérent avec les animations existantes.

## Parcours utilisateur

1. Ouvrir l'onglet **SwipeMix**
2. Vérifier que le bouton central (entre dislike ❌ et like ❤️) affiche l'icône **skip-previous** (|◀)
3. Sur la première carte, vérifier que le bouton précédent est **visuellement désactivé** (opacité réduite) et qu'un tap ne fait rien
4. **Swipe à droite** (like) la carte 1 → elle part à droite, la carte 2 apparaît et la musique démarre
5. Appuyer sur **précédent** → la carte 1 **revient en glissant depuis la droite**, son extrait audio se relance automatiquement
6. **Swipe à gauche** (dislike) la carte 1 → elle part à gauche, la carte 2 apparaît
7. Appuyer sur **précédent** → la carte 1 **revient en glissant depuis la gauche**
8. Enchaîner 3 swipes variés (ex. right, left, right) puis appuyer 3 fois de suite sur **précédent** → chaque carte revient du bon côté selon son swipe précédent, avec lecture audio à chaque retour
9. Re-swipe une carte qui vient de revenir dans l'autre sens → au prochain précédent, elle revient bien du nouveau côté
10. Remonter jusqu'à la première carte → le bouton précédent redevient désactivé
11. Vérifier le feedback haptique léger au tap sur le bouton précédent
12. Pendant l'animation d'entrée, intercepter le mouvement avec un swipe → le geste reprend correctement
13. Tester le parcours complet sur **iOS et Android**