### PR TITLE
MIX-262 refactor: extract tracklist game business logic into useTracklistGame hook

### DIFF
--- a/front-mobile/app/(tabs)/games/tracklist/game.tsx
+++ b/front-mobile/app/(tabs)/games/tracklist/game.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import {
   ActivityIndicator,
-  Alert,
   FlatList,
   Image,
   KeyboardAvoidingView,
@@ -12,524 +11,49 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
-import { router, useLocalSearchParams } from "expo-router";
+import { router } from "expo-router";
 import { ThemedText } from "@/components/ThemedText";
 import Button from "@/components/Button";
 import GameLayout from "@/components/GameLayout";
 import Header from "@/components/Header";
 import { GameErrorFeedback } from "@/components/GameErrorFeedback";
 import { Colors } from "@/constants/Colors";
-import {
-  deezerAPI,
-  DeezerAlbum,
-  DeezerArtist,
-  DeezerTrack,
-} from "@/services/deezer-api";
-import { useAuthStore } from "@/stores/authStore";
-import { useToast } from "@/components/Toast";
-import { useSettingsStore } from "@/stores/settingsStore";
-import {
-  createGameSession,
-  getMyActiveSession,
-  updateGameSession,
-} from "@/services/gameSessionService";
-import {
-  saveGameState,
-  getGameState,
-  deleteGameState,
-} from "@/services/gameStorageService";
-import {
-  GameSession,
-  TracklistGameData,
-  TrackAnswer,
-} from "@/types/gameSession";
 import { MaterialIcons } from "@expo/vector-icons";
-import { useErrorFeedback } from "@/hooks/useErrorFeedback";
-import { fuzzyMatch } from "@/utils/stringUtils";
-
-type GameState = "artistSearch" | "albumSelection" | "playing" | "result";
-
-interface GameAlbum {
-  album: DeezerAlbum;
-  tracks: DeezerTrack[];
-}
-
-interface AnswerFeedback {
-  type: "correct" | "wrong";
-  message: string;
-}
-
-interface TracklistSaveState {
-  gameState: GameState;
-  searchQuery: string;
-  selectedArtist: DeezerArtist | null;
-  candidateAlbums: DeezerAlbum[];
-  currentAlbum: GameAlbum | null;
-  foundTrackIds: number[];
-  timeRemaining: number;
-  validatedAnswers: TrackAnswer[];
-  sessionId: string | null;
-}
-
-const GAME_DURATION = 300;
-const ALBUM_CHOICES = 6;
+import { useTracklistGame } from "./hooks/useTracklistGame";
 
 export default function TracklistGameScreen() {
-  const [gameState, setGameState] = useState<GameState>("artistSearch");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<DeezerArtist[]>([]);
-  const [topArtists, setTopArtists] = useState<DeezerArtist[]>([]);
-  const [isSearching, setIsSearching] = useState(false);
-  const [isInitialLoading, setIsInitialLoading] = useState(false);
-  const [loadingAlbum, setLoadingAlbum] = useState(false);
-
-  const [candidateAlbums, setCandidateAlbums] = useState<DeezerAlbum[]>([]);
-  const [selectedArtist, setSelectedArtist] = useState<DeezerArtist | null>(
-    null,
-  );
-
-  const [currentAlbum, setCurrentAlbum] = useState<GameAlbum | null>(null);
-  const [currentInput, setCurrentInput] = useState("");
-  const [foundTrackIds, setFoundTrackIds] = useState<Set<number>>(new Set());
-  const [answerFeedback, setAnswerFeedback] = useState<AnswerFeedback | null>(
-    null,
-  );
-  const [timeRemaining, setTimeRemaining] = useState(GAME_DURATION);
-  const [isTimerRunning, setIsTimerRunning] = useState(false);
-
-  const [sessionId, setSessionId] = useState<string | null>(null);
-  const [sessionError, setSessionError] = useState(false);
-  const [validatedAnswers, setValidatedAnswers] = useState<TrackAnswer[]>([]);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [activeSession, setActiveSession] = useState<GameSession | null>(null);
-
   const inputRef = useRef<TextInput>(null);
-  const feedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const isProcessingAnswerRef = useRef(false);
-  const isSubmittingRef = useRef(false);
-
-  const { gameId, resume } = useLocalSearchParams<{
-    gameId: string;
-    resume?: string;
-  }>();
-  const user = useAuthStore((state) => state.user);
-  const { errorAnimationsEnabled } = useSettingsStore();
-  const { show } = useToast();
-  const { shakeAnimation, borderOpacity, triggerError } = useErrorFeedback(
-    errorAnimationsEnabled,
-  );
-
-  const fetchTopArtists = useCallback(async () => {
-    setIsInitialLoading(true);
-    try {
-      const response = await deezerAPI.getTopArtists(20);
-      setTopArtists(response.data);
-    } catch (error) {
-      console.error("Failed to fetch top artists:", error);
-      show({
-        type: "error",
-        message: "Impossible de charger les suggestions d'artistes",
-      });
-    } finally {
-      setIsInitialLoading(false);
-    }
-  }, [show]);
-
-  useEffect(() => {
-    void fetchTopArtists();
-  }, [fetchTopArtists]);
-
-  const performSearch = useCallback(
-    async (query: string) => {
-      if (query.trim().length < 3) {
-        setSearchResults([]);
-        return;
-      }
-
-      setIsSearching(true);
-      try {
-        const response = await deezerAPI.searchArtists(query, 20);
-        setSearchResults(response.data);
-      } catch (error) {
-        console.error("Search failed:", error);
-        show({ type: "error", message: "Échec de la recherche d'artistes" });
-      } finally {
-        setIsSearching(false);
-      }
-    },
-    [show],
-  );
-
-  useEffect(() => {
-    if (searchTimeoutRef.current) {
-      clearTimeout(searchTimeoutRef.current);
-    }
-
-    if (searchQuery.trim().length >= 3) {
-      searchTimeoutRef.current = setTimeout(() => {
-        void performSearch(searchQuery);
-      }, 400);
-    } else {
-      setSearchResults([]);
-    }
-
-    return () => {
-      if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current);
-      }
-    };
-  }, [searchQuery, performSearch]);
-
-  const loadSavedState = useCallback(async () => {
-    if (!gameId) return;
-    setLoadingAlbum(true);
-    try {
-      const saved = await getGameState<TracklistSaveState>(gameId);
-      if (saved) {
-        setGameState(saved.gameState);
-        setSearchQuery(saved.searchQuery || "");
-        setSelectedArtist(saved.selectedArtist);
-        setCandidateAlbums(saved.candidateAlbums);
-        setCurrentAlbum(saved.currentAlbum);
-        setFoundTrackIds(new Set(saved.foundTrackIds));
-        setTimeRemaining(saved.timeRemaining);
-        setValidatedAnswers(saved.validatedAnswers);
-        setSessionId(saved.sessionId);
-
-        if (saved.gameState === "playing") {
-          setIsTimerRunning(true);
-        }
-      }
-    } catch (error) {
-      console.error("Failed to load saved state:", error);
-      show({ type: "error", message: "Impossible de reprendre la partie" });
-    } finally {
-      setLoadingAlbum(false);
-    }
-  }, [gameId, show]);
-
-  useEffect(() => {
-    if (gameId) {
-      if (resume === "true") {
-        void loadSavedState();
-      } else {
-        void deleteGameState(gameId);
-
-        const timeout = new Promise<null>((resolve) =>
-          setTimeout(() => resolve(null), 5000),
-        );
-        Promise.race([getMyActiveSession(Number(gameId)), timeout])
-          .then((session) => {
-            setActiveSession(session);
-          })
-          .catch(() => {});
-      }
-    }
-  }, [gameId, resume, loadSavedState]);
-
-  useEffect(() => {
-    let interval: ReturnType<typeof setInterval>;
-    if (isTimerRunning && timeRemaining > 0) {
-      interval = setInterval(() => {
-        setTimeRemaining((prev) => {
-          if (prev <= 1) {
-            setIsTimerRunning(false);
-            return 0;
-          }
-          return prev - 1;
-        });
-      }, 1000);
-    }
-    return () => clearInterval(interval);
-  }, [isTimerRunning, timeRemaining]);
-
-  const autoSave = useCallback(async () => {
-    if (!gameId || gameState === "result") return;
-
-    const saveState: TracklistSaveState = {
-      gameState,
-      searchQuery,
-      selectedArtist,
-      candidateAlbums,
-      currentAlbum,
-      foundTrackIds: Array.from(foundTrackIds),
-      timeRemaining,
-      validatedAnswers,
-      sessionId,
-    };
-
-    await saveGameState(gameId, saveState);
-  }, [
-    gameId,
+  const {
     gameState,
     searchQuery,
-    selectedArtist,
+    searchResults,
+    topArtists,
+    isSearching,
+    isInitialLoading,
+    loadingAlbum,
     candidateAlbums,
+    selectedArtist,
     currentAlbum,
+    currentInput,
     foundTrackIds,
+    answerFeedback,
     timeRemaining,
-    validatedAnswers,
     sessionId,
-  ]);
-
-  useEffect(() => {
-    if (gameState !== "result" && gameState !== "artistSearch" && gameId) {
-      void autoSave();
-    }
-  }, [gameState, gameId, autoSave]);
-
-  const submitAnswers = useCallback(
-    async (finalFoundIds?: Set<number>, finalAnswers?: TrackAnswer[]) => {
-      if (!currentAlbum || isSubmittingRef.current) return;
-      isSubmittingRef.current = true;
-
-      try {
-        setIsTimerRunning(false);
-        const usedFoundIds = finalFoundIds ?? foundTrackIds;
-        const usedAnswers = finalAnswers ?? validatedAnswers;
-        const score = usedFoundIds.size;
-
-        if (sessionId) {
-          try {
-            const finalData: Partial<TracklistGameData> = {
-              answers: usedAnswers,
-              score,
-              timeElapsed: GAME_DURATION - timeRemaining,
-              completedAt: new Date().toISOString(),
-            };
-
-            await updateGameSession(sessionId, {
-              status: "completed",
-              gameData: finalData as unknown as Record<string, unknown>,
-            });
-          } catch (err) {
-            console.error("Failed to update session:", err);
-          }
-        }
-
-        if (gameId) {
-          void deleteGameState(gameId);
-        }
-
-        setGameState("result");
-      } finally {
-        isSubmittingRef.current = false;
-      }
-    },
-    [
-      currentAlbum,
-      foundTrackIds,
-      validatedAnswers,
-      sessionId,
-      timeRemaining,
-      gameId,
-    ],
-  );
-
-  useEffect(() => {
-    if (timeRemaining === 0 && !isTimerRunning && gameState === "playing") {
-      void submitAnswers();
-    }
-  }, [timeRemaining, isTimerRunning, gameState, submitAnswers]);
-
-  useEffect(() => {
-    return () => {
-      if (feedbackTimeoutRef.current) clearTimeout(feedbackTimeoutRef.current);
-    };
-  }, []);
-
-  useEffect(() => {
-    if (gameState !== "playing" && feedbackTimeoutRef.current) {
-      clearTimeout(feedbackTimeoutRef.current);
-      feedbackTimeoutRef.current = null;
-      setAnswerFeedback(null);
-    }
-  }, [gameState]);
-
-  const handleSelectArtist = async (artist: DeezerArtist) => {
-    setLoadingAlbum(true);
-    setSelectedArtist(artist);
-
-    try {
-      const albumsResponse = await deezerAPI.getArtistAlbums(artist.id, 25);
-
-      if (!albumsResponse.data || albumsResponse.data.length === 0) {
-        show({ type: "error", message: "Aucun album trouvé pour cet artiste" });
-        return;
-      }
-
-      const albums = albumsResponse.data.filter(
-        (a) => a.record_type === "album" || a.record_type === "ep",
-      );
-      const pool = albums.length > 0 ? albums : albumsResponse.data;
-      const shuffled = [...pool].sort(() => Math.random() - 0.5);
-      setCandidateAlbums(shuffled.slice(0, ALBUM_CHOICES));
-      setGameState("albumSelection");
-    } catch (error) {
-      console.error("Failed to load albums:", error);
-      show({ type: "error", message: "Impossible de charger les albums" });
-    } finally {
-      setLoadingAlbum(false);
-    }
-  };
-
-  const startGameWithAlbum = async (album: DeezerAlbum) => {
-    if (!gameId || !user) {
-      setSessionError(true);
-      return;
-    }
-
-    setLoadingAlbum(true);
-
-    try {
-      const tracksResponse = await deezerAPI.getAlbumTracks(album.id);
-
-      if (!tracksResponse.data || tracksResponse.data.length < 5) {
-        show({
-          type: "warning",
-          message: "Cet album n'a pas assez de titres. Choisissez-en un autre.",
-        });
-        return;
-      }
-
-      const gameAlbum: GameAlbum = {
-        album,
-        tracks: tracksResponse.data,
-      };
-
-      const gameData: TracklistGameData = {
-        genre: { id: 0, name: "Search" },
-        album: {
-          id: album.id,
-          title: album.title,
-          artistName: album.artist?.name ?? selectedArtist?.name ?? "",
-          coverUrl: album.cover_xl,
-          totalTracks: tracksResponse.data.length,
-        },
-        answers: [],
-        score: 0,
-        maxScore: tracksResponse.data.length,
-        timeElapsed: 0,
-        startedAt: new Date().toISOString(),
-        completedAt: "",
-      };
-
-      const session = await createGameSession({
-        gameId: parseInt(gameId, 10),
-        status: "active",
-        players: [{ userId: user.id }],
-        gameData: gameData as unknown as Record<string, unknown>,
-      });
-
-      setSessionId(session.id);
-      setValidatedAnswers([]);
-      setFoundTrackIds(new Set());
-      setCurrentInput("");
-      setCurrentAlbum(gameAlbum);
-      setTimeRemaining(GAME_DURATION);
-      setIsTimerRunning(true);
-      setGameState("playing");
-    } catch (error) {
-      console.error("Failed to start game:", error);
-      show({ type: "error", message: "Impossible de démarrer la partie" });
-    } finally {
-      setLoadingAlbum(false);
-    }
-  };
-
-  const formatTime = (seconds: number): string => {
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
-  };
-
-  const showFeedback = (type: "correct" | "wrong", message: string) => {
-    if (feedbackTimeoutRef.current) clearTimeout(feedbackTimeoutRef.current);
-    setAnswerFeedback({ type, message });
-    feedbackTimeoutRef.current = setTimeout(
-      () => setAnswerFeedback(null),
-      1500,
-    );
-  };
-
-  const handleSubmitAnswer = () => {
-    if (isProcessingAnswerRef.current) return;
-    const trimmed = currentInput.trim();
-    if (!trimmed || !currentAlbum) return;
-
-    isProcessingAnswerRef.current = true;
-
-    const matchedTrack = currentAlbum.tracks.find(
-      (track) =>
-        !foundTrackIds.has(track.id) &&
-        (fuzzyMatch(trimmed, track.title) ||
-          fuzzyMatch(trimmed, track.title_short)),
-    );
-
-    if (matchedTrack) {
-      const newFoundIds = new Set(foundTrackIds);
-      newFoundIds.add(matchedTrack.id);
-      setFoundTrackIds(newFoundIds);
-
-      const newAnswer: TrackAnswer = {
-        userInput: trimmed,
-        isCorrect: true,
-        matchedTrackId: matchedTrack.id,
-        timestamp: new Date().toISOString(),
-      };
-      const newAnswers = [...validatedAnswers, newAnswer];
-      setValidatedAnswers(newAnswers);
-      setCurrentInput("");
-      showFeedback("correct", `✓ ${matchedTrack.title}`);
-
-      if (newFoundIds.size === currentAlbum.tracks.length) {
-        void submitAnswers(newFoundIds, newAnswers);
-      }
-    } else {
-      setCurrentInput("");
-      triggerError();
-      showFeedback("wrong", "Essaie encore !");
-    }
-
-    isProcessingAnswerRef.current = false;
-  };
-
-  const handleAbandon = () => {
-    Alert.alert(
-      "Abandonner",
-      "Êtes-vous sûr de vouloir abandonner cette partie ?",
-      [
-        { text: "Non", style: "cancel" },
-        {
-          text: "Oui",
-          style: "destructive",
-          onPress: () => {
-            void submitAnswers();
-          },
-        },
-      ],
-    );
-  };
-
-  const resetGame = () => {
-    if (gameId) {
-      void deleteGameState(gameId);
-    }
-    setGameState("artistSearch");
-    setCurrentAlbum(null);
-    setCandidateAlbums([]);
-    setSelectedArtist(null);
-    setSearchQuery("");
-    setSearchResults([]);
-    setCurrentInput("");
-    setFoundTrackIds(new Set());
-    setTimeRemaining(GAME_DURATION);
-    setIsTimerRunning(false);
-    setValidatedAnswers([]);
-    setSessionId(null);
-    setAnswerFeedback(null);
-  };
+    sessionError,
+    shakeAnimation,
+    borderOpacity,
+    errorAnimationsEnabled,
+    setSearchQuery,
+    setCurrentInput,
+    handleSelectArtist,
+    startGameWithAlbum,
+    handleSubmitAnswer,
+    handleAbandon,
+    resetGame,
+    backToArtistSearch,
+    autoSave,
+    formatTime,
+  } = useTracklistGame();
 
   if (sessionError) {
     return (
@@ -673,7 +197,7 @@ export default function TracklistGameScreen() {
         title="Tracklist"
         sessionId={sessionId}
         onSave={autoSave}
-        onBack={() => setGameState("artistSearch")}
+        onBack={backToArtistSearch}
       >
         <View style={styles.container}>
           <View style={styles.setupContainer}>

--- a/front-mobile/app/(tabs)/games/tracklist/hooks/__tests__/useTracklistGame.test.ts
+++ b/front-mobile/app/(tabs)/games/tracklist/hooks/__tests__/useTracklistGame.test.ts
@@ -1,0 +1,290 @@
+import { renderHook, waitFor, act } from "@testing-library/react-native";
+import { useTracklistGame } from "../useTracklistGame";
+import { deezerAPI, DeezerAlbum, DeezerTrack } from "@/services/deezer-api";
+import { useLocalSearchParams } from "expo-router";
+import {
+  createGameSession,
+  getMyActiveSession,
+  updateGameSession,
+} from "@/services/gameSessionService";
+import {
+  saveGameState,
+  getGameState,
+  deleteGameState,
+} from "@/services/gameStorageService";
+import { useAuthStore } from "@/stores/authStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { useToast } from "@/components/Toast";
+import { useErrorFeedback } from "@/hooks/useErrorFeedback";
+
+jest.mock("@/services/deezer-api");
+jest.mock("@/services/gameSessionService");
+jest.mock("@/services/gameStorageService");
+jest.mock("@/stores/authStore");
+jest.mock("@/stores/settingsStore");
+jest.mock("@/components/Toast");
+jest.mock("@/hooks/useErrorFeedback");
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: jest.fn(),
+  router: { back: jest.fn(), push: jest.fn() },
+}));
+
+const mockDeezerAPI = deezerAPI as jest.Mocked<typeof deezerAPI>;
+const mockUseLocalSearchParams = useLocalSearchParams as jest.MockedFunction<
+  typeof useLocalSearchParams
+>;
+const mockCreateGameSession = createGameSession as jest.MockedFunction<
+  typeof createGameSession
+>;
+const mockGetMyActiveSession = getMyActiveSession as jest.MockedFunction<
+  typeof getMyActiveSession
+>;
+const mockUpdateGameSession = updateGameSession as jest.MockedFunction<
+  typeof updateGameSession
+>;
+const mockSaveGameState = saveGameState as jest.MockedFunction<
+  typeof saveGameState
+>;
+const mockGetGameState = getGameState as jest.MockedFunction<
+  typeof getGameState
+>;
+const mockDeleteGameState = deleteGameState as jest.MockedFunction<
+  typeof deleteGameState
+>;
+const mockUseAuthStore = useAuthStore as unknown as jest.Mock;
+const mockUseSettingsStore = useSettingsStore as unknown as jest.Mock;
+const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
+const mockUseErrorFeedback = useErrorFeedback as jest.MockedFunction<
+  typeof useErrorFeedback
+>;
+
+const buildTrack = (id: number, title: string): DeezerTrack =>
+  ({
+    id,
+    title,
+    title_short: title,
+    title_version: "",
+    link: "",
+    duration: 180,
+    rank: 0,
+    explicit_lyrics: false,
+    explicit_content_lyrics: 0,
+    explicit_content_cover: 0,
+    preview: "",
+    md5_image: "",
+    artist: { id: 1, name: "Artist" },
+    album: { id: 1, title: "Album" },
+    type: "track",
+  }) as unknown as DeezerTrack;
+
+const buildAlbum = (id: number, title: string): DeezerAlbum =>
+  ({
+    id,
+    title,
+    cover: "",
+    cover_small: "",
+    cover_medium: "",
+    cover_big: "",
+    cover_xl: "",
+    md5_image: "",
+    genre_id: 0,
+    release_date: "",
+    record_type: "album",
+    tracklist: "",
+    explicit_lyrics: false,
+    nb_tracks: 10,
+    duration: 2000,
+    fans: 0,
+    type: "album",
+    artist: { id: 1, name: "Artist" },
+  }) as unknown as DeezerAlbum;
+
+const sampleTracks: DeezerTrack[] = [
+  buildTrack(101, "Sunset Boulevard"),
+  buildTrack(102, "Midnight Drive"),
+  buildTrack(103, "Ocean Eyes"),
+  buildTrack(104, "Neon Dreams"),
+  buildTrack(105, "Stellar"),
+  buildTrack(106, "Ether"),
+];
+
+const sampleAlbum = buildAlbum(500, "Greatest Hits");
+
+const buildSavedPlayingState = (
+  overrides: Partial<Record<string, unknown>> = {},
+) => ({
+  gameState: "playing",
+  searchQuery: "",
+  selectedArtist: null,
+  candidateAlbums: [],
+  currentAlbum: { album: sampleAlbum, tracks: sampleTracks },
+  foundTrackIds: [],
+  timeRemaining: 200,
+  validatedAnswers: [],
+  sessionId: "session-saved",
+  ...overrides,
+});
+
+describe("useTracklistGame", () => {
+  const mockShow = jest.fn();
+  const mockTriggerError = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "1" });
+    mockUseAuthStore.mockImplementation(
+      (selector: (state: unknown) => unknown) =>
+        selector({ user: { id: "user-1" } }),
+    );
+    mockUseSettingsStore.mockReturnValue({ errorAnimationsEnabled: false });
+    mockUseToast.mockReturnValue({ show: mockShow });
+    mockUseErrorFeedback.mockReturnValue({
+      shakeAnimation: { value: 0 } as unknown as ReturnType<
+        typeof useErrorFeedback
+      >["shakeAnimation"],
+      borderOpacity: { value: 0 } as unknown as ReturnType<
+        typeof useErrorFeedback
+      >["borderOpacity"],
+      errorMessage: null,
+      triggerError: mockTriggerError,
+    });
+
+    mockDeezerAPI.getTopArtists.mockResolvedValue({ data: [] } as never);
+    mockDeezerAPI.getArtistAlbums.mockResolvedValue({
+      data: [sampleAlbum],
+    } as never);
+    mockDeezerAPI.getAlbumTracks.mockResolvedValue({
+      data: sampleTracks,
+    } as never);
+    mockGetMyActiveSession.mockResolvedValue(null as never);
+    mockCreateGameSession.mockResolvedValue({ id: "session-new" } as never);
+    mockUpdateGameSession.mockResolvedValue(undefined as never);
+    mockSaveGameState.mockResolvedValue(undefined);
+    mockDeleteGameState.mockResolvedValue(undefined);
+    mockGetGameState.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("resumes a saved playing state and ticks the timer down", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "1", resume: "true" });
+    mockGetGameState.mockResolvedValue(buildSavedPlayingState());
+
+    const { result } = renderHook(() => useTracklistGame());
+
+    await waitFor(() => {
+      expect(result.current.gameState).toBe("playing");
+      expect(result.current.timeRemaining).toBe(200);
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(result.current.timeRemaining).toBe(199);
+  });
+
+  it("auto-submits when the timer reaches zero", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "1", resume: "true" });
+    mockGetGameState.mockResolvedValue(
+      buildSavedPlayingState({ timeRemaining: 2 }),
+    );
+
+    const { result } = renderHook(() => useTracklistGame());
+
+    await waitFor(() => expect(result.current.gameState).toBe("playing"));
+
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    await waitFor(() => expect(result.current.gameState).toBe("result"));
+    expect(mockUpdateGameSession).toHaveBeenCalledWith(
+      "session-saved",
+      expect.objectContaining({ status: "completed" }),
+    );
+  });
+
+  it("handleSubmitAnswer marks a correct fuzzy match as found", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "1", resume: "true" });
+    mockGetGameState.mockResolvedValue(buildSavedPlayingState());
+
+    const { result } = renderHook(() => useTracklistGame());
+    await waitFor(() => expect(result.current.gameState).toBe("playing"));
+
+    act(() => {
+      result.current.setCurrentInput("Sunset Boulevard");
+    });
+    act(() => {
+      result.current.handleSubmitAnswer();
+    });
+
+    expect(result.current.foundTrackIds.has(101)).toBe(true);
+    expect(result.current.answerFeedback?.type).toBe("correct");
+    expect(result.current.currentInput).toBe("");
+    expect(mockTriggerError).not.toHaveBeenCalled();
+  });
+
+  it("handleSubmitAnswer triggers error feedback on a wrong answer", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "1", resume: "true" });
+    mockGetGameState.mockResolvedValue(buildSavedPlayingState());
+
+    const { result } = renderHook(() => useTracklistGame());
+    await waitFor(() => expect(result.current.gameState).toBe("playing"));
+
+    act(() => {
+      result.current.setCurrentInput("Totally Unrelated Title");
+    });
+    act(() => {
+      result.current.handleSubmitAnswer();
+    });
+
+    expect(result.current.answerFeedback?.type).toBe("wrong");
+    expect(mockTriggerError).toHaveBeenCalledTimes(1);
+    expect(result.current.foundTrackIds.size).toBe(0);
+  });
+
+  it("resetGame clears state and deletes saved storage", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "1", resume: "true" });
+    mockGetGameState.mockResolvedValue(
+      buildSavedPlayingState({ foundTrackIds: [101, 102], timeRemaining: 120 }),
+    );
+
+    const { result } = renderHook(() => useTracklistGame());
+    await waitFor(() => expect(result.current.gameState).toBe("playing"));
+
+    mockDeleteGameState.mockClear();
+
+    act(() => {
+      result.current.resetGame();
+    });
+
+    expect(result.current.gameState).toBe("artistSearch");
+    expect(result.current.currentAlbum).toBeNull();
+    expect(result.current.foundTrackIds.size).toBe(0);
+    expect(result.current.timeRemaining).toBe(300);
+    expect(mockDeleteGameState).toHaveBeenCalledWith("1");
+  });
+
+  it("startGameWithAlbum creates a session and transitions to playing", async () => {
+    const { result } = renderHook(() => useTracklistGame());
+
+    await waitFor(() => expect(result.current.gameState).toBe("artistSearch"));
+
+    await act(async () => {
+      await result.current.startGameWithAlbum(sampleAlbum);
+    });
+
+    expect(mockCreateGameSession).toHaveBeenCalledWith(
+      expect.objectContaining({ gameId: 1, status: "active" }),
+    );
+    expect(result.current.sessionId).toBe("session-new");
+    expect(result.current.gameState).toBe("playing");
+    expect(result.current.currentAlbum?.album.id).toBe(500);
+    expect(result.current.timeRemaining).toBe(300);
+  });
+});

