### PR TITLE
MIX-263 refactor: extract useArtistSearch hook and ArtistSelector shared component

### DIFF
--- a/front-mobile/app/(tabs)/games/tracklist/game.tsx
+++ b/front-mobile/app/(tabs)/games/tracklist/game.tsx
@@ -1,35 +1,20 @@
-import { useRef } from "react";
-import {
-  ActivityIndicator,
-  FlatList,
-  Image,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
-  StyleSheet,
-  TextInput,
-  TouchableOpacity,
-  View,
-} from "react-native";
+import { StyleSheet, View } from "react-native";
 import { router } from "expo-router";
+import { MaterialIcons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/ThemedText";
 import Button from "@/components/Button";
-import GameLayout from "@/components/GameLayout";
 import Header from "@/components/Header";
-import { GameErrorFeedback } from "@/components/GameErrorFeedback";
 import { Colors } from "@/constants/Colors";
-import { MaterialIcons } from "@expo/vector-icons";
-import { useTracklistGame } from "./hooks/useTracklistGame";
+import { useTracklistGame } from "@/hooks/feature/tracklist/useTracklistGame";
+import TracklistArtistSearch from "@/components/feature/tracklist/TracklistArtistSearch";
+import TracklistAlbumStep from "@/components/feature/tracklist/TracklistAlbumStep";
+import TracklistPlayingScreen from "@/components/feature/tracklist/TracklistPlayingScreen";
+import TracklistResultScreen from "@/components/feature/tracklist/TracklistResultScreen";
 
 export default function TracklistGameScreen() {
-  const inputRef = useRef<TextInput>(null);
   const {
     gameState,
     searchQuery,
-    searchResults,
-    topArtists,
-    isSearching,
-    isInitialLoading,
     loadingAlbum,
     candidateAlbums,
     selectedArtist,
@@ -83,426 +68,61 @@ export default function TracklistGameScreen() {
 
   if (gameState === "artistSearch") {
     return (
-      <GameLayout title="Tracklist" sessionId={sessionId} onSave={autoSave}>
-        <View style={styles.container}>
-          <View style={styles.setupContainer}>
-            <ThemedText type="title" style={styles.title}>
-              Cherchez un artiste
-            </ThemedText>
-            <ThemedText style={styles.subtitle}>
-              Entrez le nom d&apos;un artiste pour tester vos connaissances
-            </ThemedText>
-
-            <View style={styles.searchContainer}>
-              <MaterialIcons
-                name="search"
-                size={24}
-                color={Colors.game.textMuted}
-                style={styles.searchIcon}
-              />
-              <TextInput
-                style={styles.searchInput}
-                placeholder="Rechercher un artiste..."
-                placeholderTextColor={Colors.game.textMuted}
-                value={searchQuery}
-                onChangeText={setSearchQuery}
-                autoCorrect={false}
-              />
-              {searchQuery.length > 0 && (
-                <TouchableOpacity
-                  onPress={() => setSearchQuery("")}
-                  style={styles.clearButton}
-                >
-                  <MaterialIcons
-                    name="close"
-                    size={20}
-                    color={Colors.game.textMuted}
-                  />
-                </TouchableOpacity>
-              )}
-            </View>
-
-            {isSearching || isInitialLoading ? (
-              <View style={styles.loadingContainer}>
-                <ActivityIndicator size="large" color={Colors.primary.survol} />
-              </View>
-            ) : (
-              <FlatList
-                data={
-                  searchQuery.trim().length >= 3 ? searchResults : topArtists
-                }
-                keyExtractor={(item) => item.id.toString()}
-                contentContainerStyle={styles.artistList}
-                keyboardShouldPersistTaps="handled"
-                ListHeaderComponent={
-                  searchQuery.trim().length < 3 && topArtists.length > 0 ? (
-                    <ThemedText style={styles.sectionTitle}>
-                      Artistes populaires en France
-                    </ThemedText>
-                  ) : null
-                }
-                renderItem={({ item }) => (
-                  <TouchableOpacity
-                    style={styles.artistListItem}
-                    onPress={() => handleSelectArtist(item)}
-                    disabled={loadingAlbum}
-                  >
-                    <Image
-                      source={{ uri: item.picture_medium }}
-                      style={styles.artistListImage}
-                    />
-                    <View style={styles.artistListInfo}>
-                      <ThemedText style={styles.artistListName}>
-                        {item.name}
-                      </ThemedText>
-                    </View>
-                    <MaterialIcons
-                      name="chevron-right"
-                      size={24}
-                      color={Colors.game.textMuted}
-                    />
-                  </TouchableOpacity>
-                )}
-                ListEmptyComponent={
-                  searchQuery.trim().length >= 3 ? (
-                    <ThemedText style={styles.emptyText}>
-                      Aucun artiste trouvé
-                    </ThemedText>
-                  ) : searchQuery.trim().length < 3 && !isInitialLoading ? (
-                    <ThemedText style={styles.emptyText}>
-                      Aucune suggestion disponible
-                    </ThemedText>
-                  ) : null
-                }
-              />
-            )}
-
-            {loadingAlbum && (
-              <View style={styles.loadingOverlay}>
-                <ActivityIndicator size="large" color={Colors.primary.survol} />
-                <ThemedText style={styles.loadingText}>
-                  Chargement des albums...
-                </ThemedText>
-              </View>
-            )}
-          </View>
-        </View>
-      </GameLayout>
+      <TracklistArtistSearch
+        sessionId={sessionId}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        loadingAlbum={loadingAlbum}
+        onSelectArtist={handleSelectArtist}
+        onSave={autoSave}
+      />
     );
   }
 
   if (gameState === "albumSelection") {
     return (
-      <GameLayout
-        title="Tracklist"
+      <TracklistAlbumStep
         sessionId={sessionId}
-        onSave={autoSave}
+        selectedArtist={selectedArtist}
+        candidateAlbums={candidateAlbums}
+        loadingAlbum={loadingAlbum}
+        onSelectAlbum={startGameWithAlbum}
         onBack={backToArtistSearch}
-      >
-        <View style={styles.container}>
-          <View style={styles.setupContainer}>
-            <ThemedText type="title" style={styles.title}>
-              Choisissez un album
-            </ThemedText>
-            <ThemedText style={styles.subtitle}>
-              {selectedArtist?.name} — Quel album veux-tu trouver ?
-            </ThemedText>
-
-            <FlatList
-              key="albums"
-              data={candidateAlbums}
-              numColumns={2}
-              keyExtractor={(item) => item.id.toString()}
-              contentContainerStyle={styles.genreGrid}
-              renderItem={({ item }) => (
-                <TouchableOpacity
-                  style={styles.albumChoiceCard}
-                  onPress={() => startGameWithAlbum(item)}
-                  disabled={loadingAlbum}
-                  accessibilityLabel={`Album ${item.title} de ${item.artist?.name ?? selectedArtist?.name}`}
-                  accessibilityRole="button"
-                >
-                  <Image
-                    source={{ uri: item.cover_medium }}
-                    style={styles.albumChoiceCover}
-                  />
-                  <View style={styles.albumChoiceInfo}>
-                    <ThemedText
-                      style={styles.albumChoiceTitle}
-                      numberOfLines={2}
-                    >
-                      {item.title}
-                    </ThemedText>
-                    <ThemedText
-                      style={styles.albumChoiceArtist}
-                      numberOfLines={1}
-                    >
-                      {item.artist?.name ?? selectedArtist?.name}
-                    </ThemedText>
-                  </View>
-                </TouchableOpacity>
-              )}
-            />
-
-            {loadingAlbum && (
-              <View style={styles.loadingOverlay}>
-                <ActivityIndicator size="large" color={Colors.primary.survol} />
-                <ThemedText style={styles.loadingText}>
-                  Chargement de l&apos;album...
-                </ThemedText>
-              </View>
-            )}
-          </View>
-        </View>
-      </GameLayout>
+        onSave={autoSave}
+      />
     );
   }
 
   if (gameState === "playing" && currentAlbum) {
-    const foundCount = foundTrackIds.size;
-    const totalCount = currentAlbum.tracks.length;
-
     return (
-      <GameErrorFeedback
+      <TracklistPlayingScreen
+        sessionId={sessionId}
+        currentAlbum={currentAlbum}
+        selectedArtist={selectedArtist}
+        foundTrackIds={foundTrackIds}
+        currentInput={currentInput}
+        setCurrentInput={setCurrentInput}
+        answerFeedback={answerFeedback}
+        timeRemaining={timeRemaining}
+        formatTime={formatTime}
         shakeAnimation={shakeAnimation}
         borderOpacity={borderOpacity}
-        errorMessage={null}
-        animationsEnabled={errorAnimationsEnabled}
-      >
-        <GameLayout title="Tracklist" sessionId={sessionId} onSave={autoSave}>
-          <KeyboardAvoidingView
-            style={styles.container}
-            behavior={Platform.OS === "ios" ? "padding" : "height"}
-            keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 20}
-          >
-            <View style={styles.badgeRow}>
-              <View style={styles.badge}>
-                <ThemedText style={styles.badgeText}>
-                  {foundCount}/{totalCount}{" "}
-                  {foundCount > 1 ? "TROUVÉS" : "TROUVÉ"}
-                </ThemedText>
-              </View>
-              <View
-                style={[
-                  styles.badge,
-                  timeRemaining < 60 && styles.badgeWarning,
-                ]}
-              >
-                <MaterialIcons
-                  name="timer"
-                  size={14}
-                  color={
-                    timeRemaining < 60
-                      ? Colors.game.warning
-                      : Colors.primary.survol
-                  }
-                />
-                <ThemedText
-                  style={[
-                    styles.badgeText,
-                    timeRemaining < 60 && styles.badgeTextWarning,
-                  ]}
-                >
-                  {formatTime(timeRemaining)}
-                </ThemedText>
-              </View>
-            </View>
-            <ScrollView
-              style={styles.trackList}
-              contentContainerStyle={styles.trackListContent}
-              keyboardShouldPersistTaps="handled"
-            >
-              <View style={styles.albumCard}>
-                <Image
-                  source={{ uri: currentAlbum.album.cover_xl }}
-                  style={styles.coverImage}
-                />
-                <ThemedText style={styles.albumTitle}>
-                  {currentAlbum.album.title}
-                </ThemedText>
-                <ThemedText style={styles.artistName}>
-                  {currentAlbum.album.artist?.name ?? selectedArtist?.name}
-                </ThemedText>
-                <TouchableOpacity
-                  style={styles.abandonButtonSmall}
-                  onPress={handleAbandon}
-                >
-                  <ThemedText style={styles.abandonText}>Abandonner</ThemedText>
-                </TouchableOpacity>
-              </View>
-
-              {currentAlbum.tracks.map((track, index) => {
-                const isFound = foundTrackIds.has(track.id);
-                return (
-                  <View key={track.id} style={styles.trackItem}>
-                    <ThemedText style={styles.trackNumber}>
-                      {index + 1}.
-                    </ThemedText>
-                    {isFound ? (
-                      <>
-                        <ThemedText style={styles.trackFound}>
-                          {track.title}
-                        </ThemedText>
-                        <MaterialIcons
-                          name="check-circle"
-                          size={16}
-                          color={Colors.game.success}
-                        />
-                      </>
-                    ) : (
-                      <ThemedText style={styles.trackHidden}>
-                        {track.title
-                          .split(" ")
-                          .map(
-                            (word) =>
-                              word.charAt(0).toUpperCase() +
-                              "_".repeat(Math.max(0, word.length - 1)),
-                          )
-                          .join(" ")}
-                      </ThemedText>
-                    )}
-                  </View>
-                );
-              })}
-            </ScrollView>
-
-            <View style={styles.inputWrapper}>
-              {answerFeedback && (
-                <View
-                  style={[
-                    styles.feedbackBanner,
-                    answerFeedback.type === "correct"
-                      ? styles.feedbackCorrect
-                      : styles.feedbackWrong,
-                  ]}
-                >
-                  <ThemedText style={styles.feedbackText}>
-                    {answerFeedback.message}
-                  </ThemedText>
-                </View>
-              )}
-              <View style={styles.inputContainer}>
-                <TextInput
-                  ref={inputRef}
-                  style={styles.singleInput}
-                  placeholder="Tape un son..."
-                  placeholderTextColor={Colors.game.textSubtle}
-                  value={currentInput}
-                  onChangeText={setCurrentInput}
-                  onSubmitEditing={handleSubmitAnswer}
-                  autoCorrect={false}
-                  autoCapitalize="words"
-                  returnKeyType="send"
-                  blurOnSubmit={false}
-                  accessibilityLabel="Saisir un titre de l'album"
-                  accessibilityHint="Entrez un titre de chanson de l'album pour valider votre réponse"
-                />
-                <TouchableOpacity
-                  style={styles.sendButton}
-                  onPress={handleSubmitAnswer}
-                  accessibilityLabel="Valider la réponse"
-                  accessibilityRole="button"
-                >
-                  <MaterialIcons
-                    name="send"
-                    size={22}
-                    color={Colors.primary.survol}
-                  />
-                </TouchableOpacity>
-              </View>
-            </View>
-          </KeyboardAvoidingView>
-        </GameLayout>
-      </GameErrorFeedback>
+        errorAnimationsEnabled={errorAnimationsEnabled}
+        onSubmitAnswer={handleSubmitAnswer}
+        onAbandon={handleAbandon}
+        onSave={autoSave}
+      />
     );
   }
 
   if (gameState === "result" && currentAlbum) {
-    const score = foundTrackIds.size;
-    const maxScore = currentAlbum.tracks.length;
-    const percentage = Math.round((score / maxScore) * 100);
-
     return (
-      <>
-        <Header title="Tracklist" variant="withBack" />
-        <ScrollView
-          style={styles.container}
-          contentContainerStyle={styles.resultContent}
-        >
-          <View style={styles.resultHeader}>
-            <ThemedText type="title" style={styles.resultTitle}>
-              {percentage >= 75
-                ? "Excellent ! 🎉"
-                : percentage >= 50
-                  ? "Bien joué ! 👍"
-                  : "Continuez à vous entraîner ! 💪"}
-            </ThemedText>
-
-            <View style={styles.scoreCard}>
-              <ThemedText style={styles.scoreText}>
-                {score} / {maxScore}
-              </ThemedText>
-              <ThemedText style={styles.scoreLabel}>
-                Titres trouvés ({percentage}%)
-              </ThemedText>
-            </View>
-
-            <View style={styles.albumReveal}>
-              <Image
-                source={{ uri: currentAlbum.album.cover_xl }}
-                style={styles.revealImage}
-              />
-              <ThemedText style={styles.revealAlbumTitle}>
-                {currentAlbum.album.title}
-              </ThemedText>
-              <ThemedText style={styles.revealArtistName}>
-                {currentAlbum.album.artist?.name ?? selectedArtist?.name}
-              </ThemedText>
-            </View>
-          </View>
-
-          <View style={styles.comparisonSection}>
-            <ThemedText style={styles.comparisonTitle}>
-              Titres de l&apos;album
-            </ThemedText>
-            <View style={styles.trackResultList}>
-              {currentAlbum.tracks.map((track, index) => {
-                const isFound = foundTrackIds.has(track.id);
-                return (
-                  <View key={track.id} style={styles.trackResultItem}>
-                    <MaterialIcons
-                      name={isFound ? "check-circle" : "cancel"}
-                      size={20}
-                      color={isFound ? Colors.game.success : Colors.game.error}
-                    />
-                    <ThemedText style={styles.trackResultNumber}>
-                      {index + 1}.
-                    </ThemedText>
-                    <ThemedText
-                      style={[
-                        styles.trackResultText,
-                        isFound && styles.answerCorrect,
-                        !isFound && styles.answerIncorrect,
-                      ]}
-                    >
-                      {track.title}
-                    </ThemedText>
-                  </View>
-                );
-              })}
-            </View>
-          </View>
-
-          <View style={styles.resultActions}>
-            <Button title="Rejouer" onPress={resetGame} />
-            <Button
-              title="Retour aux jeux"
-              variant="outline"
-              onPress={() => router.push("/games")}
-            />
-          </View>
-        </ScrollView>
-      </>
+      <TracklistResultScreen
+        currentAlbum={currentAlbum}
+        selectedArtist={selectedArtist}
+        foundTrackIds={foundTrackIds}
+        onReplay={resetGame}
+      />
     );
   }
 
@@ -510,370 +130,6 @@ export default function TracklistGameScreen() {
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: Colors.primary.fondPremier,
-  },
-  setupContainer: {
-    flex: 1,
-    padding: 20,
-  },
-  title: {
-    textAlign: "center",
-    marginBottom: 10,
-    marginTop: 20,
-  },
-  subtitle: {
-    textAlign: "center",
-    color: Colors.game.textMuted,
-    fontSize: 16,
-    marginBottom: 20,
-  },
-  searchContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
-    borderRadius: 12,
-    paddingHorizontal: 12,
-    marginBottom: 20,
-    borderWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.1)",
-  },
-  searchIcon: {
-    marginRight: 8,
-  },
-  searchInput: {
-    flex: 1,
-    height: 50,
-    color: Colors.dark.text,
-    fontSize: 16,
-  },
-  artistList: {
-    paddingBottom: 20,
-  },
-  sectionTitle: {
-    fontSize: 18,
-    fontWeight: "bold",
-    color: "white",
-    marginTop: 10,
-    marginBottom: 15,
-  },
-  artistListItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
-    borderRadius: 12,
-    padding: 12,
-    marginBottom: 10,
-    borderWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.1)",
-  },
-  artistListImage: {
-    width: 60,
-    height: 60,
-    borderRadius: 30,
-    marginRight: 15,
-  },
-  artistListInfo: {
-    flex: 1,
-  },
-  artistListName: {
-    fontSize: 18,
-    fontWeight: "600",
-    color: Colors.dark.text,
-  },
-  emptyText: {
-    textAlign: "center",
-    color: Colors.game.textMuted,
-    marginTop: 40,
-    fontSize: 16,
-  },
-  loadingContainer: {
-    flex: 1,
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  genreGrid: {
-    paddingBottom: 20,
-  },
-  clearButton: {
-    padding: 8,
-  },
-  loadingOverlay: {
-    ...StyleSheet.absoluteFillObject,
-    backgroundColor: "rgba(0, 0, 0, 0.8)",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  loadingText: {
-    color: "white",
-    marginTop: 15,
-    fontSize: 16,
-  },
-  albumChoiceCard: {
-    flex: 1,
-    margin: 8,
-    borderRadius: 12,
-    overflow: "hidden",
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
-    borderWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.08)",
-  },
-  albumChoiceCover: {
-    width: "100%",
-    aspectRatio: 1,
-  },
-  albumChoiceInfo: {
-    padding: 8,
-  },
-  albumChoiceTitle: {
-    color: "white",
-    fontSize: 13,
-    fontWeight: "600",
-    marginBottom: 2,
-  },
-  albumChoiceArtist: {
-    color: Colors.game.textMuted,
-    fontSize: 12,
-  },
-  badgeRow: {
-    flexDirection: "row",
-    justifyContent: "center",
-    gap: 12,
-    paddingVertical: 12,
-    paddingHorizontal: 20,
-    backgroundColor: "rgba(0, 0, 0, 0.5)",
-  },
-  badge: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    backgroundColor: "rgba(255, 255, 255, 0.08)",
-    paddingHorizontal: 16,
-    paddingVertical: 8,
-    borderRadius: 20,
-    borderWidth: 1,
-    borderColor: Colors.primary.survol,
-  },
-  badgeWarning: {
-    borderColor: Colors.game.warning,
-  },
-  badgeText: {
-    color: Colors.primary.survol,
-    fontSize: 13,
-    fontWeight: "bold",
-  },
-  badgeTextWarning: {
-    color: Colors.game.warning,
-  },
-  albumCard: {
-    alignItems: "center",
-    paddingHorizontal: 20,
-    paddingVertical: 14,
-    backgroundColor: "rgba(0, 0, 0, 0.3)",
-  },
-  coverImage: {
-    width: 100,
-    height: 100,
-    borderRadius: 10,
-    marginBottom: 10,
-  },
-  albumTitle: {
-    color: "white",
-    fontSize: 16,
-    fontWeight: "bold",
-    textAlign: "center",
-    marginBottom: 2,
-  },
-  artistName: {
-    color: Colors.game.textMuted,
-    fontSize: 14,
-    textAlign: "center",
-    marginBottom: 10,
-  },
-  abandonButtonSmall: {
-    paddingHorizontal: 16,
-    paddingVertical: 6,
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: "rgba(255, 107, 107, 0.5)",
-  },
-  abandonText: {
-    color: Colors.game.warning,
-    fontSize: 13,
-  },
-  trackList: {
-    flex: 1,
-  },
-  trackListContent: {
-    paddingHorizontal: 20,
-    paddingVertical: 12,
-    paddingBottom: 20,
-  },
-  trackItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    paddingVertical: 8,
-    borderBottomWidth: 1,
-    borderBottomColor: "rgba(255, 255, 255, 0.06)",
-  },
-  trackNumber: {
-    color: Colors.game.textSubtle,
-    fontSize: 14,
-    minWidth: 28,
-  },
-  trackFound: {
-    color: Colors.game.success,
-    fontSize: 15,
-    fontWeight: "600",
-    flex: 1,
-  },
-  trackHidden: {
-    color: Colors.game.textSubtle,
-    fontSize: 15,
-    flex: 1,
-    letterSpacing: 2,
-  },
-  inputWrapper: {
-    backgroundColor: "rgba(0, 0, 0, 0.9)",
-    borderTopWidth: 1,
-    borderTopColor: "rgba(255, 255, 255, 0.1)",
-  },
-  feedbackBanner: {
-    paddingHorizontal: 20,
-    paddingVertical: 8,
-    alignItems: "center",
-  },
-  feedbackCorrect: {
-    backgroundColor: "rgba(76, 175, 80, 0.15)",
-  },
-  feedbackWrong: {
-    backgroundColor: "rgba(244, 67, 54, 0.15)",
-  },
-  feedbackText: {
-    fontSize: 14,
-    fontWeight: "600",
-  },
-  inputContainer: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-  },
-  singleInput: {
-    flex: 1,
-    backgroundColor: "rgba(255, 255, 255, 0.1)",
-    borderRadius: 24,
-    paddingHorizontal: 18,
-    paddingVertical: 12,
-    color: "white",
-    fontSize: 16,
-    borderWidth: 1,
-    borderColor: "rgba(255, 255, 255, 0.2)",
-  },
-  sendButton: {
-    width: 44,
-    height: 44,
-    borderRadius: 22,
-    backgroundColor: "rgba(255, 255, 255, 0.08)",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  resultContent: {
-    padding: 20,
-    paddingBottom: 40,
-  },
-  resultHeader: {
-    alignItems: "center",
-    marginBottom: 30,
-  },
-  resultTitle: {
-    textAlign: "center",
-    marginBottom: 20,
-  },
-  scoreCard: {
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
-    padding: 20,
-    borderRadius: 16,
-    alignItems: "center",
-    marginBottom: 20,
-    borderWidth: 2,
-    borderColor: Colors.primary.survol,
-  },
-  scoreText: {
-    color: Colors.primary.survol,
-    fontSize: 48,
-    fontWeight: "bold",
-    lineHeight: 58,
-  },
-  scoreLabel: {
-    color: "white",
-    fontSize: 16,
-    marginTop: 5,
-  },
-  albumReveal: {
-    alignItems: "center",
-  },
-  revealImage: {
-    width: 180,
-    height: 180,
-    borderRadius: 12,
-    marginBottom: 15,
-  },
-  revealAlbumTitle: {
-    color: "white",
-    fontSize: 18,
-    fontWeight: "bold",
-    textAlign: "center",
-    marginBottom: 5,
-  },
-  revealArtistName: {
-    color: Colors.game.textMuted,
-    fontSize: 16,
-    textAlign: "center",
-  },
-  comparisonSection: {
-    marginBottom: 30,
-  },
-  comparisonTitle: {
-    color: "white",
-    fontSize: 20,
-    fontWeight: "bold",
-    marginBottom: 15,
-    textAlign: "center",
-  },
-  trackResultList: {
-    backgroundColor: "rgba(255, 255, 255, 0.05)",
-    borderRadius: 12,
-    padding: 15,
-  },
-  trackResultItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    marginBottom: 10,
-  },
-  trackResultNumber: {
-    color: Colors.game.textMuted,
-    fontSize: 14,
-    minWidth: 25,
-  },
-  trackResultText: {
-    fontSize: 14,
-    flex: 1,
-  },
-  answerCorrect: {
-    color: Colors.game.success,
-    fontWeight: "bold",
-  },
-  answerIncorrect: {
-    color: Colors.game.error,
-  },
-  resultActions: {
-    gap: 12,
-  },
   errorContainer: {
     flex: 1,
     backgroundColor: Colors.primary.fondPremier,

--- a/front-mobile/components/ArtistSelector.tsx
+++ b/front-mobile/components/ArtistSelector.tsx
@@ -47,11 +47,13 @@ export default function ArtistSelector({
           value={query}
           onChangeText={onQueryChange}
           autoCorrect={false}
+          editable={!disabled}
         />
         {query.length > 0 && (
           <TouchableOpacity
             onPress={() => onQueryChange("")}
             style={styles.clearButton}
+            disabled={disabled}
           >
             <MaterialIcons
               name="close"

--- a/front-mobile/components/ArtistSelector.tsx
+++ b/front-mobile/components/ArtistSelector.tsx
@@ -1,0 +1,185 @@
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import { DeezerArtist } from "@/services/deezer-api";
+import { useArtistSearch } from "@/hooks/useArtistSearch";
+
+interface ArtistSelectorProps {
+  query: string;
+  onQueryChange: (query: string) => void;
+  onSelect: (artist: DeezerArtist) => void;
+  disabled?: boolean;
+}
+
+export default function ArtistSelector({
+  query,
+  onQueryChange,
+  onSelect,
+  disabled = false,
+}: ArtistSelectorProps) {
+  const { topArtists, searchResults, isSearching, isInitialLoading, hasQuery } =
+    useArtistSearch(query);
+
+  const data = hasQuery ? searchResults : topArtists;
+
+  return (
+    <>
+      <View style={styles.searchContainer}>
+        <MaterialIcons
+          name="search"
+          size={24}
+          color={Colors.game.textMuted}
+          style={styles.searchIcon}
+        />
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Rechercher un artiste..."
+          placeholderTextColor={Colors.game.textMuted}
+          value={query}
+          onChangeText={onQueryChange}
+          autoCorrect={false}
+        />
+        {query.length > 0 && (
+          <TouchableOpacity
+            onPress={() => onQueryChange("")}
+            style={styles.clearButton}
+          >
+            <MaterialIcons
+              name="close"
+              size={20}
+              color={Colors.game.textMuted}
+            />
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {isSearching || isInitialLoading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.primary.survol} />
+        </View>
+      ) : (
+        <FlatList
+          data={data}
+          keyExtractor={(item) => item.id.toString()}
+          contentContainerStyle={styles.artistList}
+          keyboardShouldPersistTaps="handled"
+          ListHeaderComponent={
+            !hasQuery && topArtists.length > 0 ? (
+              <ThemedText style={styles.sectionTitle}>
+                Artistes populaires en France
+              </ThemedText>
+            ) : null
+          }
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              style={styles.artistListItem}
+              onPress={() => onSelect(item)}
+              disabled={disabled}
+            >
+              <Image
+                source={{ uri: item.picture_medium }}
+                style={styles.artistListImage}
+              />
+              <View style={styles.artistListInfo}>
+                <ThemedText style={styles.artistListName}>
+                  {item.name}
+                </ThemedText>
+              </View>
+              <MaterialIcons
+                name="chevron-right"
+                size={24}
+                color={Colors.game.textMuted}
+              />
+            </TouchableOpacity>
+          )}
+          ListEmptyComponent={
+            <ThemedText style={styles.emptyText}>
+              {hasQuery
+                ? "Aucun artiste trouvé"
+                : "Aucune suggestion disponible"}
+            </ThemedText>
+          }
+        />
+      )}
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  searchContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 12,
+    paddingHorizontal: 12,
+    marginBottom: 20,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+  },
+  searchIcon: {
+    marginRight: 8,
+  },
+  searchInput: {
+    flex: 1,
+    height: 50,
+    color: Colors.dark.text,
+    fontSize: 16,
+  },
+  clearButton: {
+    padding: 8,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  artistList: {
+    paddingBottom: 20,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+    color: "white",
+    marginTop: 10,
+    marginBottom: 15,
+  },
+  artistListItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 10,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.1)",
+  },
+  artistListImage: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    marginRight: 15,
+  },
+  artistListInfo: {
+    flex: 1,
+  },
+  artistListName: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: Colors.dark.text,
+  },
+  emptyText: {
+    textAlign: "center",
+    color: Colors.game.textMuted,
+    marginTop: 40,
+    fontSize: 16,
+  },
+});

