### PR TITLE
MIX-260 refactor: extract useGenres hook for shared game genre selection

### DIFF
--- a/front-mobile/app/(tabs)/games/blurchette/game.tsx
+++ b/front-mobile/app/(tabs)/games/blurchette/game.tsx
@@ -41,6 +41,7 @@ import {
 import { BlurchetteGameData, GameSession } from "@/types/gameSession";
 import { MaterialIcons } from "@expo/vector-icons";
 import { useErrorFeedback } from "@/hooks/useErrorFeedback";
+import { useGenres } from "@/hooks/useGenres";
 import { fuzzyMatch } from "@/utils/stringUtils";
 
 type GameState = "genreSelection" | "playing" | "result";
@@ -70,8 +71,7 @@ interface BlurchetteSaveState {
 export default function BlurchetteGameScreen() {
   const [showRules, setShowRules] = useState(false);
   const [gameState, setGameState] = useState<GameState>("genreSelection");
-  const [genres, setGenres] = useState<DeezerGenre[]>([]);
-  const [loadingGenres, setLoadingGenres] = useState(true);
+  const { genres, loadingGenres } = useGenres();
   const [loadingTrack, setLoadingTrack] = useState(false);
 
   const [currentTrack, setCurrentTrack] = useState<GameTrack | null>(null);
@@ -147,22 +147,6 @@ export default function BlurchetteGameScreen() {
   const { shakeAnimation, borderOpacity, errorMessage, triggerError } =
     useErrorFeedback(errorAnimationsEnabled);
 
-  const loadGenres = useCallback(async () => {
-    try {
-      const response = await deezerAPI.getGenres();
-      const filteredGenres = response.data.filter((g) => g.id !== 0);
-      setGenres(filteredGenres);
-    } catch (error) {
-      console.error("Failed to load genres:", error);
-      show({
-        type: "error",
-        message: "Impossible de charger les genres musicaux",
-      });
-    } finally {
-      setLoadingGenres(false);
-    }
-  }, [show]);
-
   const loadSavedState = useCallback(async () => {
     if (!gameId) return;
     setLoadingTrack(true);
@@ -187,8 +171,6 @@ export default function BlurchetteGameScreen() {
   }, [gameId, show]);
 
   useEffect(() => {
-    loadGenres();
-
     if (gameId) {
       if (resume === "true") {
         void loadSavedState();
@@ -204,7 +186,7 @@ export default function BlurchetteGameScreen() {
           .catch(() => {});
       }
     }
-  }, [gameId, resume, loadGenres, loadSavedState]);
+  }, [gameId, resume, loadSavedState]);
 
   const autoSave = useCallback(async () => {
     if (!gameId || gameState === "result") return;

--- a/front-mobile/app/(tabs)/games/tracklist/game.tsx
+++ b/front-mobile/app/(tabs)/games/tracklist/game.tsx
@@ -4,12 +4,10 @@ import {
   Alert,
   FlatList,
   Image,
-  Modal,
   KeyboardAvoidingView,
   Platform,
   ScrollView,
   StyleSheet,
-  Text,
   TextInput,
   TouchableOpacity,
   View,
@@ -77,7 +75,6 @@ const GAME_DURATION = 300;
 const ALBUM_CHOICES = 6;
 
 export default function TracklistGameScreen() {
-  const [showRules, setShowRules] = useState(false);
   const [gameState, setGameState] = useState<GameState>("artistSearch");
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<DeezerArtist[]>([]);
@@ -666,7 +663,6 @@ export default function TracklistGameScreen() {
             )}
           </View>
         </View>
-        {rulesModal}
       </GameLayout>
     );
   }
@@ -734,7 +730,6 @@ export default function TracklistGameScreen() {
             )}
           </View>
         </View>
-        {rulesModal}
       </GameLayout>
     );
   }
@@ -893,7 +888,6 @@ export default function TracklistGameScreen() {
               </View>
             </View>
           </KeyboardAvoidingView>
-          {rulesModal}
         </GameLayout>
       </GameErrorFeedback>
     );
@@ -990,76 +984,6 @@ export default function TracklistGameScreen() {
 
   return null;
 }
-
-const rulesStyles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: "rgba(0,0,0,0.75)",
-    justifyContent: "flex-end",
-  },
-  container: {
-    backgroundColor: "#121212",
-    borderTopLeftRadius: 24,
-    borderTopRightRadius: 24,
-    maxHeight: "80%",
-    borderTopWidth: 1,
-    borderColor: "#14FFEC33",
-  },
-  header: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    padding: 20,
-    borderBottomWidth: 1,
-    borderBottomColor: "#2A2A2A",
-  },
-  title: {
-    color: "#FFFFFF",
-    fontSize: 18,
-    fontWeight: "700",
-  },
-  closeBtn: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
-    backgroundColor: "#2A2A2A",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  closeText: {
-    color: "#FFFFFF",
-    fontSize: 14,
-  },
-  content: {
-    padding: 20,
-    gap: 14,
-  },
-  rule: {
-    flexDirection: "row",
-    gap: 14,
-    backgroundColor: "rgba(255,255,255,0.04)",
-    borderRadius: 12,
-    padding: 14,
-    borderLeftWidth: 3,
-    borderLeftColor: "#14FFEC",
-  },
-  ruleIcon: {
-    fontSize: 22,
-  },
-  ruleText: {
-    flex: 1,
-    gap: 4,
-  },
-  ruleBold: {
-    color: "#FFFFFF",
-    fontWeight: "700",
-    fontSize: 14,
-  },
-  ruleDesc: {
-    color: "#999",
-    fontSize: 13,
-  },
-});
 
 const styles = StyleSheet.create({
   container: {

--- a/front-mobile/components/Header.tsx
+++ b/front-mobile/components/Header.tsx
@@ -115,20 +115,20 @@ export default function Header({
               accessibilityLabel="Ouvrir les paramètres"
             >
               <Ionicons name="settings-sharp" size={20} color="#FFFFFF" />
-              </TouchableOpacity>
-            )}
-            {!hasSettings && onInfo && (
-              <TouchableOpacity
-                onPress={onInfo}
-                activeOpacity={0.8}
-                style={styles.iconButton}
-                accessibilityLabel="Voir les règles"
-              >
-                <Ionicons
-                  name="information-circle-outline"
-                  size={22}
-                  color="#FFFFFF"
-                />
+            </TouchableOpacity>
+          )}
+          {!hasSettings && onInfo && (
+            <TouchableOpacity
+              onPress={onInfo}
+              activeOpacity={0.8}
+              style={styles.iconButton}
+              accessibilityLabel="Voir les règles"
+            >
+              <Ionicons
+                name="information-circle-outline"
+                size={22}
+                color="#FFFFFF"
+              />
             </TouchableOpacity>
           )}
         </View>

--- a/front-mobile/components/games/RulesModal.tsx
+++ b/front-mobile/components/games/RulesModal.tsx
@@ -38,10 +38,15 @@ export default function RulesModal({
   const overlayOpacity = useRef(new Animated.Value(0)).current;
   const translateY = useRef(new Animated.Value(SCREEN_HEIGHT)).current;
   const animationRef = useRef<Animated.CompositeAnimation | null>(null);
+  const visibleRef = useRef(visible);
+  const hasBeenVisibleRef = useRef(false);
 
   useEffect(() => {
-    if (visible && !mounted) {
-      animationRef.current?.stop();
+    visibleRef.current = visible;
+    animationRef.current?.stop();
+
+    if (visible) {
+      hasBeenVisibleRef.current = true;
       overlayOpacity.setValue(0);
       translateY.setValue(SCREEN_HEIGHT);
       setMounted(true);
@@ -60,8 +65,7 @@ export default function RulesModal({
         }),
       ]);
       animationRef.current.start();
-    } else if (!visible && mounted) {
-      animationRef.current?.stop();
+    } else if (hasBeenVisibleRef.current) {
       animationRef.current = Animated.sequence([
         Animated.timing(translateY, {
           toValue: SCREEN_HEIGHT,
@@ -77,10 +81,10 @@ export default function RulesModal({
         }),
       ]);
       animationRef.current.start(({ finished }) => {
-        if (finished) setMounted(false);
+        if (finished && !visibleRef.current) setMounted(false);
       });
     }
-  }, [visible, mounted, overlayOpacity, translateY]);
+  }, [visible, overlayOpacity, translateY]);
 
   useEffect(() => {
     return () => {

--- a/front-mobile/components/games/RulesModal.tsx
+++ b/front-mobile/components/games/RulesModal.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
-  Modal,
+  Animated,
+  BackHandler,
+  Dimensions,
+  Easing,
   ScrollView,
   StyleSheet,
   TouchableOpacity,
@@ -22,6 +25,8 @@ interface RulesModalProps {
   steps: RulesStep[];
 }
 
+const SCREEN_HEIGHT = Dimensions.get("window").height;
+
 export default function RulesModal({
   visible,
   onClose,
@@ -29,74 +34,142 @@ export default function RulesModal({
   objective,
   steps,
 }: RulesModalProps) {
+  const [mounted, setMounted] = useState(false);
+  const overlayOpacity = useRef(new Animated.Value(0)).current;
+  const translateY = useRef(new Animated.Value(SCREEN_HEIGHT)).current;
+  const animationRef = useRef<Animated.CompositeAnimation | null>(null);
+
+  useEffect(() => {
+    if (visible && !mounted) {
+      animationRef.current?.stop();
+      overlayOpacity.setValue(0);
+      translateY.setValue(SCREEN_HEIGHT);
+      setMounted(true);
+      animationRef.current = Animated.sequence([
+        Animated.timing(overlayOpacity, {
+          toValue: 1,
+          duration: 220,
+          easing: Easing.out(Easing.quad),
+          useNativeDriver: true,
+        }),
+        Animated.timing(translateY, {
+          toValue: 0,
+          duration: 480,
+          easing: Easing.out(Easing.cubic),
+          useNativeDriver: true,
+        }),
+      ]);
+      animationRef.current.start();
+    } else if (!visible && mounted) {
+      animationRef.current?.stop();
+      animationRef.current = Animated.sequence([
+        Animated.timing(translateY, {
+          toValue: SCREEN_HEIGHT,
+          duration: 320,
+          easing: Easing.in(Easing.cubic),
+          useNativeDriver: true,
+        }),
+        Animated.timing(overlayOpacity, {
+          toValue: 0,
+          duration: 180,
+          easing: Easing.in(Easing.quad),
+          useNativeDriver: true,
+        }),
+      ]);
+      animationRef.current.start(({ finished }) => {
+        if (finished) setMounted(false);
+      });
+    }
+  }, [visible, mounted, overlayOpacity, translateY]);
+
+  useEffect(() => {
+    return () => {
+      animationRef.current?.stop();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+      onClose();
+      return true;
+    });
+    return () => sub.remove();
+  }, [mounted, onClose]);
+
+  if (!mounted) return null;
+
   return (
-    <Modal
-      animationType="slide"
-      transparent={true}
-      visible={visible}
-      onRequestClose={onClose}
+    <Animated.View
+      style={[styles.overlay, { opacity: overlayOpacity }]}
+      pointerEvents="box-none"
     >
-      <View style={styles.overlay}>
-        <View style={styles.modalCard}>
-          <View style={styles.header}>
-            <ThemedText type="subtitle" style={styles.title}>
-              {title}
-            </ThemedText>
-            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-              <MaterialIcons name="close" size={24} color="#999" />
-            </TouchableOpacity>
+      <TouchableOpacity
+        style={StyleSheet.absoluteFill}
+        activeOpacity={1}
+        onPress={onClose}
+      />
+      <Animated.View
+        style={[styles.modalCard, { transform: [{ translateY }] }]}
+      >
+        <View style={styles.header}>
+          <ThemedText type="subtitle" style={styles.title}>
+            {title}
+          </ThemedText>
+          <TouchableOpacity onPress={onClose} style={styles.closeButton}>
+            <MaterialIcons name="close" size={24} color="#999" />
+          </TouchableOpacity>
+        </View>
+
+        <ScrollView
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.content}
+        >
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <MaterialIcons
+                name="info"
+                size={20}
+                color={Colors.primary.survol}
+              />
+              <ThemedText style={styles.sectionTitle}>Objectif</ThemedText>
+            </View>
+            <ThemedText style={styles.text}>{objective}</ThemedText>
           </View>
 
-          <ScrollView
-            showsVerticalScrollIndicator={false}
-            contentContainerStyle={styles.content}
-          >
-            <View style={styles.section}>
-              <View style={styles.sectionHeader}>
-                <MaterialIcons
-                  name="info"
-                  size={20}
-                  color={Colors.primary.survol}
-                />
-                <ThemedText style={styles.sectionTitle}>Objectif</ThemedText>
-              </View>
-              <ThemedText style={styles.text}>{objective}</ThemedText>
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <MaterialIcons
+                name="sports-esports"
+                size={20}
+                color={Colors.primary.survol}
+              />
+              <ThemedText style={styles.sectionTitle}>Comment jouer</ThemedText>
             </View>
-
-            <View style={styles.section}>
-              <View style={styles.sectionHeader}>
-                <MaterialIcons
-                  name="sports-esports"
-                  size={20}
-                  color={Colors.primary.survol}
-                />
-                <ThemedText style={styles.sectionTitle}>
-                  Comment jouer
-                </ThemedText>
-              </View>
-              <View style={styles.list}>
-                {steps.map((step, index) => (
-                  <View key={index} style={styles.listItem}>
-                    <ThemedText style={styles.listNumber}>
-                      {index + 1}.
-                    </ThemedText>
-                    <ThemedText style={styles.listText}>{step.text}</ThemedText>
-                  </View>
-                ))}
-              </View>
+            <View style={styles.list}>
+              {steps.map((step, index) => (
+                <View key={index} style={styles.listItem}>
+                  <ThemedText style={styles.listNumber}>
+                    {index + 1}.
+                  </ThemedText>
+                  <ThemedText style={styles.listText}>{step.text}</ThemedText>
+                </View>
+              ))}
             </View>
-          </ScrollView>
-        </View>
-      </View>
-    </Modal>
+          </View>
+        </ScrollView>
+      </Animated.View>
+    </Animated.View>
   );
 }
 
 const styles = StyleSheet.create({
   overlay: {
-    flex: 1,
+    ...StyleSheet.absoluteFillObject,
     backgroundColor: "rgba(0,0,0,0.8)",
     justifyContent: "flex-end",
+    zIndex: 1000,
+    elevation: 1000,
   },
   modalCard: {
     backgroundColor: "#121212",
@@ -104,8 +177,6 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 24,
     padding: 24,
     maxHeight: "80%",
-    borderTopWidth: 0.2,
-    borderColor: Colors.primary.survol,
   },
   header: {
     flexDirection: "row",

--- a/front-mobile/components/games/RulesModal.tsx
+++ b/front-mobile/components/games/RulesModal.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useRef, useState } from "react";
 import {
   Animated,
   BackHandler,
-  Dimensions,
   Easing,
   ScrollView,
   StyleSheet,
   TouchableOpacity,
+  useWindowDimensions,
   View,
 } from "react-native";
 import { MaterialIcons } from "@expo/vector-icons";
@@ -25,8 +25,6 @@ interface RulesModalProps {
   steps: RulesStep[];
 }
 
-const SCREEN_HEIGHT = Dimensions.get("window").height;
-
 export default function RulesModal({
   visible,
   onClose,
@@ -34,9 +32,10 @@ export default function RulesModal({
   objective,
   steps,
 }: RulesModalProps) {
+  const { height: screenHeight } = useWindowDimensions();
   const [mounted, setMounted] = useState(false);
   const overlayOpacity = useRef(new Animated.Value(0)).current;
-  const translateY = useRef(new Animated.Value(SCREEN_HEIGHT)).current;
+  const translateY = useRef(new Animated.Value(screenHeight)).current;
   const animationRef = useRef<Animated.CompositeAnimation | null>(null);
   const visibleRef = useRef(visible);
   const hasBeenVisibleRef = useRef(false);
@@ -48,7 +47,7 @@ export default function RulesModal({
     if (visible) {
       hasBeenVisibleRef.current = true;
       overlayOpacity.setValue(0);
-      translateY.setValue(SCREEN_HEIGHT);
+      translateY.setValue(screenHeight);
       setMounted(true);
       animationRef.current = Animated.sequence([
         Animated.timing(overlayOpacity, {
@@ -68,7 +67,7 @@ export default function RulesModal({
     } else if (hasBeenVisibleRef.current) {
       animationRef.current = Animated.sequence([
         Animated.timing(translateY, {
-          toValue: SCREEN_HEIGHT,
+          toValue: screenHeight,
           duration: 320,
           easing: Easing.in(Easing.cubic),
           useNativeDriver: true,
@@ -84,7 +83,7 @@ export default function RulesModal({
         if (finished && !visibleRef.current) setMounted(false);
       });
     }
-  }, [visible, overlayOpacity, translateY]);
+  }, [visible, overlayOpacity, translateY, screenHeight]);
 
   useEffect(() => {
     return () => {

--- a/front-mobile/hooks/__tests__/useGenres.test.ts
+++ b/front-mobile/hooks/__tests__/useGenres.test.ts
@@ -86,4 +86,32 @@ describe("useGenres", () => {
     expect(result.current.genres).toHaveLength(2);
     expect(mockDeezerAPI.getGenres).toHaveBeenCalledTimes(2);
   });
+
+  it("flips loadingGenres back to true at the start of a reload", async () => {
+    mockDeezerAPI.getGenres.mockResolvedValueOnce({
+      data: [buildGenre(132, "Pop")],
+    });
+
+    const { result } = renderHook(() => useGenres());
+    await waitFor(() => expect(result.current.loadingGenres).toBe(false));
+
+    let resolveReload: (value: { data: DeezerGenre[] }) => void = () => {};
+    mockDeezerAPI.getGenres.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveReload = resolve;
+      }),
+    );
+
+    act(() => {
+      void result.current.reloadGenres();
+    });
+
+    await waitFor(() => expect(result.current.loadingGenres).toBe(true));
+
+    await act(async () => {
+      resolveReload({ data: [buildGenre(152, "Rock")] });
+    });
+
+    await waitFor(() => expect(result.current.loadingGenres).toBe(false));
+  });
 });

--- a/front-mobile/hooks/__tests__/useGenres.test.ts
+++ b/front-mobile/hooks/__tests__/useGenres.test.ts
@@ -1,0 +1,89 @@
+import { renderHook, waitFor, act } from "@testing-library/react-native";
+import { useGenres } from "../useGenres";
+import { deezerAPI, DeezerGenre } from "@/services/deezer-api";
+import { useToast } from "@/components/Toast";
+
+jest.mock("@/services/deezer-api");
+jest.mock("@/components/Toast");
+
+const mockDeezerAPI = deezerAPI as jest.Mocked<typeof deezerAPI>;
+const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
+
+describe("useGenres", () => {
+  const mockShow = jest.fn();
+
+  const buildGenre = (id: number, name = `Genre ${id}`): DeezerGenre => ({
+    id,
+    name,
+    picture: `pic-${id}`,
+    picture_small: `pic-s-${id}`,
+    picture_medium: `pic-m-${id}`,
+    picture_big: `pic-b-${id}`,
+    picture_xl: `pic-xl-${id}`,
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseToast.mockReturnValue({ show: mockShow });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("loads and filters out the 'All' genre (id === 0)", async () => {
+    mockDeezerAPI.getGenres.mockResolvedValue({
+      data: [
+        buildGenre(0, "All"),
+        buildGenre(132, "Pop"),
+        buildGenre(152, "Rock"),
+      ],
+    });
+
+    const { result } = renderHook(() => useGenres());
+
+    expect(result.current.loadingGenres).toBe(true);
+
+    await waitFor(() => expect(result.current.loadingGenres).toBe(false));
+
+    expect(result.current.genres).toHaveLength(2);
+    expect(result.current.genres.map((g) => g.id)).toEqual([132, 152]);
+    expect(mockShow).not.toHaveBeenCalled();
+  });
+
+  it("shows a toast error and keeps genres empty when the API fails", async () => {
+    mockDeezerAPI.getGenres.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useGenres());
+
+    await waitFor(() => expect(result.current.loadingGenres).toBe(false));
+
+    expect(result.current.genres).toEqual([]);
+    expect(mockShow).toHaveBeenCalledWith({
+      type: "error",
+      message: "Impossible de charger les genres musicaux",
+    });
+  });
+
+  it("exposes reloadGenres to refetch on demand", async () => {
+    mockDeezerAPI.getGenres.mockResolvedValueOnce({
+      data: [buildGenre(132, "Pop")],
+    });
+
+    const { result } = renderHook(() => useGenres());
+    await waitFor(() => expect(result.current.loadingGenres).toBe(false));
+    expect(result.current.genres).toHaveLength(1);
+
+    mockDeezerAPI.getGenres.mockResolvedValueOnce({
+      data: [buildGenre(132, "Pop"), buildGenre(152, "Rock")],
+    });
+
+    await act(async () => {
+      await result.current.reloadGenres();
+    });
+
+    expect(result.current.genres).toHaveLength(2);
+    expect(mockDeezerAPI.getGenres).toHaveBeenCalledTimes(2);
+  });
+});

--- a/front-mobile/hooks/useGenres.ts
+++ b/front-mobile/hooks/useGenres.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from "react";
+import { deezerAPI, DeezerGenre } from "@/services/deezer-api";
+import { useToast } from "@/components/Toast";
+
+export function useGenres() {
+  const [genres, setGenres] = useState<DeezerGenre[]>([]);
+  const [loadingGenres, setLoadingGenres] = useState(true);
+  const { show } = useToast();
+
+  const loadGenres = useCallback(async () => {
+    setLoadingGenres(true);
+    try {
+      const response = await deezerAPI.getGenres();
+      setGenres(response.data.filter((g) => g.id !== 0));
+    } catch (error) {
+      console.error("Failed to load genres:", error);
+      show({
+        type: "error",
+        message: "Impossible de charger les genres musicaux",
+      });
+    } finally {
+      setLoadingGenres(false);
+    }
+  }, [show]);
+
+  useEffect(() => {
+    void loadGenres();
+  }, [loadGenres]);
+
+  return { genres, loadingGenres, reloadGenres: loadGenres };
+}

--- a/front-mobile/hooks/useGenres.ts
+++ b/front-mobile/hooks/useGenres.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { deezerAPI, DeezerGenre } from "@/services/deezer-api";
 import { useToast } from "@/components/Toast";
 
@@ -6,20 +6,32 @@ export function useGenres() {
   const [genres, setGenres] = useState<DeezerGenre[]>([]);
   const [loadingGenres, setLoadingGenres] = useState(true);
   const { show } = useToast();
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const loadGenres = useCallback(async () => {
-    setLoadingGenres(true);
+    if (isMountedRef.current) setLoadingGenres(true);
     try {
       const response = await deezerAPI.getGenres();
-      setGenres(response.data.filter((g) => g.id !== 0));
+      if (isMountedRef.current) {
+        setGenres(response.data.filter((g) => g.id !== 0));
+      }
     } catch (error) {
       console.error("Failed to load genres:", error);
-      show({
-        type: "error",
-        message: "Impossible de charger les genres musicaux",
-      });
+      if (isMountedRef.current) {
+        show({
+          type: "error",
+          message: "Impossible de charger les genres musicaux",
+        });
+      }
     } finally {
-      setLoadingGenres(false);
+      if (isMountedRef.current) setLoadingGenres(false);
     }
   }, [show]);
 


### PR DESCRIPTION
## Description

Extraction de la logique de chargement des genres Deezer dans un hook réutilisable `useGenres`, prêt à être consommé par le futur jeu Blind Test (MIX-256) sans duplication. Inclut en bonus un nettoyage du code mort dans `tracklist/game.tsx` (références `rulesModal` orphelines) et une refonte de la modal des règles partagée (`RulesModal`) avec une animation custom séquencée : l'overlay sombre apparaît en fade-in puis la carte des règles slide depuis le bas, avec l'inverse à la fermeture.

## Parcours utilisateur

1. Ouvrir l'app et aller dans **Jeux → Blurchette**
2. Vérifier que la liste des genres musicaux s'affiche après le loader (hook `useGenres` en action)
3. Cliquer sur un genre (ex : Pop, Rock) et vérifier que la partie démarre normalement
4. Revenir à l'accueil Blurchette, cliquer sur **"Voir les règles"**
5. Observer l'animation : l'overlay noir apparaît d'abord en fondu, puis la carte des règles slide du bas vers le haut
6. Fermer la modal via le bouton ✕ → vérifier l'animation inverse (carte slide vers le bas puis overlay fade out)
7. Rouvrir la modal et taper en dehors de la carte (sur le fond noir) → vérifier que ça ferme la modal
8. Sur Android, rouvrir la modal et appuyer sur le bouton back physique → vérifier que ça ferme proprement
9. Répéter les étapes 4-8 sur le jeu **Tracklist** (même modal partagée)
10. Jouer une partie Tracklist (recherche artiste → album → partie) → vérifier qu'il n'y a pas de régression suite au cleanup
11. (Optionnel) Couper le wifi avant d'ouvrir Blurchette → un toast rouge "Impossible de charger les genres musicaux" doit s'afficher (pas d'Alert native)