--- a/front-mobile/app/(tabs)/games/tracklist/hooks/useTracklistGame.ts
+++ b/front-mobile/app/(tabs)/games/tracklist/hooks/useTracklistGame.ts
@@ -188,35 +188,35 @@ export function useTracklistGame() {
   }, [gameId, show]);
 
   useEffect(() => {
-    if (gameId) {
-      if (resume === "true") {
-        void loadSavedState();
-      } else {
-        void deleteGameState(gameId);
-
-        const timeout = new Promise<null>((resolve) =>
-          setTimeout(() => resolve(null), 5000),
-        );
-        Promise.race([getMyActiveSession(Number(gameId)), timeout]).catch(
-          () => {},
-        );
-      }
+    if (!gameId) return;
+    if (resume === "true") {
+      void loadSavedState();
+      return;
     }
+    void deleteGameState(gameId);
+
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<null>((resolve) => {
+      timeoutId = setTimeout(() => resolve(null), 5000);
+    });
+    Promise.race([getMyActiveSession(Number(gameId)), timeoutPromise])
+      .catch(() => {})
+      .finally(() => {
+        if (timeoutId) clearTimeout(timeoutId);
+      });
   }, [gameId, resume, loadSavedState]);
 
   useEffect(() => {
-    let interval: ReturnType<typeof setInterval>;
-    if (isTimerRunning && timeRemaining > 0) {
-      interval = setInterval(() => {
-        setTimeRemaining((prev) => {
-          if (prev <= 1) {
-            setIsTimerRunning(false);
-            return 0;
-          }
-          return prev - 1;
-        });
-      }, 1000);
-    }
+    if (!isTimerRunning || timeRemaining <= 0) return;
+    const interval = setInterval(() => {
+      setTimeRemaining((prev) => {
+        if (prev <= 1) {
+          setIsTimerRunning(false);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
     return () => clearInterval(interval);
   }, [isTimerRunning, timeRemaining]);
 

--- a/front-mobile/app/(tabs)/games/tracklist/hooks/useTracklistGame.ts
+++ b/front-mobile/app/(tabs)/games/tracklist/hooks/useTracklistGame.ts
@@ -1,0 +1,573 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Alert } from "react-native";
+import { useLocalSearchParams } from "expo-router";
+import {
+  deezerAPI,
+  DeezerAlbum,
+  DeezerArtist,
+  DeezerTrack,
+} from "@/services/deezer-api";
+import { useAuthStore } from "@/stores/authStore";
+import { useToast } from "@/components/Toast";
+import { useSettingsStore } from "@/stores/settingsStore";
+import {
+  createGameSession,
+  getMyActiveSession,
+  updateGameSession,
+} from "@/services/gameSessionService";
+import {
+  saveGameState,
+  getGameState,
+  deleteGameState,
+} from "@/services/gameStorageService";
+import { TracklistGameData, TrackAnswer } from "@/types/gameSession";
+import { useErrorFeedback } from "@/hooks/useErrorFeedback";
+import { fuzzyMatch } from "@/utils/stringUtils";
+
+export type GameState =
+  | "artistSearch"
+  | "albumSelection"
+  | "playing"
+  | "result";
+
+export interface GameAlbum {
+  album: DeezerAlbum;
+  tracks: DeezerTrack[];
+}
+
+export interface AnswerFeedback {
+  type: "correct" | "wrong";
+  message: string;
+}
+
+interface TracklistSaveState {
+  gameState: GameState;
+  searchQuery: string;
+  selectedArtist: DeezerArtist | null;
+  candidateAlbums: DeezerAlbum[];
+  currentAlbum: GameAlbum | null;
+  foundTrackIds: number[];
+  timeRemaining: number;
+  validatedAnswers: TrackAnswer[];
+  sessionId: string | null;
+}
+
+export const GAME_DURATION = 300;
+const ALBUM_CHOICES = 6;
+
+export function useTracklistGame() {
+  const [gameState, setGameState] = useState<GameState>("artistSearch");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<DeezerArtist[]>([]);
+  const [topArtists, setTopArtists] = useState<DeezerArtist[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(false);
+  const [loadingAlbum, setLoadingAlbum] = useState(false);
+
+  const [candidateAlbums, setCandidateAlbums] = useState<DeezerAlbum[]>([]);
+  const [selectedArtist, setSelectedArtist] = useState<DeezerArtist | null>(
+    null,
+  );
+
+  const [currentAlbum, setCurrentAlbum] = useState<GameAlbum | null>(null);
+  const [currentInput, setCurrentInput] = useState("");
+  const [foundTrackIds, setFoundTrackIds] = useState<Set<number>>(new Set());
+  const [answerFeedback, setAnswerFeedback] = useState<AnswerFeedback | null>(
+    null,
+  );
+  const [timeRemaining, setTimeRemaining] = useState(GAME_DURATION);
+  const [isTimerRunning, setIsTimerRunning] = useState(false);
+
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [sessionError, setSessionError] = useState(false);
+  const [validatedAnswers, setValidatedAnswers] = useState<TrackAnswer[]>([]);
+
+  const feedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isProcessingAnswerRef = useRef(false);
+  const isSubmittingRef = useRef(false);
+
+  const { gameId, resume } = useLocalSearchParams<{
+    gameId: string;
+    resume?: string;
+  }>();
+  const user = useAuthStore((state) => state.user);
+  const { errorAnimationsEnabled } = useSettingsStore();
+  const { show } = useToast();
+  const { shakeAnimation, borderOpacity, triggerError } = useErrorFeedback(
+    errorAnimationsEnabled,
+  );
+
+  const fetchTopArtists = useCallback(async () => {
+    setIsInitialLoading(true);
+    try {
+      const response = await deezerAPI.getTopArtists(20);
+      setTopArtists(response.data);
+    } catch (error) {
+      console.error("Failed to fetch top artists:", error);
+      show({
+        type: "error",
+        message: "Impossible de charger les suggestions d'artistes",
+      });
+    } finally {
+      setIsInitialLoading(false);
+    }
+  }, [show]);
+
+  useEffect(() => {
+    void fetchTopArtists();
+  }, [fetchTopArtists]);
+
+  const performSearch = useCallback(
+    async (query: string) => {
+      if (query.trim().length < 3) {
+        setSearchResults([]);
+        return;
+      }
+
+      setIsSearching(true);
+      try {
+        const response = await deezerAPI.searchArtists(query, 20);
+        setSearchResults(response.data);
+      } catch (error) {
+        console.error("Search failed:", error);
+        show({ type: "error", message: "Échec de la recherche d'artistes" });
+      } finally {
+        setIsSearching(false);
+      }
+    },
+    [show],
+  );
+
+  useEffect(() => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    if (searchQuery.trim().length >= 3) {
+      searchTimeoutRef.current = setTimeout(() => {
+        void performSearch(searchQuery);
+      }, 400);
+    } else {
+      setSearchResults([]);
+    }
+
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, [searchQuery, performSearch]);
+
+  const loadSavedState = useCallback(async () => {
+    if (!gameId) return;
+    setLoadingAlbum(true);
+    try {
+      const saved = await getGameState<TracklistSaveState>(gameId);
+      if (saved) {
+        setGameState(saved.gameState);
+        setSearchQuery(saved.searchQuery || "");
+        setSelectedArtist(saved.selectedArtist);
+        setCandidateAlbums(saved.candidateAlbums);
+        setCurrentAlbum(saved.currentAlbum);
+        setFoundTrackIds(new Set(saved.foundTrackIds));
+        setTimeRemaining(saved.timeRemaining);
+        setValidatedAnswers(saved.validatedAnswers);
+        setSessionId(saved.sessionId);
+
+        if (saved.gameState === "playing") {
+          setIsTimerRunning(true);
+        }
+      }
+    } catch (error) {
+      console.error("Failed to load saved state:", error);
+      show({ type: "error", message: "Impossible de reprendre la partie" });
+    } finally {
+      setLoadingAlbum(false);
+    }
+  }, [gameId, show]);
+
+  useEffect(() => {
+    if (gameId) {
+      if (resume === "true") {
+        void loadSavedState();
+      } else {
+        void deleteGameState(gameId);
+
+        const timeout = new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), 5000),
+        );
+        Promise.race([getMyActiveSession(Number(gameId)), timeout]).catch(
+          () => {},
+        );
+      }
+    }
+  }, [gameId, resume, loadSavedState]);
+
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval>;
+    if (isTimerRunning && timeRemaining > 0) {
+      interval = setInterval(() => {
+        setTimeRemaining((prev) => {
+          if (prev <= 1) {
+            setIsTimerRunning(false);
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    }
+    return () => clearInterval(interval);
+  }, [isTimerRunning, timeRemaining]);
+
+  const autoSave = useCallback(async () => {
+    if (!gameId || gameState === "result") return;
+
+    const saveState: TracklistSaveState = {
+      gameState,
+      searchQuery,
+      selectedArtist,
+      candidateAlbums,
+      currentAlbum,
+      foundTrackIds: Array.from(foundTrackIds),
+      timeRemaining,
+      validatedAnswers,
+      sessionId,
+    };
+
+    await saveGameState(gameId, saveState);
+  }, [
+    gameId,
+    gameState,
+    searchQuery,
+    selectedArtist,
+    candidateAlbums,
+    currentAlbum,
+    foundTrackIds,
+    timeRemaining,
+    validatedAnswers,
+    sessionId,
+  ]);
+
+  useEffect(() => {
+    if (gameState !== "result" && gameState !== "artistSearch" && gameId) {
+      void autoSave();
+    }
+  }, [gameState, gameId, autoSave]);
+
+  const submitAnswers = useCallback(
+    async (finalFoundIds?: Set<number>, finalAnswers?: TrackAnswer[]) => {
+      if (!currentAlbum || isSubmittingRef.current) return;
+      isSubmittingRef.current = true;
+
+      try {
+        setIsTimerRunning(false);
+        const usedFoundIds = finalFoundIds ?? foundTrackIds;
+        const usedAnswers = finalAnswers ?? validatedAnswers;
+        const score = usedFoundIds.size;
+
+        if (sessionId) {
+          try {
+            const finalData: Partial<TracklistGameData> = {
+              answers: usedAnswers,
+              score,
+              timeElapsed: GAME_DURATION - timeRemaining,
+              completedAt: new Date().toISOString(),
+            };
+
+            await updateGameSession(sessionId, {
+              status: "completed",
+              gameData: finalData as unknown as Record<string, unknown>,
+            });
+          } catch (err) {
+            console.error("Failed to update session:", err);
+          }
+        }
+
+        if (gameId) {
+          void deleteGameState(gameId);
+        }
+
+        setGameState("result");
+      } finally {
+        isSubmittingRef.current = false;
+      }
+    },
+    [
+      currentAlbum,
+      foundTrackIds,
+      validatedAnswers,
+      sessionId,
+      timeRemaining,
+      gameId,
+    ],
+  );
+
+  useEffect(() => {
+    if (timeRemaining === 0 && !isTimerRunning && gameState === "playing") {
+      void submitAnswers();
+    }
+  }, [timeRemaining, isTimerRunning, gameState, submitAnswers]);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimeoutRef.current) clearTimeout(feedbackTimeoutRef.current);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (gameState !== "playing" && feedbackTimeoutRef.current) {
+      clearTimeout(feedbackTimeoutRef.current);
+      feedbackTimeoutRef.current = null;
+      setAnswerFeedback(null);
+    }
+  }, [gameState]);
+
+  const handleSelectArtist = useCallback(
+    async (artist: DeezerArtist) => {
+      setLoadingAlbum(true);
+      setSelectedArtist(artist);
+
+      try {
+        const albumsResponse = await deezerAPI.getArtistAlbums(artist.id, 25);
+
+        if (!albumsResponse.data || albumsResponse.data.length === 0) {
+          show({
+            type: "error",
+            message: "Aucun album trouvé pour cet artiste",
+          });
+          return;
+        }
+
+        const albums = albumsResponse.data.filter(
+          (a) => a.record_type === "album" || a.record_type === "ep",
+        );
+        const pool = albums.length > 0 ? albums : albumsResponse.data;
+        const shuffled = [...pool].sort(() => Math.random() - 0.5);
+        setCandidateAlbums(shuffled.slice(0, ALBUM_CHOICES));
+        setGameState("albumSelection");
+      } catch (error) {
+        console.error("Failed to load albums:", error);
+        show({ type: "error", message: "Impossible de charger les albums" });
+      } finally {
+        setLoadingAlbum(false);
+      }
+    },
+    [show],
+  );
+
+  const startGameWithAlbum = useCallback(
+    async (album: DeezerAlbum) => {
+      if (!gameId || !user) {
+        setSessionError(true);
+        return;
+      }
+
+      setLoadingAlbum(true);
+
+      try {
+        const tracksResponse = await deezerAPI.getAlbumTracks(album.id);
+
+        if (!tracksResponse.data || tracksResponse.data.length < 5) {
+          show({
+            type: "warning",
+            message:
+              "Cet album n'a pas assez de titres. Choisissez-en un autre.",
+          });
+          return;
+        }
+
+        const gameAlbum: GameAlbum = {
+          album,
+          tracks: tracksResponse.data,
+        };
+
+        const gameData: TracklistGameData = {
+          genre: { id: 0, name: "Search" },
+          album: {
+            id: album.id,
+            title: album.title,
+            artistName: album.artist?.name ?? selectedArtist?.name ?? "",
+            coverUrl: album.cover_xl,
+            totalTracks: tracksResponse.data.length,
+          },
+          answers: [],
+          score: 0,
+          maxScore: tracksResponse.data.length,
+          timeElapsed: 0,
+          startedAt: new Date().toISOString(),
+          completedAt: "",
+        };
+
+        const session = await createGameSession({
+          gameId: parseInt(gameId, 10),
+          status: "active",
+          players: [{ userId: user.id }],
+          gameData: gameData as unknown as Record<string, unknown>,
+        });
+
+        setSessionId(session.id);
+        setValidatedAnswers([]);
+        setFoundTrackIds(new Set());
+        setCurrentInput("");
+        setCurrentAlbum(gameAlbum);
+        setTimeRemaining(GAME_DURATION);
+        setIsTimerRunning(true);
+        setGameState("playing");
+      } catch (error) {
+        console.error("Failed to start game:", error);
+        show({ type: "error", message: "Impossible de démarrer la partie" });
+      } finally {
+        setLoadingAlbum(false);
+      }
+    },
+    [gameId, user, selectedArtist, show],
+  );
+
+  const formatTime = (seconds: number): string => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, "0")}:${secs.toString().padStart(2, "0")}`;
+  };
+
+  const showFeedback = useCallback(
+    (type: "correct" | "wrong", message: string) => {
+      if (feedbackTimeoutRef.current) clearTimeout(feedbackTimeoutRef.current);
+      setAnswerFeedback({ type, message });
+      feedbackTimeoutRef.current = setTimeout(
+        () => setAnswerFeedback(null),
+        1500,
+      );
+    },
+    [],
+  );
+
+  const handleSubmitAnswer = useCallback(() => {
+    if (isProcessingAnswerRef.current) return;
+    const trimmed = currentInput.trim();
+    if (!trimmed || !currentAlbum) return;
+
+    isProcessingAnswerRef.current = true;
+
+    const matchedTrack = currentAlbum.tracks.find(
+      (track) =>
+        !foundTrackIds.has(track.id) &&
+        (fuzzyMatch(trimmed, track.title) ||
+          fuzzyMatch(trimmed, track.title_short)),
+    );
+
+    if (matchedTrack) {
+      const newFoundIds = new Set(foundTrackIds);
+      newFoundIds.add(matchedTrack.id);
+      setFoundTrackIds(newFoundIds);
+
+      const newAnswer: TrackAnswer = {
+        userInput: trimmed,
+        isCorrect: true,
+        matchedTrackId: matchedTrack.id,
+        timestamp: new Date().toISOString(),
+      };
+      const newAnswers = [...validatedAnswers, newAnswer];
+      setValidatedAnswers(newAnswers);
+      setCurrentInput("");
+      showFeedback("correct", `✓ ${matchedTrack.title}`);
+
+      if (newFoundIds.size === currentAlbum.tracks.length) {
+        void submitAnswers(newFoundIds, newAnswers);
+      }
+    } else {
+      setCurrentInput("");
+      triggerError();
+      showFeedback("wrong", "Essaie encore !");
+    }
+
+    isProcessingAnswerRef.current = false;
+  }, [
+    currentInput,
+    currentAlbum,
+    foundTrackIds,
+    validatedAnswers,
+    showFeedback,
+    submitAnswers,
+    triggerError,
+  ]);
+
+  const handleAbandon = useCallback(() => {
+    Alert.alert(
+      "Abandonner",
+      "Êtes-vous sûr de vouloir abandonner cette partie ?",
+      [
+        { text: "Non", style: "cancel" },
+        {
+          text: "Oui",
+          style: "destructive",
+          onPress: () => {
+            void submitAnswers();
+          },
+        },
+      ],
+    );
+  }, [submitAnswers]);
+
+  const resetGame = useCallback(() => {
+    if (gameId) {
+      void deleteGameState(gameId);
+    }
+    setGameState("artistSearch");
+    setCurrentAlbum(null);
+    setCandidateAlbums([]);
+    setSelectedArtist(null);
+    setSearchQuery("");
+    setSearchResults([]);
+    setCurrentInput("");
+    setFoundTrackIds(new Set());
+    setTimeRemaining(GAME_DURATION);
+    setIsTimerRunning(false);
+    setValidatedAnswers([]);
+    setSessionId(null);
+    setAnswerFeedback(null);
+  }, [gameId]);
+
+  const backToArtistSearch = useCallback(() => {
+    setGameState("artistSearch");
+  }, []);
+
+  return {
+    // State
+    gameState,
+    searchQuery,
+    searchResults,
+    topArtists,
+    isSearching,
+    isInitialLoading,
+    loadingAlbum,
+    candidateAlbums,
+    selectedArtist,
+    currentAlbum,
+    currentInput,
+    foundTrackIds,
+    answerFeedback,
+    timeRemaining,
+    sessionId,
+    sessionError,
+
+    // Error feedback
+    shakeAnimation,
+    borderOpacity,
+    errorAnimationsEnabled,
+
+    // Controlled input setters
+    setSearchQuery,
+    setCurrentInput,
+
+    // Handlers
+    handleSelectArtist,
+    startGameWithAlbum,
+    handleSubmitAnswer,
+    handleAbandon,
+    resetGame,
+    backToArtistSearch,
+    autoSave,
+    formatTime,
+  };
+}


### PR DESCRIPTION
## Description

Extraction de toute la logique métier du composant `app/(tabs)/games/tracklist/game.tsx` (auparavant 1375 lignes) dans un nouveau hook `app/(tabs)/games/tracklist/hooks/useTracklistGame.ts`. Le composant devient un orchestrateur qui délègue états, refs, handlers et effects (recherche d'artiste debouncée, sélection d'album, timer, autosave, reprise de partie, soumission) au hook. Refacto verbatim sans aucun changement de comportement ; prépare le terrain pour MIX-263 (découpage JSX en sous-composants par état).

## Parcours utilisateur

1. Ouvrir l'app et naviguer vers Jeux → Tracklist → démarrer une partie
2. Écran `artistSearch` : vérifier que les « Artistes populaires en France » (top 20) s'affichent au mount
3. Taper 3+ lettres dans la recherche → debounce 400ms puis affichage des résultats Deezer
4. Effacer la recherche via le bouton ✕ → retour à la liste des artistes populaires
5. Sélectionner un artiste → loading → écran `albumSelection` avec 6 albums
6. Cliquer « Retour » en haut → retour à `artistSearch` avec la recherche conservée
7. Re-sélectionner l'artiste puis un album → la partie démarre (timer 5:00, tracklist masquée)
8. Taper un titre correct → feedback vert « ✓ Titre » + track révélé + compteur mis à jour
9. Taper un titre faux → shake/border rouge + feedback « Essaie encore ! »
10. Quitter l'app et relancer avec `resume=true` → la partie reprend là où elle était (autosave)
11. Laisser le timer atteindre 0:00 → écran `result` avec score et comparaison
12. Tester « Abandonner » → confirmation → écran `result`
13. Cliquer « Rejouer » → reset complet et retour à `artistSearch`
14. Tester sans `gameId` / sans user → écran « Jeu indisponible »
15. Vérifier iOS et Android