--- a/front-mobile/components/feature/tracklist/TracklistAlbumStep.tsx
+++ b/front-mobile/components/feature/tracklist/TracklistAlbumStep.tsx
@@ -30,6 +30,7 @@ export default function TracklistAlbumStep({
   onBack,
   onSave,
 }: TracklistAlbumStepProps) {
+  const artistName = selectedArtist?.name ?? "cet artiste";
   return (
     <GameLayout
       title="Tracklist"
@@ -43,7 +44,7 @@ export default function TracklistAlbumStep({
             Choisissez un album
           </ThemedText>
           <ThemedText style={styles.subtitle}>
-            {selectedArtist?.name} — Quel album veux-tu trouver ?
+            {artistName} — Quel album veux-tu trouver ?
           </ThemedText>
 
           <FlatList
@@ -57,7 +58,7 @@ export default function TracklistAlbumStep({
                 style={styles.albumChoiceCard}
                 onPress={() => onSelectAlbum(item)}
                 disabled={loadingAlbum}
-                accessibilityLabel={`Album ${item.title} de ${item.artist?.name ?? selectedArtist?.name}`}
+                accessibilityLabel={`Album ${item.title} de ${item.artist?.name ?? artistName}`}
                 accessibilityRole="button"
               >
                 <Image
@@ -72,7 +73,7 @@ export default function TracklistAlbumStep({
                     style={styles.albumChoiceArtist}
                     numberOfLines={1}
                   >
-                    {item.artist?.name ?? selectedArtist?.name}
+                    {item.artist?.name ?? artistName}
                   </ThemedText>
                 </View>
               </TouchableOpacity>

--- a/front-mobile/components/feature/tracklist/TracklistAlbumStep.tsx
+++ b/front-mobile/components/feature/tracklist/TracklistAlbumStep.tsx
@@ -1,0 +1,156 @@
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import GameLayout from "@/components/GameLayout";
+import { Colors } from "@/constants/Colors";
+import { DeezerAlbum, DeezerArtist } from "@/services/deezer-api";
+
+interface TracklistAlbumStepProps {
+  sessionId: string | null;
+  selectedArtist: DeezerArtist | null;
+  candidateAlbums: DeezerAlbum[];
+  loadingAlbum: boolean;
+  onSelectAlbum: (album: DeezerAlbum) => Promise<void>;
+  onBack: () => void;
+  onSave: () => Promise<void>;
+}
+
+export default function TracklistAlbumStep({
+  sessionId,
+  selectedArtist,
+  candidateAlbums,
+  loadingAlbum,
+  onSelectAlbum,
+  onBack,
+  onSave,
+}: TracklistAlbumStepProps) {
+  return (
+    <GameLayout
+      title="Tracklist"
+      sessionId={sessionId}
+      onSave={onSave}
+      onBack={onBack}
+    >
+      <View style={styles.container}>
+        <View style={styles.setupContainer}>
+          <ThemedText type="title" style={styles.title}>
+            Choisissez un album
+          </ThemedText>
+          <ThemedText style={styles.subtitle}>
+            {selectedArtist?.name} — Quel album veux-tu trouver ?
+          </ThemedText>
+
+          <FlatList
+            key="albums"
+            data={candidateAlbums}
+            numColumns={2}
+            keyExtractor={(item) => item.id.toString()}
+            contentContainerStyle={styles.genreGrid}
+            renderItem={({ item }) => (
+              <TouchableOpacity
+                style={styles.albumChoiceCard}
+                onPress={() => onSelectAlbum(item)}
+                disabled={loadingAlbum}
+                accessibilityLabel={`Album ${item.title} de ${item.artist?.name ?? selectedArtist?.name}`}
+                accessibilityRole="button"
+              >
+                <Image
+                  source={{ uri: item.cover_medium }}
+                  style={styles.albumChoiceCover}
+                />
+                <View style={styles.albumChoiceInfo}>
+                  <ThemedText style={styles.albumChoiceTitle} numberOfLines={2}>
+                    {item.title}
+                  </ThemedText>
+                  <ThemedText
+                    style={styles.albumChoiceArtist}
+                    numberOfLines={1}
+                  >
+                    {item.artist?.name ?? selectedArtist?.name}
+                  </ThemedText>
+                </View>
+              </TouchableOpacity>
+            )}
+          />
+
+          {loadingAlbum && (
+            <View style={styles.loadingOverlay}>
+              <ActivityIndicator size="large" color={Colors.primary.survol} />
+              <ThemedText style={styles.loadingText}>
+                Chargement de l&apos;album...
+              </ThemedText>
+            </View>
+          )}
+        </View>
+      </View>
+    </GameLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+  },
+  setupContainer: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: 10,
+    marginTop: 20,
+  },
+  subtitle: {
+    textAlign: "center",
+    color: Colors.game.textMuted,
+    fontSize: 16,
+    marginBottom: 20,
+  },
+  genreGrid: {
+    paddingBottom: 20,
+  },
+  albumChoiceCard: {
+    flex: 1,
+    margin: 8,
+    borderRadius: 12,
+    overflow: "hidden",
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.08)",
+  },
+  albumChoiceCover: {
+    width: "100%",
+    aspectRatio: 1,
+  },
+  albumChoiceInfo: {
+    padding: 8,
+  },
+  albumChoiceTitle: {
+    color: "white",
+    fontSize: 13,
+    fontWeight: "600",
+    marginBottom: 2,
+  },
+  albumChoiceArtist: {
+    color: Colors.game.textMuted,
+    fontSize: 12,
+  },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0, 0, 0, 0.8)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  loadingText: {
+    color: "white",
+    marginTop: 15,
+    fontSize: 16,
+  },
+});

--- a/front-mobile/components/feature/tracklist/TracklistArtistSearch.tsx
+++ b/front-mobile/components/feature/tracklist/TracklistArtistSearch.tsx
@@ -1,0 +1,88 @@
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import GameLayout from "@/components/GameLayout";
+import ArtistSelector from "@/components/ArtistSelector";
+import { Colors } from "@/constants/Colors";
+import { DeezerArtist } from "@/services/deezer-api";
+
+interface TracklistArtistSearchProps {
+  sessionId: string | null;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  loadingAlbum: boolean;
+  onSelectArtist: (artist: DeezerArtist) => void;
+  onSave: () => Promise<void>;
+}
+
+export default function TracklistArtistSearch({
+  sessionId,
+  searchQuery,
+  setSearchQuery,
+  loadingAlbum,
+  onSelectArtist,
+  onSave,
+}: TracklistArtistSearchProps) {
+  return (
+    <GameLayout title="Tracklist" sessionId={sessionId} onSave={onSave}>
+      <View style={styles.container}>
+        <View style={styles.setupContainer}>
+          <ThemedText type="title" style={styles.title}>
+            Cherchez un artiste
+          </ThemedText>
+          <ThemedText style={styles.subtitle}>
+            Entrez le nom d&apos;un artiste pour tester vos connaissances
+          </ThemedText>
+
+          <ArtistSelector
+            query={searchQuery}
+            onQueryChange={setSearchQuery}
+            onSelect={onSelectArtist}
+            disabled={loadingAlbum}
+          />
+
+          {loadingAlbum && (
+            <View style={styles.loadingOverlay}>
+              <ActivityIndicator size="large" color={Colors.primary.survol} />
+              <ThemedText style={styles.loadingText}>
+                Chargement des albums...
+              </ThemedText>
+            </View>
+          )}
+        </View>
+      </View>
+    </GameLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+  },
+  setupContainer: {
+    flex: 1,
+    padding: 20,
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: 10,
+    marginTop: 20,
+  },
+  subtitle: {
+    textAlign: "center",
+    color: Colors.game.textMuted,
+    fontSize: 16,
+    marginBottom: 20,
+  },
+  loadingOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0, 0, 0, 0.8)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  loadingText: {
+    color: "white",
+    marginTop: 15,
+    fontSize: 16,
+  },
+});

--- a/front-mobile/components/feature/tracklist/TracklistPlayingScreen.tsx
+++ b/front-mobile/components/feature/tracklist/TracklistPlayingScreen.tsx
@@ -1,0 +1,362 @@
+import {
+  Animated,
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/ThemedText";
+import GameLayout from "@/components/GameLayout";
+import { GameErrorFeedback } from "@/components/GameErrorFeedback";
+import { Colors } from "@/constants/Colors";
+import { DeezerArtist } from "@/services/deezer-api";
+import {
+  AnswerFeedback,
+  GameAlbum,
+} from "@/hooks/feature/tracklist/useTracklistGame";
+
+interface TracklistPlayingScreenProps {
+  sessionId: string | null;
+  currentAlbum: GameAlbum;
+  selectedArtist: DeezerArtist | null;
+  foundTrackIds: Set<number>;
+  currentInput: string;
+  setCurrentInput: (value: string) => void;
+  answerFeedback: AnswerFeedback | null;
+  timeRemaining: number;
+  formatTime: (seconds: number) => string;
+  shakeAnimation: Animated.Value;
+  borderOpacity: Animated.Value;
+  errorAnimationsEnabled: boolean;
+  onSubmitAnswer: () => void;
+  onAbandon: () => void;
+  onSave: () => Promise<void>;
+}
+
+export default function TracklistPlayingScreen({
+  sessionId,
+  currentAlbum,
+  selectedArtist,
+  foundTrackIds,
+  currentInput,
+  setCurrentInput,
+  answerFeedback,
+  timeRemaining,
+  formatTime,
+  shakeAnimation,
+  borderOpacity,
+  errorAnimationsEnabled,
+  onSubmitAnswer,
+  onAbandon,
+  onSave,
+}: TracklistPlayingScreenProps) {
+  const foundCount = foundTrackIds.size;
+  const totalCount = currentAlbum.tracks.length;
+
+  return (
+    <GameErrorFeedback
+      shakeAnimation={shakeAnimation}
+      borderOpacity={borderOpacity}
+      errorMessage={null}
+      animationsEnabled={errorAnimationsEnabled}
+    >
+      <GameLayout title="Tracklist" sessionId={sessionId} onSave={onSave}>
+        <KeyboardAvoidingView
+          style={styles.container}
+          behavior={Platform.OS === "ios" ? "padding" : "height"}
+          keyboardVerticalOffset={Platform.OS === "ios" ? 0 : 20}
+        >
+          <View style={styles.badgeRow}>
+            <View style={styles.badge}>
+              <ThemedText style={styles.badgeText}>
+                {foundCount}/{totalCount}{" "}
+                {foundCount > 1 ? "TROUVÉS" : "TROUVÉ"}
+              </ThemedText>
+            </View>
+            <View
+              style={[styles.badge, timeRemaining < 60 && styles.badgeWarning]}
+            >
+              <MaterialIcons
+                name="timer"
+                size={14}
+                color={
+                  timeRemaining < 60
+                    ? Colors.game.warning
+                    : Colors.primary.survol
+                }
+              />
+              <ThemedText
+                style={[
+                  styles.badgeText,
+                  timeRemaining < 60 && styles.badgeTextWarning,
+                ]}
+              >
+                {formatTime(timeRemaining)}
+              </ThemedText>
+            </View>
+          </View>
+          <ScrollView
+            style={styles.trackList}
+            contentContainerStyle={styles.trackListContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={styles.albumCard}>
+              <Image
+                source={{ uri: currentAlbum.album.cover_xl }}
+                style={styles.coverImage}
+              />
+              <ThemedText style={styles.albumTitle}>
+                {currentAlbum.album.title}
+              </ThemedText>
+              <ThemedText style={styles.artistName}>
+                {currentAlbum.album.artist?.name ?? selectedArtist?.name}
+              </ThemedText>
+              <TouchableOpacity
+                style={styles.abandonButtonSmall}
+                onPress={onAbandon}
+              >
+                <ThemedText style={styles.abandonText}>Abandonner</ThemedText>
+              </TouchableOpacity>
+            </View>
+
+            {currentAlbum.tracks.map((track, index) => {
+              const isFound = foundTrackIds.has(track.id);
+              return (
+                <View key={track.id} style={styles.trackItem}>
+                  <ThemedText style={styles.trackNumber}>
+                    {index + 1}.
+                  </ThemedText>
+                  {isFound ? (
+                    <>
+                      <ThemedText style={styles.trackFound}>
+                        {track.title}
+                      </ThemedText>
+                      <MaterialIcons
+                        name="check-circle"
+                        size={16}
+                        color={Colors.game.success}
+                      />
+                    </>
+                  ) : (
+                    <ThemedText style={styles.trackHidden}>
+                      {track.title
+                        .split(" ")
+                        .map(
+                          (word) =>
+                            word.charAt(0).toUpperCase() +
+                            "_".repeat(Math.max(0, word.length - 1)),
+                        )
+                        .join(" ")}
+                    </ThemedText>
+                  )}
+                </View>
+              );
+            })}
+          </ScrollView>
+
+          <View style={styles.inputWrapper}>
+            {answerFeedback && (
+              <View
+                style={[
+                  styles.feedbackBanner,
+                  answerFeedback.type === "correct"
+                    ? styles.feedbackCorrect
+                    : styles.feedbackWrong,
+                ]}
+              >
+                <ThemedText style={styles.feedbackText}>
+                  {answerFeedback.message}
+                </ThemedText>
+              </View>
+            )}
+            <View style={styles.inputContainer}>
+              <TextInput
+                style={styles.singleInput}
+                placeholder="Tape un son..."
+                placeholderTextColor={Colors.game.textSubtle}
+                value={currentInput}
+                onChangeText={setCurrentInput}
+                onSubmitEditing={onSubmitAnswer}
+                autoCorrect={false}
+                autoCapitalize="words"
+                returnKeyType="send"
+                blurOnSubmit={false}
+                accessibilityLabel="Saisir un titre de l'album"
+                accessibilityHint="Entrez un titre de chanson de l'album pour valider votre réponse"
+              />
+              <TouchableOpacity
+                style={styles.sendButton}
+                onPress={onSubmitAnswer}
+                accessibilityLabel="Valider la réponse"
+                accessibilityRole="button"
+              >
+                <MaterialIcons
+                  name="send"
+                  size={22}
+                  color={Colors.primary.survol}
+                />
+              </TouchableOpacity>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </GameLayout>
+    </GameErrorFeedback>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+  },
+  badgeRow: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 12,
+    paddingVertical: 12,
+    paddingHorizontal: 20,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+  },
+  badge: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    backgroundColor: "rgba(255, 255, 255, 0.08)",
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: Colors.primary.survol,
+  },
+  badgeWarning: {
+    borderColor: Colors.game.warning,
+  },
+  badgeText: {
+    color: Colors.primary.survol,
+    fontSize: 13,
+    fontWeight: "bold",
+  },
+  badgeTextWarning: {
+    color: Colors.game.warning,
+  },
+  albumCard: {
+    alignItems: "center",
+    paddingHorizontal: 20,
+    paddingVertical: 14,
+    backgroundColor: "rgba(0, 0, 0, 0.3)",
+  },
+  coverImage: {
+    width: 100,
+    height: 100,
+    borderRadius: 10,
+    marginBottom: 10,
+  },
+  albumTitle: {
+    color: "white",
+    fontSize: 16,
+    fontWeight: "bold",
+    textAlign: "center",
+    marginBottom: 2,
+  },
+  artistName: {
+    color: Colors.game.textMuted,
+    fontSize: 14,
+    textAlign: "center",
+    marginBottom: 10,
+  },
+  abandonButtonSmall: {
+    paddingHorizontal: 16,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "rgba(255, 107, 107, 0.5)",
+  },
+  abandonText: {
+    color: Colors.game.warning,
+    fontSize: 13,
+  },
+  trackList: {
+    flex: 1,
+  },
+  trackListContent: {
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+    paddingBottom: 20,
+  },
+  trackItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingVertical: 8,
+    borderBottomWidth: 1,
+    borderBottomColor: "rgba(255, 255, 255, 0.06)",
+  },
+  trackNumber: {
+    color: Colors.game.textSubtle,
+    fontSize: 14,
+    minWidth: 28,
+  },
+  trackFound: {
+    color: Colors.game.success,
+    fontSize: 15,
+    fontWeight: "600",
+    flex: 1,
+  },
+  trackHidden: {
+    color: Colors.game.textSubtle,
+    fontSize: 15,
+    flex: 1,
+    letterSpacing: 2,
+  },
+  inputWrapper: {
+    backgroundColor: "rgba(0, 0, 0, 0.9)",
+    borderTopWidth: 1,
+    borderTopColor: "rgba(255, 255, 255, 0.1)",
+  },
+  feedbackBanner: {
+    paddingHorizontal: 20,
+    paddingVertical: 8,
+    alignItems: "center",
+  },
+  feedbackCorrect: {
+    backgroundColor: "rgba(76, 175, 80, 0.15)",
+  },
+  feedbackWrong: {
+    backgroundColor: "rgba(244, 67, 54, 0.15)",
+  },
+  feedbackText: {
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  inputContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  singleInput: {
+    flex: 1,
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+    borderRadius: 24,
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    color: "white",
+    fontSize: 16,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.2)",
+  },
+  sendButton: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: "rgba(255, 255, 255, 0.08)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+});

--- a/front-mobile/components/feature/tracklist/TracklistResultScreen.tsx
+++ b/front-mobile/components/feature/tracklist/TracklistResultScreen.tsx
@@ -1,0 +1,210 @@
+import { Image, ScrollView, StyleSheet, View } from "react-native";
+import { router } from "expo-router";
+import { MaterialIcons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/ThemedText";
+import Button from "@/components/Button";
+import Header from "@/components/Header";
+import { Colors } from "@/constants/Colors";
+import { DeezerArtist } from "@/services/deezer-api";
+import { GameAlbum } from "@/hooks/feature/tracklist/useTracklistGame";
+
+interface TracklistResultScreenProps {
+  currentAlbum: GameAlbum;
+  selectedArtist: DeezerArtist | null;
+  foundTrackIds: Set<number>;
+  onReplay: () => void;
+}
+
+export default function TracklistResultScreen({
+  currentAlbum,
+  selectedArtist,
+  foundTrackIds,
+  onReplay,
+}: TracklistResultScreenProps) {
+  const score = foundTrackIds.size;
+  const maxScore = currentAlbum.tracks.length;
+  const percentage = Math.round((score / maxScore) * 100);
+
+  return (
+    <>
+      <Header title="Tracklist" variant="withBack" />
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.resultContent}
+      >
+        <View style={styles.resultHeader}>
+          <ThemedText type="title" style={styles.resultTitle}>
+            {percentage >= 75
+              ? "Excellent ! 🎉"
+              : percentage >= 50
+                ? "Bien joué ! 👍"
+                : "Continuez à vous entraîner ! 💪"}
+          </ThemedText>
+
+          <View style={styles.scoreCard}>
+            <ThemedText style={styles.scoreText}>
+              {score} / {maxScore}
+            </ThemedText>
+            <ThemedText style={styles.scoreLabel}>
+              Titres trouvés ({percentage}%)
+            </ThemedText>
+          </View>
+
+          <View style={styles.albumReveal}>
+            <Image
+              source={{ uri: currentAlbum.album.cover_xl }}
+              style={styles.revealImage}
+            />
+            <ThemedText style={styles.revealAlbumTitle}>
+              {currentAlbum.album.title}
+            </ThemedText>
+            <ThemedText style={styles.revealArtistName}>
+              {currentAlbum.album.artist?.name ?? selectedArtist?.name}
+            </ThemedText>
+          </View>
+        </View>
+
+        <View style={styles.comparisonSection}>
+          <ThemedText style={styles.comparisonTitle}>
+            Titres de l&apos;album
+          </ThemedText>
+          <View style={styles.trackResultList}>
+            {currentAlbum.tracks.map((track, index) => {
+              const isFound = foundTrackIds.has(track.id);
+              return (
+                <View key={track.id} style={styles.trackResultItem}>
+                  <MaterialIcons
+                    name={isFound ? "check-circle" : "cancel"}
+                    size={20}
+                    color={isFound ? Colors.game.success : Colors.game.error}
+                  />
+                  <ThemedText style={styles.trackResultNumber}>
+                    {index + 1}.
+                  </ThemedText>
+                  <ThemedText
+                    style={[
+                      styles.trackResultText,
+                      isFound && styles.answerCorrect,
+                      !isFound && styles.answerIncorrect,
+                    ]}
+                  >
+                    {track.title}
+                  </ThemedText>
+                </View>
+              );
+            })}
+          </View>
+        </View>
+
+        <View style={styles.resultActions}>
+          <Button title="Rejouer" onPress={onReplay} />
+          <Button
+            title="Retour aux jeux"
+            variant="outline"
+            onPress={() => router.push("/games")}
+          />
+        </View>
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+  },
+  resultContent: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  resultHeader: {
+    alignItems: "center",
+    marginBottom: 30,
+  },
+  resultTitle: {
+    textAlign: "center",
+    marginBottom: 20,
+  },
+  scoreCard: {
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    padding: 20,
+    borderRadius: 16,
+    alignItems: "center",
+    marginBottom: 20,
+    borderWidth: 2,
+    borderColor: Colors.primary.survol,
+  },
+  scoreText: {
+    color: Colors.primary.survol,
+    fontSize: 48,
+    fontWeight: "bold",
+    lineHeight: 58,
+  },
+  scoreLabel: {
+    color: "white",
+    fontSize: 16,
+    marginTop: 5,
+  },
+  albumReveal: {
+    alignItems: "center",
+  },
+  revealImage: {
+    width: 180,
+    height: 180,
+    borderRadius: 12,
+    marginBottom: 15,
+  },
+  revealAlbumTitle: {
+    color: "white",
+    fontSize: 18,
+    fontWeight: "bold",
+    textAlign: "center",
+    marginBottom: 5,
+  },
+  revealArtistName: {
+    color: Colors.game.textMuted,
+    fontSize: 16,
+    textAlign: "center",
+  },
+  comparisonSection: {
+    marginBottom: 30,
+  },
+  comparisonTitle: {
+    color: "white",
+    fontSize: 20,
+    fontWeight: "bold",
+    marginBottom: 15,
+    textAlign: "center",
+  },
+  trackResultList: {
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 12,
+    padding: 15,
+  },
+  trackResultItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    marginBottom: 10,
+  },
+  trackResultNumber: {
+    color: Colors.game.textMuted,
+    fontSize: 14,
+    minWidth: 25,
+  },
+  trackResultText: {
+    fontSize: 14,
+    flex: 1,
+  },
+  answerCorrect: {
+    color: Colors.game.success,
+    fontWeight: "bold",
+  },
+  answerIncorrect: {
+    color: Colors.game.error,
+  },
+  resultActions: {
+    gap: 12,
+  },
+});

--- a/front-mobile/hooks/__tests__/useArtistSearch.test.ts
+++ b/front-mobile/hooks/__tests__/useArtistSearch.test.ts
@@ -1,0 +1,184 @@
+import { renderHook, waitFor, act } from "@testing-library/react-native";
+import { useArtistSearch } from "../useArtistSearch";
+import { deezerAPI, DeezerArtist } from "@/services/deezer-api";
+import { useToast } from "@/components/Toast";
+
+jest.mock("@/services/deezer-api");
+jest.mock("@/components/Toast");
+
+const mockDeezerAPI = deezerAPI as jest.Mocked<typeof deezerAPI>;
+const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
+
+const buildArtist = (id: number, name = `Artist ${id}`): DeezerArtist =>
+  ({
+    id,
+    name,
+    link: "",
+    picture: "",
+    picture_small: "",
+    picture_medium: `pic-m-${id}`,
+    picture_big: "",
+    picture_xl: "",
+    nb_album: 0,
+    nb_fan: 0,
+    type: "artist",
+  }) as DeezerArtist;
+
+describe("useArtistSearch", () => {
+  const mockShow = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockUseToast.mockReturnValue({ show: mockShow });
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    mockDeezerAPI.getTopArtists.mockResolvedValue({
+      data: [buildArtist(1), buildArtist(2)],
+    });
+    mockDeezerAPI.searchArtists.mockResolvedValue({
+      data: [buildArtist(99, "Daft Punk")],
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("loads top artists on mount", async () => {
+    const { result } = renderHook(() => useArtistSearch(""));
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoading).toBe(false);
+    });
+
+    expect(mockDeezerAPI.getTopArtists).toHaveBeenCalledWith(20);
+    expect(result.current.topArtists).toHaveLength(2);
+    expect(result.current.searchResults).toEqual([]);
+  });
+
+  it("shows a toast error when top artists fetch fails", async () => {
+    mockDeezerAPI.getTopArtists.mockRejectedValueOnce(new Error("down"));
+
+    const { result } = renderHook(() => useArtistSearch(""));
+
+    await waitFor(() => {
+      expect(result.current.isInitialLoading).toBe(false);
+    });
+
+    expect(result.current.topArtists).toEqual([]);
+    expect(mockShow).toHaveBeenCalledWith({
+      type: "error",
+      message: "Impossible de charger les suggestions d'artistes",
+    });
+  });
+
+  it("does not search when query is shorter than 3 characters", async () => {
+    const { rerender } = renderHook<
+      ReturnType<typeof useArtistSearch>,
+      { q: string }
+    >(({ q }) => useArtistSearch(q), {
+      initialProps: { q: "" },
+    });
+
+    await waitFor(() => {
+      expect(mockDeezerAPI.getTopArtists).toHaveBeenCalled();
+    });
+
+    rerender({ q: "ab" });
+
+    await act(async () => {
+      jest.advanceTimersByTime(500);
+    });
+
+    expect(mockDeezerAPI.searchArtists).not.toHaveBeenCalled();
+  });
+
+  it("debounces the search by 400ms and returns results", async () => {
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useArtistSearch>,
+      { q: string }
+    >(({ q }) => useArtistSearch(q), {
+      initialProps: { q: "" },
+    });
+
+    await waitFor(() => {
+      expect(mockDeezerAPI.getTopArtists).toHaveBeenCalled();
+    });
+
+    rerender({ q: "daf" });
+
+    await act(async () => {
+      jest.advanceTimersByTime(399);
+    });
+    expect(mockDeezerAPI.searchArtists).not.toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+    });
+
+    await waitFor(() => {
+      expect(mockDeezerAPI.searchArtists).toHaveBeenCalledWith("daf", 20);
+    });
+
+    await waitFor(() => {
+      expect(result.current.searchResults).toHaveLength(1);
+    });
+    expect(result.current.searchResults[0].name).toBe("Daft Punk");
+  });
+
+  it("resets search results when query drops below 3 characters", async () => {
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useArtistSearch>,
+      { q: string }
+    >(({ q }) => useArtistSearch(q), {
+      initialProps: { q: "daft" },
+    });
+
+    await waitFor(() => {
+      expect(mockDeezerAPI.getTopArtists).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(result.current.searchResults).toHaveLength(1);
+    });
+
+    rerender({ q: "da" });
+
+    await waitFor(() => {
+      expect(result.current.searchResults).toEqual([]);
+    });
+  });
+
+  it("shows a toast error when search fails", async () => {
+    mockDeezerAPI.searchArtists.mockRejectedValueOnce(new Error("search down"));
+
+    const { rerender } = renderHook<
+      ReturnType<typeof useArtistSearch>,
+      { q: string }
+    >(({ q }) => useArtistSearch(q), {
+      initialProps: { q: "" },
+    });
+
+    await waitFor(() => {
+      expect(mockDeezerAPI.getTopArtists).toHaveBeenCalled();
+    });
+
+    rerender({ q: "daft" });
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(mockShow).toHaveBeenCalledWith({
+        type: "error",
+        message: "Échec de la recherche d'artistes",
+      });
+    });
+  });
+});

--- a/front-mobile/hooks/__tests__/useArtistSearch.test.ts
+++ b/front-mobile/hooks/__tests__/useArtistSearch.test.ts
@@ -127,6 +127,49 @@ describe("useArtistSearch", () => {
     expect(result.current.searchResults[0].name).toBe("Daft Punk");
   });
 
+  it("clears isSearching immediately when query drops below 3 characters mid-flight", async () => {
+    let resolveSearch: (value: { data: DeezerArtist[] }) => void = () => {};
+    mockDeezerAPI.searchArtists.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSearch = resolve;
+        }),
+    );
+
+    const { result, rerender } = renderHook<
+      ReturnType<typeof useArtistSearch>,
+      { q: string }
+    >(({ q }) => useArtistSearch(q), {
+      initialProps: { q: "daft" },
+    });
+
+    await waitFor(() => {
+      expect(mockDeezerAPI.getTopArtists).toHaveBeenCalled();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSearching).toBe(true);
+    });
+
+    rerender({ q: "da" });
+
+    await waitFor(() => {
+      expect(result.current.isSearching).toBe(false);
+    });
+    expect(result.current.searchResults).toEqual([]);
+
+    await act(async () => {
+      resolveSearch({ data: [buildArtist(99, "Daft Punk")] });
+    });
+
+    expect(result.current.searchResults).toEqual([]);
+    expect(result.current.isSearching).toBe(false);
+  });
+
   it("resets search results when query drops below 3 characters", async () => {
     const { result, rerender } = renderHook<
       ReturnType<typeof useArtistSearch>,

--- a/front-mobile/hooks/feature/tracklist/__tests__/useTracklistGame.test.ts
+++ b/front-mobile/hooks/feature/tracklist/__tests__/useTracklistGame.test.ts
@@ -151,7 +151,6 @@ describe("useTracklistGame", () => {
       triggerError: mockTriggerError,
     });
 
-    mockDeezerAPI.getTopArtists.mockResolvedValue({ data: [] } as never);
     mockDeezerAPI.getArtistAlbums.mockResolvedValue({
       data: [sampleAlbum],
     } as never);

--- a/front-mobile/hooks/feature/tracklist/useTracklistGame.ts
+++ b/front-mobile/hooks/feature/tracklist/useTracklistGame.ts
@@ -58,10 +58,6 @@ const ALBUM_CHOICES = 6;
 export function useTracklistGame() {
   const [gameState, setGameState] = useState<GameState>("artistSearch");
   const [searchQuery, setSearchQuery] = useState("");
-  const [searchResults, setSearchResults] = useState<DeezerArtist[]>([]);
-  const [topArtists, setTopArtists] = useState<DeezerArtist[]>([]);
-  const [isSearching, setIsSearching] = useState(false);
-  const [isInitialLoading, setIsInitialLoading] = useState(false);
   const [loadingAlbum, setLoadingAlbum] = useState(false);
 
   const [candidateAlbums, setCandidateAlbums] = useState<DeezerAlbum[]>([]);
@@ -83,7 +79,6 @@ export function useTracklistGame() {
   const [validatedAnswers, setValidatedAnswers] = useState<TrackAnswer[]>([]);
 
   const feedbackTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isProcessingAnswerRef = useRef(false);
   const isSubmittingRef = useRef(false);
 
@@ -97,67 +92,6 @@ export function useTracklistGame() {
   const { shakeAnimation, borderOpacity, triggerError } = useErrorFeedback(
     errorAnimationsEnabled,
   );
-
-  const fetchTopArtists = useCallback(async () => {
-    setIsInitialLoading(true);
-    try {
-      const response = await deezerAPI.getTopArtists(20);
-      setTopArtists(response.data);
-    } catch (error) {
-      console.error("Failed to fetch top artists:", error);
-      show({
-        type: "error",
-        message: "Impossible de charger les suggestions d'artistes",
-      });
-    } finally {
-      setIsInitialLoading(false);
-    }
-  }, [show]);
-
-  useEffect(() => {
-    void fetchTopArtists();
-  }, [fetchTopArtists]);
-
-  const performSearch = useCallback(
-    async (query: string) => {
-      if (query.trim().length < 3) {
-        setSearchResults([]);
-        return;
-      }
-
-      setIsSearching(true);
-      try {
-        const response = await deezerAPI.searchArtists(query, 20);
-        setSearchResults(response.data);
-      } catch (error) {
-        console.error("Search failed:", error);
-        show({ type: "error", message: "Échec de la recherche d'artistes" });
-      } finally {
-        setIsSearching(false);
-      }
-    },
-    [show],
-  );
-
-  useEffect(() => {
-    if (searchTimeoutRef.current) {
-      clearTimeout(searchTimeoutRef.current);
-    }
-
-    if (searchQuery.trim().length >= 3) {
-      searchTimeoutRef.current = setTimeout(() => {
-        void performSearch(searchQuery);
-      }, 400);
-    } else {
-      setSearchResults([]);
-    }
-
-    return () => {
-      if (searchTimeoutRef.current) {
-        clearTimeout(searchTimeoutRef.current);
-      }
-    };
-  }, [searchQuery, performSearch]);
 
   const loadSavedState = useCallback(async () => {
     if (!gameId) return;
@@ -518,7 +452,6 @@ export function useTracklistGame() {
     setCandidateAlbums([]);
     setSelectedArtist(null);
     setSearchQuery("");
-    setSearchResults([]);
     setCurrentInput("");
     setFoundTrackIds(new Set());
     setTimeRemaining(GAME_DURATION);
@@ -533,13 +466,8 @@ export function useTracklistGame() {
   }, []);
 
   return {
-    // State
     gameState,
     searchQuery,
-    searchResults,
-    topArtists,
-    isSearching,
-    isInitialLoading,
     loadingAlbum,
     candidateAlbums,
     selectedArtist,
@@ -550,17 +478,11 @@ export function useTracklistGame() {
     timeRemaining,
     sessionId,
     sessionError,
-
-    // Error feedback
     shakeAnimation,
     borderOpacity,
     errorAnimationsEnabled,
-
-    // Controlled input setters
     setSearchQuery,
     setCurrentInput,
-
-    // Handlers
     handleSelectArtist,
     startGameWithAlbum,
     handleSubmitAnswer,

--- a/front-mobile/hooks/useArtistSearch.ts
+++ b/front-mobile/hooks/useArtistSearch.ts
@@ -1,0 +1,99 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { deezerAPI, DeezerArtist } from "@/services/deezer-api";
+import { useToast } from "@/components/Toast";
+
+const SEARCH_DEBOUNCE_MS = 400;
+const MIN_QUERY_LENGTH = 3;
+const TOP_ARTISTS_LIMIT = 20;
+const SEARCH_RESULTS_LIMIT = 20;
+
+export function useArtistSearch(query: string) {
+  const [topArtists, setTopArtists] = useState<DeezerArtist[]>([]);
+  const [searchResults, setSearchResults] = useState<DeezerArtist[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isInitialLoading, setIsInitialLoading] = useState(false);
+
+  const { show } = useToast();
+  const isMountedRef = useRef(true);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestSearchRequestIdRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const fetchTopArtists = useCallback(async () => {
+    if (isMountedRef.current) setIsInitialLoading(true);
+    try {
+      const response = await deezerAPI.getTopArtists(TOP_ARTISTS_LIMIT);
+      if (isMountedRef.current) setTopArtists(response.data);
+    } catch (error) {
+      console.error("Failed to fetch top artists:", error);
+      if (isMountedRef.current) {
+        show({
+          type: "error",
+          message: "Impossible de charger les suggestions d'artistes",
+        });
+      }
+    } finally {
+      if (isMountedRef.current) setIsInitialLoading(false);
+    }
+  }, [show]);
+
+  useEffect(() => {
+    void fetchTopArtists();
+  }, [fetchTopArtists]);
+
+  const performSearch = useCallback(
+    async (q: string) => {
+      const requestId = ++latestSearchRequestIdRef.current;
+      if (isMountedRef.current) setIsSearching(true);
+      try {
+        const response = await deezerAPI.searchArtists(q, SEARCH_RESULTS_LIMIT);
+        if (!isMountedRef.current) return;
+        if (requestId !== latestSearchRequestIdRef.current) return;
+        setSearchResults(response.data);
+      } catch (error) {
+        if (!isMountedRef.current) return;
+        if (requestId !== latestSearchRequestIdRef.current) return;
+        console.error("Search failed:", error);
+        show({ type: "error", message: "Échec de la recherche d'artistes" });
+      } finally {
+        if (
+          isMountedRef.current &&
+          requestId === latestSearchRequestIdRef.current
+        ) {
+          setIsSearching(false);
+        }
+      }
+    },
+    [show],
+  );
+
+  const hasQuery = query.trim().length >= MIN_QUERY_LENGTH;
+
+  useEffect(() => {
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    if (hasQuery) {
+      searchTimeoutRef.current = setTimeout(() => {
+        void performSearch(query);
+      }, SEARCH_DEBOUNCE_MS);
+    } else {
+      setSearchResults([]);
+    }
+
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, [query, hasQuery, performSearch]);
+
+  return { topArtists, searchResults, isSearching, isInitialLoading, hasQuery };
+}

--- a/front-mobile/hooks/useArtistSearch.ts
+++ b/front-mobile/hooks/useArtistSearch.ts
@@ -85,7 +85,9 @@ export function useArtistSearch(query: string) {
         void performSearch(query);
       }, SEARCH_DEBOUNCE_MS);
     } else {
+      latestSearchRequestIdRef.current += 1;
       setSearchResults([]);
+      setIsSearching(false);
     }
 
     return () => {


### PR DESCRIPTION
## Description

Découpage de `front-mobile/app/(tabs)/games/tracklist/game.tsx` (899 lignes) en 4 sous-composants par état de jeu (`TracklistArtistSearch`, `TracklistAlbumStep`, `TracklistPlayingScreen`, `TracklistResultScreen`) colocalisés sous `components/feature/tracklist/`. Le fichier `game.tsx` ne fait plus que 155 lignes et agit comme orchestrateur entre états. En parallèle, la logique de recherche d'artiste a été extraite dans un hook partagé `useArtistSearch` et un composant présentationnel `ArtistSelector`, réutilisables par d'autres jeux futurs. Le hook `useTracklistGame` a été sorti de `app/` vers `hooks/feature/tracklist/` pour éviter qu'Expo Router ne le traite comme une route.

## Parcours utilisateur

1. Lancer le jeu Tracklist depuis l'index des jeux → écran « Cherchez un artiste » doit afficher les 20 top artistes français en liste
2. Taper une recherche (≥ 3 caractères, ex : « daft ») → debounce 400 ms → les résultats remplacent les top artistes. Le bouton clear (×) doit fonctionner
3. Sélectionner un artiste → écran « Choisissez un album » avec une grille 2 colonnes (6 albums shufflés)
4. Appuyer sur le bouton retour depuis l'écran de sélection d'album → retour à la recherche d'artiste, avec `searchQuery` conservé
5. Choisir un album → écran de jeu (timer 5 min, badge score, champ « Tape un son... », bouton abandon)
6. Saisir un titre correct (fuzzy match accepté) → feedback vert ✓, coche dans la liste, compteur +1
7. Saisir un titre faux → animation de shake + feedback rouge « Essaie encore ! »
8. Terminer la partie (trouver tous les titres OU laisser le timer expirer OU cliquer Abandonner) → écran de résultat (score, pourcentage, révélation de l'album, liste comparative des titres)
9. Appuyer sur « Rejouer » → retour propre à l'écran de recherche d'artiste
10. Appuyer sur « Retour aux jeux » → navigation vers `/games`
11. Test de reprise : quitter pendant la sélection d'album (back), rouvrir le jeu avec `resume=true` → l'état doit être restauré intégralement, y compris `searchQuery`