### PR TITLE
MIX-286 chore: install ally and spotify driver

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,3 +29,10 @@ MAIL_FROM_NAME="Rythmix App"
 # Frontend URL for email verification links
 FRONTEND_URL=https://api.localhost
 LIMITER_STORE=database
+
+# Spotify OAuth (https://developer.spotify.com/dashboard)
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+SPOTIFY_CALLBACK_URL=http://localhost:3333/api/auth/spotify/callback
+# Deep link scheme used to return to the mobile app after OAuth. Defaults to "frontmobile".
+SPOTIFY_DEEP_LINK_SCHEME=frontmobile

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -29,3 +29,9 @@ MAIL_FROM_NAME="Rythmix App"
 # Frontend URL for email verification links
 FRONTEND_URL=https://api.localhost
 LIMITER_STORE=memory
+
+# Spotify OAuth (dummy values for testing)
+SPOTIFY_CLIENT_ID=test_client_id
+SPOTIFY_CLIENT_SECRET=test_client_secret
+SPOTIFY_CALLBACK_URL=http://localhost:3333/api/auth/spotify/callback
+SPOTIFY_DEEP_LINK_SCHEME=frontmobile

--- a/backend/adonisrc.ts
+++ b/backend/adonisrc.ts
@@ -54,6 +54,7 @@ export default defineConfig({
     () => import('@adonisjs/mail/mail_provider'),
     () => import('@adonisjs/core/providers/edge_provider'),
     () => import('@adonisjs/limiter/limiter_provider'),
+    () => import('@adonisjs/ally/ally_provider'),
     () => import('@foadonis/openapi/openapi_provider'),
   ],
 

--- a/backend/app/controllers/me_integrations_controller.ts
+++ b/backend/app/controllers/me_integrations_controller.ts
@@ -1,5 +1,6 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
+import logger from '@adonisjs/core/services/logger'
 import { ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
 import { SpotifyService } from '#services/spotify_service'
 import { spotifyRecentlyPlayedValidator, spotifyTopValidator } from '#validators/spotify_validator'
@@ -39,7 +40,7 @@ export default class MeIntegrationsController {
       const data = await this.spotifyService.getTopTracks(user.id, qs)
       return response.ok(data)
     } catch (error) {
-      return this.handleSpotifyError(error, response)
+      return this.handleSpotifyError(error, response, { userId: user.id, path: 'top-tracks' })
     }
   }
 
@@ -56,7 +57,7 @@ export default class MeIntegrationsController {
       const data = await this.spotifyService.getTopArtists(user.id, qs)
       return response.ok(data)
     } catch (error) {
-      return this.handleSpotifyError(error, response)
+      return this.handleSpotifyError(error, response, { userId: user.id, path: 'top-artists' })
     }
   }
 
@@ -75,7 +76,10 @@ export default class MeIntegrationsController {
       const data = await this.spotifyService.getRecentlyPlayed(user.id, qs)
       return response.ok(data)
     } catch (error) {
-      return this.handleSpotifyError(error, response)
+      return this.handleSpotifyError(error, response, {
+        userId: user.id,
+        path: 'recently-played',
+      })
     }
   }
 
@@ -95,13 +99,18 @@ export default class MeIntegrationsController {
     return response.ok({ message: 'Spotify integration removed' })
   }
 
-  private handleSpotifyError(error: unknown, response: HttpContext['response']) {
+  private handleSpotifyError(
+    error: unknown,
+    response: HttpContext['response'],
+    context: { userId: string; path: string }
+  ) {
     if (error instanceof Error && error.message === 'Spotify integration not found') {
       return response.notFound({ message: error.message })
     }
     if (error instanceof Error && error.message === 'Spotify refresh token missing') {
       return response.unauthorized({ message: 'Spotify session expired, please reconnect' })
     }
+    logger.error({ err: error, ...context }, 'Spotify data fetch failed')
     return response.internalServerError({
       message: 'Failed to fetch Spotify data',
     })

--- a/backend/app/controllers/me_integrations_controller.ts
+++ b/backend/app/controllers/me_integrations_controller.ts
@@ -1,0 +1,109 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
+import { SpotifyService } from '#services/spotify_service'
+import { spotifyRecentlyPlayedValidator, spotifyTopValidator } from '#validators/spotify_validator'
+
+@inject()
+export default class MeIntegrationsController {
+  constructor(private readonly spotifyService: SpotifyService) {}
+
+  @ApiOperation({
+    summary: 'Get Spotify integration status',
+    description: 'Returns whether the current user has linked their Spotify account.',
+  })
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({ status: 200, description: 'Status returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async spotifyStatus({ auth, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const integration = await this.spotifyService.findByUserId(user.id)
+
+    return response.ok({
+      connected: !!integration,
+      providerUserId: integration?.providerUserId ?? null,
+      scopes: integration?.scopes ?? null,
+    })
+  }
+
+  @ApiOperation({ summary: 'Get my Spotify top tracks' })
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({ status: 200, description: 'Top tracks returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Spotify integration not found' })
+  async topTracks({ auth, request, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const qs = await request.validateUsing(spotifyTopValidator, { data: request.qs() })
+
+    try {
+      const data = await this.spotifyService.getTopTracks(user.id, qs)
+      return response.ok(data)
+    } catch (error) {
+      return this.handleSpotifyError(error, response)
+    }
+  }
+
+  @ApiOperation({ summary: 'Get my Spotify top artists' })
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({ status: 200, description: 'Top artists returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Spotify integration not found' })
+  async topArtists({ auth, request, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const qs = await request.validateUsing(spotifyTopValidator, { data: request.qs() })
+
+    try {
+      const data = await this.spotifyService.getTopArtists(user.id, qs)
+      return response.ok(data)
+    } catch (error) {
+      return this.handleSpotifyError(error, response)
+    }
+  }
+
+  @ApiOperation({ summary: 'Get my Spotify recently played tracks' })
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({ status: 200, description: 'Recently played returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Spotify integration not found' })
+  async recentlyPlayed({ auth, request, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const qs = await request.validateUsing(spotifyRecentlyPlayedValidator, {
+      data: request.qs(),
+    })
+
+    try {
+      const data = await this.spotifyService.getRecentlyPlayed(user.id, qs)
+      return response.ok(data)
+    } catch (error) {
+      return this.handleSpotifyError(error, response)
+    }
+  }
+
+  @ApiOperation({ summary: 'Unlink Spotify integration' })
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({ status: 200, description: 'Integration removed' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'No Spotify integration to unlink' })
+  async unlinkSpotify({ auth, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const removed = await this.spotifyService.unlink(user.id)
+
+    if (!removed) {
+      return response.notFound({ message: 'No Spotify integration to unlink' })
+    }
+
+    return response.ok({ message: 'Spotify integration removed' })
+  }
+
+  private handleSpotifyError(error: unknown, response: HttpContext['response']) {
+    if (error instanceof Error && error.message === 'Spotify integration not found') {
+      return response.notFound({ message: error.message })
+    }
+    if (error instanceof Error && error.message === 'Spotify refresh token missing') {
+      return response.unauthorized({ message: 'Spotify session expired, please reconnect' })
+    }
+    return response.internalServerError({
+      message: 'Failed to fetch Spotify data',
+    })
+  }
+}

--- a/backend/app/controllers/spotify_auth_controller.ts
+++ b/backend/app/controllers/spotify_auth_controller.ts
@@ -1,13 +1,12 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { DateTime } from 'luxon'
-import { Secret } from '@adonisjs/core/helpers'
 import encryption from '@adonisjs/core/services/encryption'
 import logger from '@adonisjs/core/services/logger'
 import env from '#start/env'
-import User from '#models/user'
 import { inject } from '@adonisjs/core'
 import { SpotifyService } from '#services/spotify_service'
-import { ApiOperation, ApiResponse } from '@foadonis/openapi/decorators'
+import { ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
+import { spotifyInitValidator } from '#validators/spotify_validator'
 
 interface SpotifyState {
   userId: string
@@ -26,37 +25,30 @@ export default class SpotifyAuthController {
   @ApiOperation({
     summary: 'Initiate Spotify OAuth flow',
     description:
-      'Redirects the authenticated user to Spotify. Expects a Rythmix bearer token and a deep-link `returnUrl` as query params so the flow can be triggered from WebBrowser (no custom headers).',
+      'Returns a Spotify authorization URL that the mobile client opens in a WebBrowser. The Rythmix identity is taken from the Authorization header — never from the query string — so the token is not leaked to logs, proxies or browser history.',
   })
-  @ApiResponse({ status: 302, description: 'Redirect to Spotify authorization page' })
-  @ApiResponse({ status: 400, description: 'Missing or invalid returnUrl' })
-  @ApiResponse({ status: 401, description: 'Missing or invalid Rythmix token' })
-  async redirect({ ally, request, response }: HttpContext) {
-    const qs = request.qs()
-    const token = qs.token as string | undefined
-    const returnUrl = qs.returnUrl as string | undefined
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({ status: 200, description: 'Authorization URL returned' })
+  @ApiResponse({ status: 400, description: 'Invalid returnUrl' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async init({ ally, auth, request, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const { returnUrl } = await request.validateUsing(spotifyInitValidator)
 
-    if (!token) {
-      return response.unauthorized({ message: 'Missing Rythmix token' })
-    }
-
-    if (!returnUrl || !this.isAllowedReturnUrl(returnUrl)) {
+    if (!this.isAllowedReturnUrl(returnUrl)) {
       return response.badRequest({ message: 'Invalid returnUrl' })
     }
 
-    const accessToken = await User.accessTokens.verify(new Secret(token))
-    if (!accessToken) {
-      return response.unauthorized({ message: 'Invalid Rythmix token' })
-    }
+    const state = this.encodeState(user.id, returnUrl)
 
-    const state = this.encodeState(accessToken.tokenableId as string, returnUrl)
-
-    return ally
+    const authorizeUrl = await ally
       .use('spotify')
       .stateless()
-      .redirect((req) => {
+      .redirectUrl((req) => {
         req.param('state', state)
       })
+
+    return response.ok({ authorizeUrl })
   }
 
   @ApiOperation({

--- a/backend/app/controllers/spotify_auth_controller.ts
+++ b/backend/app/controllers/spotify_auth_controller.ts
@@ -1,0 +1,179 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import { Secret } from '@adonisjs/core/helpers'
+import encryption from '@adonisjs/core/services/encryption'
+import logger from '@adonisjs/core/services/logger'
+import env from '#start/env'
+import User from '#models/user'
+import { inject } from '@adonisjs/core'
+import { SpotifyService } from '#services/spotify_service'
+import { ApiOperation, ApiResponse } from '@foadonis/openapi/decorators'
+
+interface SpotifyState {
+  userId: string
+  returnUrl: string
+  expiresAt: string
+}
+
+const STATE_TTL_MINUTES = 10
+const ALLOWED_RETURN_URL_SCHEMES = ['frontmobile', 'exp', 'exp+frontmobile']
+const MAX_RETURN_URL_LENGTH = 500
+
+@inject()
+export default class SpotifyAuthController {
+  constructor(private readonly spotifyService: SpotifyService) {}
+
+  @ApiOperation({
+    summary: 'Initiate Spotify OAuth flow',
+    description:
+      'Redirects the authenticated user to Spotify. Expects a Rythmix bearer token and a deep-link `returnUrl` as query params so the flow can be triggered from WebBrowser (no custom headers).',
+  })
+  @ApiResponse({ status: 302, description: 'Redirect to Spotify authorization page' })
+  @ApiResponse({ status: 400, description: 'Missing or invalid returnUrl' })
+  @ApiResponse({ status: 401, description: 'Missing or invalid Rythmix token' })
+  async redirect({ ally, request, response }: HttpContext) {
+    const qs = request.qs()
+    const token = qs.token as string | undefined
+    const returnUrl = qs.returnUrl as string | undefined
+
+    if (!token) {
+      return response.unauthorized({ message: 'Missing Rythmix token' })
+    }
+
+    if (!returnUrl || !this.isAllowedReturnUrl(returnUrl)) {
+      return response.badRequest({ message: 'Invalid returnUrl' })
+    }
+
+    const accessToken = await User.accessTokens.verify(new Secret(token))
+    if (!accessToken) {
+      return response.unauthorized({ message: 'Invalid Rythmix token' })
+    }
+
+    const state = this.encodeState(accessToken.tokenableId as string, returnUrl)
+
+    return ally
+      .use('spotify')
+      .stateless()
+      .redirect((req) => {
+        req.param('state', state)
+      })
+  }
+
+  @ApiOperation({
+    summary: 'Spotify OAuth callback',
+    description:
+      'Handles the Spotify redirect, exchanges the code and upserts the UserIntegration. Finishes with an HTTP 302 to the mobile deep-link URL provided at redirect time.',
+  })
+  @ApiResponse({ status: 302, description: 'Redirect to the mobile deep-link' })
+  async callback({ ally, request, response }: HttpContext) {
+    const fallbackUrl = this.buildFallbackUrl()
+    const spotify = ally.use('spotify').stateless()
+
+    const stateRaw = request.qs().state as string | undefined
+    const decoded = stateRaw ? this.decodeState(stateRaw) : null
+
+    if (spotify.accessDenied()) {
+      return response.redirect(
+        this.appendStatus(decoded?.returnUrl ?? fallbackUrl, 'error', 'access_denied')
+      )
+    }
+
+    if (!decoded) {
+      return response.redirect(this.appendStatus(fallbackUrl, 'error', 'invalid_state'))
+    }
+
+    try {
+      const token = await spotify.accessToken()
+      logger.info(
+        { scope: (token as { scope?: string }).scope, expiresIn: token.expiresIn },
+        'Spotify access token obtained'
+      )
+
+      const meResponse = await fetch('https://api.spotify.com/v1/me', {
+        headers: { Authorization: `Bearer ${token.token}` },
+      })
+
+      if (!meResponse.ok) {
+        const rawBody = await meResponse.text()
+        logger.error(
+          {
+            status: meResponse.status,
+            body: rawBody,
+            scope: (token as { scope?: string }).scope,
+          },
+          'Spotify /v1/me returned non-2xx'
+        )
+        return response.redirect(
+          this.appendStatus(decoded.returnUrl, 'error', `spotify_me_${meResponse.status}`)
+        )
+      }
+
+      const me = (await meResponse.json()) as { id?: string }
+      if (!me.id) {
+        return response.redirect(this.appendStatus(decoded.returnUrl, 'error', 'spotify_me_no_id'))
+      }
+
+      await this.spotifyService.upsertIntegration(decoded.userId, {
+        providerUserId: me.id,
+        accessToken: token.token,
+        refreshToken: token.refreshToken ?? null,
+        expiresAt: token.expiresIn
+          ? DateTime.now().plus({ seconds: token.expiresIn })
+          : token.expiresAt
+            ? DateTime.fromJSDate(token.expiresAt)
+            : null,
+        scopes: this.extractScopes(token as Record<string, unknown>),
+      })
+
+      return response.redirect(this.appendStatus(decoded.returnUrl, 'ok'))
+    } catch (error) {
+      logger.error({ err: error, qs: request.qs() }, 'Spotify callback failed')
+      const reason = error instanceof Error ? error.message.slice(0, 120) : 'unknown_error'
+      return response.redirect(this.appendStatus(decoded.returnUrl, 'error', reason))
+    }
+  }
+
+  private isAllowedReturnUrl(url: string): boolean {
+    if (url.length > MAX_RETURN_URL_LENGTH) return false
+    const schemeMatch = url.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//)
+    if (!schemeMatch) return false
+    return ALLOWED_RETURN_URL_SCHEMES.includes(schemeMatch[1])
+  }
+
+  private buildFallbackUrl(): string {
+    const scheme = env.get('SPOTIFY_DEEP_LINK_SCHEME', 'frontmobile')
+    return `${scheme}://spotify-linked`
+  }
+
+  private appendStatus(url: string, status: 'ok' | 'error', reason?: string): string {
+    const separator = url.includes('?') ? '&' : '?'
+    const params = new URLSearchParams({ status })
+    if (reason) params.set('reason', reason)
+    return `${url}${separator}${params.toString()}`
+  }
+
+  private extractScopes(token: Record<string, unknown>): string | null {
+    const rawScope = (token.scope ??
+      (token as { original?: { scope?: string } }).original?.scope) as string | string[] | undefined
+    if (!rawScope) return null
+    return Array.isArray(rawScope) ? rawScope.join(' ') : rawScope
+  }
+
+  private encodeState(userId: string, returnUrl: string): string {
+    const payload: SpotifyState = {
+      userId,
+      returnUrl,
+      expiresAt: DateTime.now().plus({ minutes: STATE_TTL_MINUTES }).toISO()!,
+    }
+    return encryption.encrypt(payload)
+  }
+
+  private decodeState(state: string): { userId: string; returnUrl: string } | null {
+    const payload = encryption.decrypt<SpotifyState>(state)
+    if (!payload) return null
+    const expiresAt = DateTime.fromISO(payload.expiresAt)
+    if (!expiresAt.isValid || expiresAt <= DateTime.now()) return null
+    if (!this.isAllowedReturnUrl(payload.returnUrl)) return null
+    return { userId: payload.userId, returnUrl: payload.returnUrl }
+  }
+}

--- a/backend/app/enums/integration_provider.ts
+++ b/backend/app/enums/integration_provider.ts
@@ -1,0 +1,5 @@
+export enum IntegrationProvider {
+  SPOTIFY = 'spotify',
+}
+
+export const INTEGRATION_PROVIDERS = Object.values(IntegrationProvider)

--- a/backend/app/models/user.ts
+++ b/backend/app/models/user.ts
@@ -8,6 +8,7 @@ import { randomUUID } from 'node:crypto'
 import { hasMany } from '@adonisjs/lucid/orm'
 import LikedTrack from '#models/liked_track'
 import FavoriteGame from '#models/favorite_game'
+import UserIntegration from '#models/user_integration'
 import type { HasMany } from '@adonisjs/lucid/types/relations'
 import { ApiProperty } from '@foadonis/openapi/decorators'
 
@@ -75,6 +76,9 @@ export default class User extends compose(BaseModel, AuthFinder) {
 
   @hasMany(() => FavoriteGame)
   declare favoriteGames: HasMany<typeof FavoriteGame>
+
+  @hasMany(() => UserIntegration)
+  declare integrations: HasMany<typeof UserIntegration>
 
   @column({ serializeAs: null })
   declare verificationToken: string | null

--- a/backend/app/models/user_integration.ts
+++ b/backend/app/models/user_integration.ts
@@ -1,0 +1,62 @@
+import { DateTime } from 'luxon'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import encryption from '@adonisjs/core/services/encryption'
+import User from '#models/user'
+import { IntegrationProvider } from '#enums/integration_provider'
+import { ApiProperty } from '@foadonis/openapi/decorators'
+
+const encryptedColumn = {
+  prepare: (value: string | null | undefined) =>
+    value === null || value === undefined ? value : encryption.encrypt(value),
+  consume: (value: string | null | undefined) =>
+    value === null || value === undefined ? value : encryption.decrypt<string>(value),
+}
+
+export default class UserIntegration extends BaseModel {
+  @ApiProperty({ description: 'Integration unique identifier', example: 1 })
+  @column({ isPrimary: true })
+  declare id: number
+
+  @ApiProperty({ description: 'User ID owning the integration (UUID)' })
+  @column()
+  declare userId: string
+
+  @ApiProperty({ description: 'Third-party provider', enum: Object.values(IntegrationProvider) })
+  @column()
+  declare provider: IntegrationProvider
+
+  @ApiProperty({ description: 'Provider-side user id' })
+  @column()
+  declare providerUserId: string
+
+  @column({ serializeAs: null, ...encryptedColumn })
+  declare accessToken: string
+
+  @column({ serializeAs: null, ...encryptedColumn })
+  declare refreshToken: string | null
+
+  @ApiProperty({ description: 'Access token expiry (ISO8601)', nullable: true })
+  @column.dateTime()
+  declare expiresAt: DateTime | null
+
+  @ApiProperty({ description: 'Space-separated scopes granted by the user', nullable: true })
+  @column()
+  declare scopes: string | null
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
+
+  get isExpired(): boolean {
+    if (!this.expiresAt) return false
+    return this.expiresAt <= DateTime.now()
+  }
+}

--- a/backend/app/services/spotify_service.ts
+++ b/backend/app/services/spotify_service.ts
@@ -1,0 +1,168 @@
+import { DateTime } from 'luxon'
+import env from '#start/env'
+import UserIntegration from '#models/user_integration'
+import { IntegrationProvider } from '#enums/integration_provider'
+
+export type SpotifyTimeRange = 'short_term' | 'medium_term' | 'long_term'
+
+export interface SpotifyUpsertPayload {
+  providerUserId: string
+  accessToken: string
+  refreshToken?: string | null
+  expiresAt?: DateTime | null
+  scopes?: string | null
+}
+
+interface SpotifyRefreshResponse {
+  access_token: string
+  refresh_token?: string
+  expires_in: number
+  scope?: string
+  token_type?: string
+}
+
+const SPOTIFY_API_BASE = 'https://api.spotify.com/v1'
+const SPOTIFY_TOKEN_URL = 'https://accounts.spotify.com/api/token'
+const REFRESH_LEEWAY_SECONDS = 60
+
+export class SpotifyService {
+  async findByUserId(userId: string): Promise<UserIntegration | null> {
+    return UserIntegration.query()
+      .where('userId', userId)
+      .where('provider', IntegrationProvider.SPOTIFY)
+      .first()
+  }
+
+  async upsertIntegration(userId: string, payload: SpotifyUpsertPayload): Promise<UserIntegration> {
+    const existing = await this.findByUserId(userId)
+
+    const attributes = {
+      userId,
+      provider: IntegrationProvider.SPOTIFY,
+      providerUserId: payload.providerUserId,
+      accessToken: payload.accessToken,
+      refreshToken: payload.refreshToken ?? existing?.refreshToken ?? null,
+      expiresAt: payload.expiresAt ?? null,
+      scopes: payload.scopes ?? existing?.scopes ?? null,
+    }
+
+    return UserIntegration.updateOrCreate(
+      { userId, provider: IntegrationProvider.SPOTIFY },
+      attributes
+    )
+  }
+
+  async unlink(userId: string): Promise<boolean> {
+    const deleted = await UserIntegration.query()
+      .where('userId', userId)
+      .where('provider', IntegrationProvider.SPOTIFY)
+      .delete()
+    return Number(deleted[0]) > 0
+  }
+
+  async getValidAccessToken(userId: string): Promise<string> {
+    const integration = await this.findByUserId(userId)
+    if (!integration) {
+      throw new Error('Spotify integration not found')
+    }
+
+    if (!this.needsRefresh(integration)) {
+      return integration.accessToken
+    }
+
+    if (!integration.refreshToken) {
+      throw new Error('Spotify refresh token missing')
+    }
+
+    const refreshed = await this.refreshAccessToken(integration.refreshToken)
+
+    integration.accessToken = refreshed.access_token
+    if (refreshed.refresh_token) {
+      integration.refreshToken = refreshed.refresh_token
+    }
+    integration.expiresAt = DateTime.now().plus({ seconds: refreshed.expires_in })
+    if (refreshed.scope) integration.scopes = refreshed.scope
+    await integration.save()
+
+    return integration.accessToken
+  }
+
+  async getTopTracks(
+    userId: string,
+    options: { timeRange?: SpotifyTimeRange; limit?: number } = {}
+  ) {
+    return this.spotifyGet(userId, '/me/top/tracks', {
+      time_range: options.timeRange ?? 'medium_term',
+      limit: String(options.limit ?? 20),
+    })
+  }
+
+  async getTopArtists(
+    userId: string,
+    options: { timeRange?: SpotifyTimeRange; limit?: number } = {}
+  ) {
+    return this.spotifyGet(userId, '/me/top/artists', {
+      time_range: options.timeRange ?? 'medium_term',
+      limit: String(options.limit ?? 20),
+    })
+  }
+
+  async getRecentlyPlayed(userId: string, options: { limit?: number } = {}) {
+    return this.spotifyGet(userId, '/me/player/recently-played', {
+      limit: String(options.limit ?? 20),
+    })
+  }
+
+  private needsRefresh(integration: UserIntegration): boolean {
+    if (!integration.expiresAt) return false
+    return integration.expiresAt <= DateTime.now().plus({ seconds: REFRESH_LEEWAY_SECONDS })
+  }
+
+  private async refreshAccessToken(refreshToken: string): Promise<SpotifyRefreshResponse> {
+    const clientId = env.get('SPOTIFY_CLIENT_ID')
+    const clientSecret = env.get('SPOTIFY_CLIENT_SECRET')
+    const basicAuth = Buffer.from(`${clientId}:${clientSecret}`).toString('base64')
+
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    })
+
+    const response = await fetch(SPOTIFY_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Basic ${basicAuth}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body.toString(),
+    })
+
+    if (!response.ok) {
+      throw new Error(`Spotify token refresh failed: ${response.status}`)
+    }
+
+    return response.json() as Promise<SpotifyRefreshResponse>
+  }
+
+  private async spotifyGet(
+    userId: string,
+    path: string,
+    query: Record<string, string> = {}
+  ): Promise<unknown> {
+    const token = await this.getValidAccessToken(userId)
+    const url = new URL(SPOTIFY_API_BASE + path)
+    for (const [key, value] of Object.entries(query)) {
+      url.searchParams.set(key, value)
+    }
+
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    if (!response.ok) {
+      throw new Error(`Spotify API error ${response.status} on ${path}`)
+    }
+
+    return response.json()
+  }
+}

--- a/backend/app/services/spotify_service.ts
+++ b/backend/app/services/spotify_service.ts
@@ -24,6 +24,8 @@ interface SpotifyRefreshResponse {
 const SPOTIFY_API_BASE = 'https://api.spotify.com/v1'
 const SPOTIFY_TOKEN_URL = 'https://accounts.spotify.com/api/token'
 const REFRESH_LEEWAY_SECONDS = 60
+const MAX_RATE_LIMIT_RETRIES = 2
+const MAX_RETRY_DELAY_SECONDS = 30
 
 export class SpotifyService {
   async findByUserId(userId: string): Promise<UserIntegration | null> {
@@ -53,11 +55,10 @@ export class SpotifyService {
   }
 
   async unlink(userId: string): Promise<boolean> {
-    const deleted = await UserIntegration.query()
-      .where('userId', userId)
-      .where('provider', IntegrationProvider.SPOTIFY)
-      .delete()
-    return Number(deleted[0]) > 0
+    const integration = await this.findByUserId(userId)
+    if (!integration) return false
+    await integration.delete()
+    return true
   }
 
   async getValidAccessToken(userId: string): Promise<string> {
@@ -155,14 +156,35 @@ export class SpotifyService {
       url.searchParams.set(key, value)
     }
 
-    const response = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
-    })
+    for (let attempt = 0; attempt <= MAX_RATE_LIMIT_RETRIES; attempt++) {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
 
-    if (!response.ok) {
-      throw new Error(`Spotify API error ${response.status} on ${path}`)
+      if (response.status === 429) {
+        if (attempt === MAX_RATE_LIMIT_RETRIES) {
+          throw new Error(
+            `Spotify API rate limited on ${path} after ${MAX_RATE_LIMIT_RETRIES} retries`
+          )
+        }
+        const retryAfter = Number(response.headers.get('Retry-After'))
+        const delaySeconds = Math.min(
+          Number.isFinite(retryAfter) && retryAfter > 0 ? retryAfter : 2 ** attempt,
+          MAX_RETRY_DELAY_SECONDS
+        )
+        await this.sleep(delaySeconds * 1000)
+        continue
+      }
+
+      if (!response.ok) {
+        throw new Error(`Spotify API error ${response.status} on ${path}`)
+      }
+
+      return response.json()
     }
+  }
 
-    return response.json()
+  protected sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
   }
 }

--- a/backend/app/validators/spotify_validator.ts
+++ b/backend/app/validators/spotify_validator.ts
@@ -1,5 +1,11 @@
 import vine from '@vinejs/vine'
 
+export const spotifyInitValidator = vine.compile(
+  vine.object({
+    returnUrl: vine.string().trim().minLength(1).maxLength(500),
+  })
+)
+
 export const spotifyTopValidator = vine.compile(
   vine.object({
     timeRange: vine.enum(['short_term', 'medium_term', 'long_term']).optional(),

--- a/backend/app/validators/spotify_validator.ts
+++ b/backend/app/validators/spotify_validator.ts
@@ -1,0 +1,14 @@
+import vine from '@vinejs/vine'
+
+export const spotifyTopValidator = vine.compile(
+  vine.object({
+    timeRange: vine.enum(['short_term', 'medium_term', 'long_term']).optional(),
+    limit: vine.number().min(1).max(50).optional(),
+  })
+)
+
+export const spotifyRecentlyPlayedValidator = vine.compile(
+  vine.object({
+    limit: vine.number().min(1).max(50).optional(),
+  })
+)

--- a/backend/config/ally.ts
+++ b/backend/config/ally.ts
@@ -1,0 +1,17 @@
+import env from '#start/env'
+import { defineConfig, services } from '@adonisjs/ally'
+
+const allyConfig = defineConfig({
+  spotify: services.spotify({
+    clientId: env.get('SPOTIFY_CLIENT_ID'),
+    clientSecret: env.get('SPOTIFY_CLIENT_SECRET'),
+    callbackUrl: env.get('SPOTIFY_CALLBACK_URL'),
+    scopes: ['user-read-email', 'user-top-read', 'user-read-recently-played'],
+  }),
+})
+
+export default allyConfig
+
+declare module '@adonisjs/ally/types' {
+  interface SocialProviders extends InferSocialProviders<typeof allyConfig> {}
+}

--- a/backend/database/migrations/1776428527193_create_create_user_integrations_table.ts
+++ b/backend/database/migrations/1776428527193_create_create_user_integrations_table.ts
@@ -1,0 +1,38 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+import { INTEGRATION_PROVIDERS } from '#enums/integration_provider'
+
+export default class extends BaseSchema {
+  protected tableName = 'user_integrations'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+
+      table
+        .string('user_id', 36)
+        .notNullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('CASCADE')
+
+      table.enum('provider', INTEGRATION_PROVIDERS).notNullable()
+      table.string('provider_user_id').notNullable()
+
+      table.text('access_token').notNullable()
+      table.text('refresh_token').nullable()
+
+      table.timestamp('expires_at').nullable()
+      table.text('scopes').nullable()
+
+      table.timestamp('created_at')
+      table.timestamp('updated_at')
+
+      table.unique(['user_id', 'provider'])
+      table.index(['provider', 'provider_user_id'])
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/docs/spotify-guidelines.md
+++ b/backend/docs/spotify-guidelines.md
@@ -1,0 +1,64 @@
+# Spotify Integration Guidelines
+
+Règles officielles (issues de la doc Spotify pour AI) à respecter quand on touche à l'intégration Spotify, côté `backend` comme `front-mobile`.
+
+## OpenAPI spec
+
+Toujours se référer au schéma OpenAPI officiel pour les endpoints, paramètres et schémas de réponse — ne jamais deviner un endpoint ou un nom de champ.
+
+- Spec : https://developer.spotify.com/reference/web-api/open-api-schema.yaml
+
+## Authorization flows
+
+- **Avec un backend sécurisé (notre cas)** : utiliser le flow [Authorization Code](https://developer.spotify.com/documentation/web-api/tutorials/code-flow). Le `client_secret` vit côté backend uniquement.
+- **Sans backend (non utilisé ici)** : utiliser [Authorization Code with PKCE](https://developer.spotify.com/documentation/web-api/tutorials/code-pkce-flow).
+- **Client Credentials** : uniquement pour des données publiques non liées à un utilisateur.
+- **Implicit Grant** : interdit (déprécié).
+
+## Redirect URIs
+
+- Toujours HTTPS, sauf `http://127.0.0.1` pour le dev local.
+- Jamais `http://localhost` ni wildcards.
+- Doc : https://developer.spotify.com/documentation/web-api/concepts/redirect_uri
+
+## Scopes
+
+Ne demander que le minimum nécessaire. Ne pas pré-demander de scopes « au cas où ».
+
+Scopes actuellement utilisés (voir `config/ally.ts`) :
+
+- `user-read-email`
+- `user-top-read`
+- `user-read-recently-played`
+
+Doc : https://developer.spotify.com/documentation/web-api/concepts/scopes
+
+## Token management
+
+- `client_secret` **jamais** côté mobile — uniquement dans le backend (`.env`).
+- `access_token` et `refresh_token` stockés chiffrés en base (voir `user_integration.ts`, colonnes `encryptedColumn`).
+- Refresh automatique côté backend via `SpotifyService.getValidAccessToken()` — si Spotify omet un nouveau `refresh_token`, on garde l'ancien.
+- Doc : https://developer.spotify.com/documentation/web-api/tutorials/refreshing-tokens
+
+## Rate limits
+
+Sur HTTP 429 : respecter l'en-tête `Retry-After`, appliquer un backoff exponentiel. Pas de retry immédiat ni en boucle serrée.
+
+## Deprecated endpoints
+
+- Préférer `/playlists/{id}/items` à `/playlists/{id}/tracks`.
+- Préférer `/me/library` aux endpoints de librairie par type.
+- Ne pas consommer d'endpoint marqué déprécié dans la spec.
+
+## Error handling
+
+- Gérer tous les codes HTTP documentés dans la spec OpenAPI.
+- Lire le message d'erreur renvoyé par Spotify et le propager au user quand c'est utile.
+- Côté backend : log structuré (`logger.error({ err, ... })`), jamais juste `console.log`.
+
+## Developer Terms of Service
+
+- Ne **pas** cacher le contenu Spotify au-delà de l'usage immédiat.
+- Toujours attribuer le contenu à Spotify (logo, nom, lien).
+- Ne **pas** utiliser l'API pour entraîner un modèle ML sur des données Spotify.
+- Doc : https://developer.spotify.com/terms

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -91,6 +91,19 @@
         "@adonisjs/core": "^6.2.0"
       }
     },
+    "node_modules/@adonisjs/ally/node_modules/@poppinss/oauth-client": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@poppinss/oauth-client/-/oauth-client-7.0.1.tgz",
+      "integrity": "sha512-TQVDyNqiheSNjooD0Rx3cSbBlUWxZxWgCyC278iaVTnmlunS94qEk6Grw+thm5L1Y2+O+dfsZRtkR117hbEe1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.1",
+        "ky": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=18.16.0"
+      }
+    },
     "node_modules/@adonisjs/application": {
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@adonisjs/application/-/application-8.4.1.tgz",
@@ -2231,19 +2244,6 @@
         "http-errors": "^2.0.0",
         "safe-buffer": "5.2.1",
         "uid-safe": "2.1.5"
-      }
-    },
-    "node_modules/@poppinss/oauth-client": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@poppinss/oauth-client/-/oauth-client-7.2.0.tgz",
-      "integrity": "sha512-LUCd/fIm2oOeTltnZRSJIxZL9uy9+qHpgtNtxIO+wp8E/1Dd7ogbqIWUFYMufCxTekOoYyQlWOcOQ9rmUw5D5g==",
-      "license": "MIT",
-      "dependencies": {
-        "@poppinss/exception": "^1.2.3",
-        "ky": "^1.14.3"
-      },
-      "engines": {
-        "node": ">=24.0.0"
       }
     },
     "node_modules/@poppinss/object-builder": {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "UNLICENSED",
       "dependencies": {
+        "@adonisjs/ally": "^5.1.1",
         "@adonisjs/auth": "^9.4.0",
         "@adonisjs/core": "^6.18.0",
         "@adonisjs/cors": "^2.2.1",
@@ -72,6 +73,22 @@
       },
       "engines": {
         "node": ">=18.16.0"
+      }
+    },
+    "node_modules/@adonisjs/ally": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@adonisjs/ally/-/ally-5.1.1.tgz",
+      "integrity": "sha512-Uu+g5y7jnmMP0iXhPYTx9caJnovp+CTqxDN6XpyuLQGVZjNr9fqbPeaBVs1/jTAVSAtpv4UrHsb+827XXd24Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/oauth-client": "^7.0.1",
+        "@poppinss/utils": "^6.10.1"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "peerDependencies": {
+        "@adonisjs/core": "^6.2.0"
       }
     },
     "node_modules/@adonisjs/application": {
@@ -2164,9 +2181,9 @@
       }
     },
     "node_modules/@poppinss/exception": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.2.tgz",
-      "integrity": "sha512-m7bpKCD4QMlFCjA/nKTs23fuvoVFoA83brRKmObCUNmi/9tVu8Ve3w4YQAnJu4q3Tjf5fr685HYIC/IA2zHRSg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "license": "MIT"
     },
     "node_modules/@poppinss/hooks": {
@@ -2214,6 +2231,19 @@
         "http-errors": "^2.0.0",
         "safe-buffer": "5.2.1",
         "uid-safe": "2.1.5"
+      }
+    },
+    "node_modules/@poppinss/oauth-client": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@poppinss/oauth-client/-/oauth-client-7.2.0.tgz",
+      "integrity": "sha512-LUCd/fIm2oOeTltnZRSJIxZL9uy9+qHpgtNtxIO+wp8E/1Dd7ogbqIWUFYMufCxTekOoYyQlWOcOQ9rmUw5D5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.3",
+        "ky": "^1.14.3"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@poppinss/object-builder": {
@@ -6807,6 +6837,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
     "node_modules/levn": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -81,7 +81,8 @@
     ]
   },
   "overrides": {
-    "@stylistic/eslint-plugin-ts": "npm:@stylistic/eslint-plugin@^5.6.1"
+    "@stylistic/eslint-plugin-ts": "npm:@stylistic/eslint-plugin@^5.6.1",
+    "@poppinss/oauth-client": "7.0.1"
   },
   "prettier": "@adonisjs/prettier-config"
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -60,6 +60,7 @@
     "typescript": "~5.8"
   },
   "dependencies": {
+    "@adonisjs/ally": "^5.1.1",
     "@adonisjs/auth": "^9.4.0",
     "@adonisjs/core": "^6.18.0",
     "@adonisjs/cors": "^2.2.1",

--- a/backend/start/env.ts
+++ b/backend/start/env.ts
@@ -54,4 +54,14 @@ export default await Env.create(new URL('../', import.meta.url), {
   |----------------------------------------------------------
   */
   LIMITER_STORE: Env.schema.enum(['database', 'memory'] as const),
+
+  /*
+  |----------------------------------------------------------
+  | Variables for Spotify OAuth integration (@adonisjs/ally)
+  |----------------------------------------------------------
+  */
+  SPOTIFY_CLIENT_ID: Env.schema.string(),
+  SPOTIFY_CLIENT_SECRET: Env.schema.string(),
+  SPOTIFY_CALLBACK_URL: Env.schema.string(),
+  SPOTIFY_DEEP_LINK_SCHEME: Env.schema.string.optional(),
 })

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -13,6 +13,8 @@ const LikedTracksController = () => import('#controllers/liked_tracks_controller
 const FavoriteGamesController = () => import('#controllers/favorite_games_controller')
 const UserAchievementsController = () => import('#controllers/user_achievements_controller')
 const ProfileController = () => import('#controllers/profile_controller')
+const SpotifyAuthController = () => import('#controllers/spotify_auth_controller')
+const MeIntegrationsController = () => import('#controllers/me_integrations_controller')
 
 // Register OpenAPI/Swagger routes: /docs, /docs.json, /docs.yaml
 openapi.registerRoutes('/docs')
@@ -32,6 +34,7 @@ router.get('/', async ({ response }) => {
       userAchievements: '/api/user-achievements',
       gameSessions: '/api/game-sessions',
       profile: '/api/profile',
+      me: '/api/me',
       docs: '/docs',
     },
   })
@@ -51,8 +54,21 @@ router
           .post('/resend-verification', [AuthController, 'resendVerificationEmail'])
           .use(resendVerificationThrottle)
         router.get('/me', [AuthController, 'me']).use(middleware.auth())
+        router.get('/spotify/redirect', [SpotifyAuthController, 'redirect'])
+        router.get('/spotify/callback', [SpotifyAuthController, 'callback'])
       })
       .prefix('/auth')
+
+    router
+      .group(() => {
+        router.get('/spotify/status', [MeIntegrationsController, 'spotifyStatus'])
+        router.get('/spotify/top-tracks', [MeIntegrationsController, 'topTracks'])
+        router.get('/spotify/top-artists', [MeIntegrationsController, 'topArtists'])
+        router.get('/spotify/recently-played', [MeIntegrationsController, 'recentlyPlayed'])
+        router.delete('/spotify', [MeIntegrationsController, 'unlinkSpotify'])
+      })
+      .prefix('/me')
+      .use(middleware.auth())
 
     router
       .group(() => {

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -54,7 +54,7 @@ router
           .post('/resend-verification', [AuthController, 'resendVerificationEmail'])
           .use(resendVerificationThrottle)
         router.get('/me', [AuthController, 'me']).use(middleware.auth())
-        router.get('/spotify/redirect', [SpotifyAuthController, 'redirect'])
+        router.post('/spotify/init', [SpotifyAuthController, 'init']).use(middleware.auth())
         router.get('/spotify/callback', [SpotifyAuthController, 'callback'])
       })
       .prefix('/auth')

--- a/backend/tests/functional/me_integrations_controller.spec.ts
+++ b/backend/tests/functional/me_integrations_controller.spec.ts
@@ -1,0 +1,188 @@
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+import { createAuthenticatedUser } from '../utils/auth_helpers.js'
+import { SpotifyService } from '#services/spotify_service'
+import { deleteUserIntegrations } from '#tests/utils/user_integration_helpers'
+
+test.group('MeIntegrationsController - Spotify status', (group) => {
+  deleteUserIntegrations(group)
+
+  test('GET /api/me/spotify/status returns 401 without auth', async ({ client }) => {
+    const response = await client.get('/api/me/spotify/status')
+    response.assertStatus(401)
+  })
+
+  test('GET /api/me/spotify/status returns connected=false for a fresh user', async ({
+    client,
+  }) => {
+    const { token } = await createAuthenticatedUser('spotify_status_off')
+    const response = await client.get('/api/me/spotify/status').bearerToken(token)
+    response.assertStatus(200)
+    response.assertBodyContains({ connected: false })
+  })
+
+  test('GET /api/me/spotify/status returns connected=true after linking', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('spotify_status_on')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_linked',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-read-email',
+    })
+
+    const response = await client.get('/api/me/spotify/status').bearerToken(token)
+    response.assertStatus(200)
+    assert.equal(response.body().connected, true)
+    assert.equal(response.body().providerUserId, 'sp_linked')
+    assert.equal(response.body().scopes, 'user-read-email')
+  })
+})
+
+test.group('MeIntegrationsController - Unlink', (group) => {
+  deleteUserIntegrations(group)
+
+  test('DELETE /api/me/spotify returns 404 when no integration', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('spotify_unlink_missing')
+    const response = await client.delete('/api/me/spotify').bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('DELETE /api/me/spotify removes the integration', async ({ client, assert }) => {
+    const { user, token } = await createAuthenticatedUser('spotify_unlink_ok')
+    const service = new SpotifyService()
+    await service.upsertIntegration(user.id, {
+      providerUserId: 'sp_unlink',
+      accessToken: 'x',
+    })
+
+    const response = await client.delete('/api/me/spotify').bearerToken(token)
+    response.assertStatus(200)
+
+    assert.isNull(await service.findByUserId(user.id))
+  })
+})
+
+test.group('MeIntegrationsController - Top tracks guards', (group) => {
+  deleteUserIntegrations(group)
+
+  test('GET /api/me/spotify/top-tracks returns 401 without auth', async ({ client }) => {
+    const response = await client.get('/api/me/spotify/top-tracks')
+    response.assertStatus(401)
+  })
+
+  test('GET /api/me/spotify/top-tracks returns 404 when no integration', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('spotify_tt_nolink')
+    const response = await client.get('/api/me/spotify/top-tracks').bearerToken(token)
+    response.assertStatus(404)
+  })
+
+  test('GET /api/me/spotify/top-tracks returns 422 for invalid timeRange', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('spotify_tt_bad')
+    const response = await client
+      .get('/api/me/spotify/top-tracks')
+      .qs({ timeRange: 'nope' })
+      .bearerToken(token)
+    response.assertStatus(422)
+  })
+})
+
+test.group('MeIntegrationsController - Spotify data fetch', (group) => {
+  deleteUserIntegrations(group)
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  async function linkUser(tag: string) {
+    const ctx = await createAuthenticatedUser(tag)
+    await new SpotifyService().upsertIntegration(ctx.user.id, {
+      providerUserId: `sp_${tag}`,
+      accessToken: 'valid',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-top-read',
+    })
+    return ctx
+  }
+
+  test('GET /top-tracks returns 200 with data for a linked user', async ({ client, assert }) => {
+    const { token } = await linkUser('spotify_tt_ok')
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ items: [{ id: 'track_a', name: 'Track A' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const response = await client.get('/api/me/spotify/top-tracks').bearerToken(token)
+    response.assertStatus(200)
+    assert.equal(response.body().items[0].id, 'track_a')
+  })
+
+  test('GET /top-artists returns 200 with data', async ({ client, assert }) => {
+    const { token } = await linkUser('spotify_ta_ok')
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ items: [{ id: 'artist_a', name: 'Artist A' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const response = await client.get('/api/me/spotify/top-artists').bearerToken(token)
+    response.assertStatus(200)
+    assert.equal(response.body().items[0].id, 'artist_a')
+  })
+
+  test('GET /recently-played returns 200 with data', async ({ client, assert }) => {
+    const { token } = await linkUser('spotify_rp_ok')
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ items: [{ track: { id: 'recent_a' } }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const response = await client.get('/api/me/spotify/recently-played').bearerToken(token)
+    response.assertStatus(200)
+    assert.equal(response.body().items[0].track.id, 'recent_a')
+  })
+
+  test('GET /top-tracks returns 401 when integration is expired and has no refresh token', async ({
+    client,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('spotify_tt_norefresh')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_norefresh',
+      accessToken: 'expired',
+      refreshToken: null,
+      expiresAt: DateTime.now().minus({ minutes: 5 }),
+    })
+
+    const response = await client.get('/api/me/spotify/top-tracks').bearerToken(token)
+    response.assertStatus(401)
+    response.assertBodyContains({ message: 'Spotify session expired, please reconnect' })
+  })
+
+  test('GET /top-tracks returns 500 on generic Spotify API error', async ({ client }) => {
+    const { token } = await linkUser('spotify_tt_500')
+
+    globalThis.fetch = async () =>
+      new Response('{"error":{"status":500}}', {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const response = await client.get('/api/me/spotify/top-tracks').bearerToken(token)
+    response.assertStatus(500)
+    response.assertBodyContains({ message: 'Failed to fetch Spotify data' })
+  })
+})

--- a/backend/tests/functional/spotify_auth_controller.spec.ts
+++ b/backend/tests/functional/spotify_auth_controller.spec.ts
@@ -6,58 +6,47 @@ import { createAuthenticatedUser } from '../utils/auth_helpers.js'
 import { deleteUserIntegrations } from '#tests/utils/user_integration_helpers'
 import { SpotifyService } from '#services/spotify_service'
 
-test.group('SpotifyAuthController - Redirect guards', (group) => {
+test.group('SpotifyAuthController - Init guards', (group) => {
   deleteUserIntegrations(group)
 
-  test('GET /api/auth/spotify/redirect returns 401 without token', async ({ client }) => {
+  test('POST /api/auth/spotify/init returns 401 without auth', async ({ client }) => {
     const response = await client
-      .get('/api/auth/spotify/redirect')
-      .qs({ returnUrl: 'frontmobile://spotify-linked' })
-      .redirects(0)
+      .post('/api/auth/spotify/init')
+      .json({ returnUrl: 'frontmobile://spotify-linked' })
     response.assertStatus(401)
   })
 
-  test('GET /api/auth/spotify/redirect returns 401 with an invalid token', async ({ client }) => {
-    const response = await client
-      .get('/api/auth/spotify/redirect')
-      .qs({ token: 'oat_xxx_nope', returnUrl: 'frontmobile://spotify-linked' })
-      .redirects(0)
-    response.assertStatus(401)
+  test('POST /api/auth/spotify/init returns 422 when returnUrl is missing', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('spotify_init_no_return')
+    const response = await client.post('/api/auth/spotify/init').json({}).bearerToken(token)
+    response.assertStatus(422)
   })
 
-  test('GET /api/auth/spotify/redirect returns 400 when returnUrl is missing', async ({
+  test('POST /api/auth/spotify/init returns 400 when returnUrl scheme is not allowed', async ({
     client,
   }) => {
-    const { token } = await createAuthenticatedUser('spotify_redirect_no_return')
-    const response = await client.get('/api/auth/spotify/redirect').qs({ token }).redirects(0)
+    const { token } = await createAuthenticatedUser('spotify_init_bad_scheme')
+    const response = await client
+      .post('/api/auth/spotify/init')
+      .json({ returnUrl: 'https://evil.example.com/callback' })
+      .bearerToken(token)
     response.assertStatus(400)
   })
 
-  test('GET /api/auth/spotify/redirect returns 400 when returnUrl scheme is not allowed', async ({
-    client,
-  }) => {
-    const { token } = await createAuthenticatedUser('spotify_redirect_bad_scheme')
-    const response = await client
-      .get('/api/auth/spotify/redirect')
-      .qs({ token, returnUrl: 'https://evil.example.com/callback' })
-      .redirects(0)
-    response.assertStatus(400)
-  })
-
-  test('GET /api/auth/spotify/redirect issues a 302 to Spotify with valid input', async ({
+  test('POST /api/auth/spotify/init returns 200 with Spotify authorize URL', async ({
     client,
     assert,
   }) => {
-    const { token } = await createAuthenticatedUser('spotify_redirect_ok')
+    const { token } = await createAuthenticatedUser('spotify_init_ok')
     const response = await client
-      .get('/api/auth/spotify/redirect')
-      .qs({ token, returnUrl: 'frontmobile://spotify-linked' })
-      .redirects(0)
+      .post('/api/auth/spotify/init')
+      .json({ returnUrl: 'frontmobile://spotify-linked' })
+      .bearerToken(token)
 
-    response.assertStatus(302)
-    const location = response.headers().location as string
-    assert.include(location, 'accounts.spotify.com')
-    assert.include(location, 'state=')
+    response.assertStatus(200)
+    const body = response.body() as { authorizeUrl: string }
+    assert.include(body.authorizeUrl, 'accounts.spotify.com')
+    assert.include(body.authorizeUrl, 'state=')
   })
 })
 

--- a/backend/tests/functional/spotify_auth_controller.spec.ts
+++ b/backend/tests/functional/spotify_auth_controller.spec.ts
@@ -1,0 +1,270 @@
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+import { HttpContext } from '@adonisjs/core/http'
+import encryption from '@adonisjs/core/services/encryption'
+import { createAuthenticatedUser } from '../utils/auth_helpers.js'
+import { deleteUserIntegrations } from '#tests/utils/user_integration_helpers'
+import { SpotifyService } from '#services/spotify_service'
+
+test.group('SpotifyAuthController - Redirect guards', (group) => {
+  deleteUserIntegrations(group)
+
+  test('GET /api/auth/spotify/redirect returns 401 without token', async ({ client }) => {
+    const response = await client
+      .get('/api/auth/spotify/redirect')
+      .qs({ returnUrl: 'frontmobile://spotify-linked' })
+      .redirects(0)
+    response.assertStatus(401)
+  })
+
+  test('GET /api/auth/spotify/redirect returns 401 with an invalid token', async ({ client }) => {
+    const response = await client
+      .get('/api/auth/spotify/redirect')
+      .qs({ token: 'oat_xxx_nope', returnUrl: 'frontmobile://spotify-linked' })
+      .redirects(0)
+    response.assertStatus(401)
+  })
+
+  test('GET /api/auth/spotify/redirect returns 400 when returnUrl is missing', async ({
+    client,
+  }) => {
+    const { token } = await createAuthenticatedUser('spotify_redirect_no_return')
+    const response = await client.get('/api/auth/spotify/redirect').qs({ token }).redirects(0)
+    response.assertStatus(400)
+  })
+
+  test('GET /api/auth/spotify/redirect returns 400 when returnUrl scheme is not allowed', async ({
+    client,
+  }) => {
+    const { token } = await createAuthenticatedUser('spotify_redirect_bad_scheme')
+    const response = await client
+      .get('/api/auth/spotify/redirect')
+      .qs({ token, returnUrl: 'https://evil.example.com/callback' })
+      .redirects(0)
+    response.assertStatus(400)
+  })
+
+  test('GET /api/auth/spotify/redirect issues a 302 to Spotify with valid input', async ({
+    client,
+    assert,
+  }) => {
+    const { token } = await createAuthenticatedUser('spotify_redirect_ok')
+    const response = await client
+      .get('/api/auth/spotify/redirect')
+      .qs({ token, returnUrl: 'frontmobile://spotify-linked' })
+      .redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'accounts.spotify.com')
+    assert.include(location, 'state=')
+  })
+})
+
+interface AllyMockScenario {
+  denied?: boolean
+  accessTokenResponse?: {
+    token: string
+    refreshToken?: string
+    expiresIn?: number
+    scope?: string
+  }
+  throwOnAccessToken?: Error
+}
+
+function buildFakeAlly(scenario: AllyMockScenario) {
+  return {
+    use() {
+      return {
+        stateless() {
+          return this
+        },
+        accessDenied() {
+          return scenario.denied === true
+        },
+        async accessToken() {
+          if (scenario.throwOnAccessToken) throw scenario.throwOnAccessToken
+          return scenario.accessTokenResponse ?? { token: 'fake-access', expiresIn: 3600 }
+        },
+      }
+    },
+  }
+}
+
+function buildValidState(userId: string, returnUrl = 'frontmobile://spotify-linked'): string {
+  return encryption.encrypt({
+    userId,
+    returnUrl,
+    expiresAt: DateTime.now().plus({ minutes: 10 }).toISO(),
+  })
+}
+
+test.group('SpotifyAuthController - Callback', (group) => {
+  deleteUserIntegrations(group)
+  let originalAllyDescriptor: PropertyDescriptor | undefined
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalAllyDescriptor = Object.getOwnPropertyDescriptor(HttpContext.prototype, 'ally')
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    if (originalAllyDescriptor) {
+      Object.defineProperty(HttpContext.prototype, 'ally', originalAllyDescriptor)
+    }
+    globalThis.fetch = originalFetch
+  })
+
+  function installAllyMock(scenario: AllyMockScenario) {
+    const fake = buildFakeAlly(scenario)
+    Object.defineProperty(HttpContext.prototype, 'ally', {
+      get() {
+        return fake
+      },
+      configurable: true,
+      enumerable: false,
+    })
+  }
+
+  test('callback redirects with invalid_state when no state is provided', async ({
+    client,
+    assert,
+  }) => {
+    installAllyMock({ denied: false })
+
+    const response = await client.get('/api/auth/spotify/callback').redirects(0)
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'status=error')
+    assert.include(location, 'reason=invalid_state')
+  })
+
+  test('callback redirects with access_denied when Spotify denies', async ({ client, assert }) => {
+    const { user } = await createAuthenticatedUser('cb_denied')
+    installAllyMock({ denied: true })
+
+    const state = buildValidState(user.id)
+    const response = await client.get('/api/auth/spotify/callback').qs({ state }).redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'frontmobile://spotify-linked')
+    assert.include(location, 'reason=access_denied')
+  })
+
+  test('callback redirects with invalid_state when state is expired', async ({
+    client,
+    assert,
+  }) => {
+    installAllyMock({ denied: false })
+    const expiredState = encryption.encrypt({
+      userId: 'anyone',
+      returnUrl: 'frontmobile://spotify-linked',
+      expiresAt: DateTime.now().minus({ minutes: 5 }).toISO(),
+    })
+
+    const response = await client
+      .get('/api/auth/spotify/callback')
+      .qs({ state: expiredState })
+      .redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'reason=invalid_state')
+  })
+
+  test('callback upserts the integration and redirects with status=ok on success', async ({
+    client,
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('cb_ok')
+    installAllyMock({
+      accessTokenResponse: {
+        token: 'new-access',
+        refreshToken: 'new-refresh',
+        expiresIn: 3600,
+        scope: 'user-read-email user-top-read',
+      },
+    })
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ id: 'spotify_me_id', email: 'a@b.c' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const state = buildValidState(user.id)
+    const response = await client.get('/api/auth/spotify/callback').qs({ state }).redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'frontmobile://spotify-linked')
+    assert.include(location, 'status=ok')
+
+    const integration = await new SpotifyService().findByUserId(user.id)
+    assert.isNotNull(integration)
+    assert.equal(integration!.providerUserId, 'spotify_me_id')
+    assert.equal(integration!.accessToken, 'new-access')
+    assert.equal(integration!.refreshToken, 'new-refresh')
+    assert.equal(integration!.scopes, 'user-read-email user-top-read')
+  })
+
+  test('callback redirects with reason=spotify_me_<status> when /v1/me fails', async ({
+    client,
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('cb_me_403')
+    installAllyMock({})
+
+    globalThis.fetch = async () =>
+      new Response('{"error":{"status":403}}', {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const state = buildValidState(user.id)
+    const response = await client.get('/api/auth/spotify/callback').qs({ state }).redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'reason=spotify_me_403')
+  })
+
+  test('callback redirects with reason=spotify_me_no_id when /v1/me body has no id', async ({
+    client,
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('cb_me_noid')
+    installAllyMock({})
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ email: 'no-id@example.com' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const state = buildValidState(user.id)
+    const response = await client.get('/api/auth/spotify/callback').qs({ state }).redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'reason=spotify_me_no_id')
+  })
+
+  test('callback redirects with an error reason when accessToken throws', async ({
+    client,
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('cb_token_throws')
+    installAllyMock({ throwOnAccessToken: new Error('invalid_grant') })
+
+    const state = buildValidState(user.id)
+    const response = await client.get('/api/auth/spotify/callback').qs({ state }).redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'status=error')
+    assert.include(location, 'reason=invalid_grant')
+  })
+})

--- a/backend/tests/unit/spotify_service.spec.ts
+++ b/backend/tests/unit/spotify_service.spec.ts
@@ -1,0 +1,317 @@
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+import User from '#models/user'
+import UserIntegration from '#models/user_integration'
+import { SpotifyService } from '#services/spotify_service'
+import { IntegrationProvider } from '#enums/integration_provider'
+import { deleteUserIntegrations } from '#tests/utils/user_integration_helpers'
+
+async function createUser(tag: string) {
+  return User.create({
+    username: `spot_${tag}_${Date.now()}_${Math.random()}`,
+    email: `spot_${tag}_${Date.now()}_${Math.random()}@example.com`,
+    password: 'password123',
+  })
+}
+
+test.group('SpotifyService - Persistence', (group) => {
+  deleteUserIntegrations(group)
+  let service: SpotifyService
+
+  group.each.setup(() => {
+    service = new SpotifyService()
+  })
+
+  test('upsertIntegration creates a new integration with encrypted tokens', async ({ assert }) => {
+    const user = await createUser('upsert_create')
+    const integration = await service.upsertIntegration(user.id, {
+      providerUserId: 'spotify_user_1',
+      accessToken: 'access-token-1',
+      refreshToken: 'refresh-token-1',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-read-email',
+    })
+
+    assert.instanceOf(integration, UserIntegration)
+    assert.equal(integration.userId, user.id)
+    assert.equal(integration.provider, IntegrationProvider.SPOTIFY)
+    assert.equal(integration.accessToken, 'access-token-1')
+
+    const row = await UserIntegration.query().where('id', integration.id).firstOrFail()
+    assert.equal(row.accessToken, 'access-token-1')
+    assert.equal(row.refreshToken, 'refresh-token-1')
+  })
+
+  test('upsertIntegration updates an existing integration and keeps old refresh token when absent', async ({
+    assert,
+  }) => {
+    const user = await createUser('upsert_update')
+    await service.upsertIntegration(user.id, {
+      providerUserId: 'spotify_user_2',
+      accessToken: 'old-access',
+      refreshToken: 'old-refresh',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+    })
+
+    const updated = await service.upsertIntegration(user.id, {
+      providerUserId: 'spotify_user_2',
+      accessToken: 'new-access',
+      expiresAt: DateTime.now().plus({ hours: 2 }),
+    })
+
+    assert.equal(updated.accessToken, 'new-access')
+    assert.equal(updated.refreshToken, 'old-refresh')
+
+    const count = await UserIntegration.query().where('user_id', user.id).count('* as total')
+    assert.equal(Number(count[0].$extras.total), 1)
+  })
+
+  test('unlink returns false when no integration exists', async ({ assert }) => {
+    const user = await createUser('unlink_missing')
+    const result = await service.unlink(user.id)
+    assert.isFalse(result)
+  })
+
+  test('unlink deletes the integration and returns true', async ({ assert }) => {
+    const user = await createUser('unlink_ok')
+    await service.upsertIntegration(user.id, {
+      providerUserId: 'sp_x',
+      accessToken: 'x',
+    })
+
+    const result = await service.unlink(user.id)
+    assert.isTrue(result)
+    assert.isNull(await service.findByUserId(user.id))
+  })
+})
+
+test.group('SpotifyService - Token refresh', (group) => {
+  deleteUserIntegrations(group)
+  let service: SpotifyService
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    service = new SpotifyService()
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('getValidAccessToken returns the stored token when not expired', async ({ assert }) => {
+    const user = await createUser('valid_token')
+    await service.upsertIntegration(user.id, {
+      providerUserId: 'sp_valid',
+      accessToken: 'still-good',
+      refreshToken: 'r-1',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+    })
+
+    const calls: unknown[] = []
+    globalThis.fetch = async (...args: unknown[]) => {
+      calls.push(args)
+      throw new Error('should not be called')
+    }
+
+    const token = await service.getValidAccessToken(user.id)
+    assert.equal(token, 'still-good')
+    assert.equal(calls.length, 0)
+  })
+
+  test('getValidAccessToken refreshes expired token and keeps old refresh_token when Spotify omits it', async ({
+    assert,
+  }) => {
+    const user = await createUser('refresh_keep_old')
+    await service.upsertIntegration(user.id, {
+      providerUserId: 'sp_refresh',
+      accessToken: 'expired',
+      refreshToken: 'old-refresh',
+      expiresAt: DateTime.now().minus({ minutes: 5 }),
+    })
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ access_token: 'fresh', expires_in: 3600 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const token = await service.getValidAccessToken(user.id)
+    assert.equal(token, 'fresh')
+
+    const integration = await service.findByUserId(user.id)
+    assert.equal(integration!.accessToken, 'fresh')
+    assert.equal(integration!.refreshToken, 'old-refresh')
+  })
+
+  test('getValidAccessToken stores the new refresh_token when Spotify returns one', async ({
+    assert,
+  }) => {
+    const user = await createUser('refresh_rotate')
+    await service.upsertIntegration(user.id, {
+      providerUserId: 'sp_rotate',
+      accessToken: 'expired',
+      refreshToken: 'old-refresh',
+      expiresAt: DateTime.now().minus({ minutes: 5 }),
+    })
+
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({
+          access_token: 'fresh',
+          refresh_token: 'rotated',
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+
+    await service.getValidAccessToken(user.id)
+    const integration = await service.findByUserId(user.id)
+    assert.equal(integration!.refreshToken, 'rotated')
+  })
+
+  test('getValidAccessToken throws when no integration exists', async ({ assert }) => {
+    const user = await createUser('no_integration')
+    await assert.rejects(async () => {
+      await service.getValidAccessToken(user.id)
+    }, /not found/)
+  })
+
+  test('getValidAccessToken throws when expired and no refresh token stored', async ({
+    assert,
+  }) => {
+    const user = await createUser('refresh_missing')
+    await service.upsertIntegration(user.id, {
+      providerUserId: 'sp_missing',
+      accessToken: 'expired',
+      refreshToken: null,
+      expiresAt: DateTime.now().minus({ minutes: 5 }),
+    })
+
+    await assert.rejects(async () => {
+      await service.getValidAccessToken(user.id)
+    }, /refresh token missing/)
+  })
+
+  test('getValidAccessToken throws when Spotify refresh endpoint returns non-2xx', async ({
+    assert,
+  }) => {
+    const user = await createUser('refresh_http_fail')
+    await service.upsertIntegration(user.id, {
+      providerUserId: 'sp_http_fail',
+      accessToken: 'expired',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().minus({ minutes: 5 }),
+    })
+
+    globalThis.fetch = async () =>
+      new Response('{"error":"invalid_grant"}', {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    await assert.rejects(async () => {
+      await service.getValidAccessToken(user.id)
+    }, /token refresh failed: 400/)
+  })
+})
+
+test.group('SpotifyService - API fetch', (group) => {
+  deleteUserIntegrations(group)
+  let service: SpotifyService
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    service = new SpotifyService()
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  async function createLinkedUser(tag: string) {
+    const user = await createUser(tag)
+    await service.upsertIntegration(user.id, {
+      providerUserId: `sp_${tag}`,
+      accessToken: 'valid-access',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+    })
+    return user
+  }
+
+  test('getTopTracks hits the right URL with time_range and limit', async ({ assert }) => {
+    const user = await createLinkedUser('tt_ok')
+    let capturedUrl: string | null = null
+
+    globalThis.fetch = async (input) => {
+      capturedUrl = typeof input === 'string' ? input : (input as URL).toString()
+      return new Response(JSON.stringify({ items: [{ id: 'track_1' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const data = (await service.getTopTracks(user.id, {
+      timeRange: 'short_term',
+      limit: 5,
+    })) as { items: { id: string }[] }
+
+    assert.equal(data.items[0].id, 'track_1')
+    assert.include(capturedUrl!, 'https://api.spotify.com/v1/me/top/tracks')
+    assert.include(capturedUrl!, 'time_range=short_term')
+    assert.include(capturedUrl!, 'limit=5')
+  })
+
+  test('getTopArtists uses medium_term and limit=20 by default', async ({ assert }) => {
+    const user = await createLinkedUser('ta_defaults')
+    let capturedUrl: string | null = null
+
+    globalThis.fetch = async (input) => {
+      capturedUrl = typeof input === 'string' ? input : (input as URL).toString()
+      return new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    await service.getTopArtists(user.id)
+
+    assert.include(capturedUrl!, '/me/top/artists')
+    assert.include(capturedUrl!, 'time_range=medium_term')
+    assert.include(capturedUrl!, 'limit=20')
+  })
+
+  test('getRecentlyPlayed uses default limit=20', async ({ assert }) => {
+    const user = await createLinkedUser('rp_defaults')
+    let capturedUrl: string | null = null
+
+    globalThis.fetch = async (input) => {
+      capturedUrl = typeof input === 'string' ? input : (input as URL).toString()
+      return new Response(JSON.stringify({ items: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    await service.getRecentlyPlayed(user.id)
+
+    assert.include(capturedUrl!, '/me/player/recently-played')
+    assert.include(capturedUrl!, 'limit=20')
+  })
+
+  test('spotifyGet throws with status on Spotify API error', async ({ assert }) => {
+    const user = await createLinkedUser('api_error')
+
+    globalThis.fetch = async () =>
+      new Response('{"error":{"status":401}}', {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    await assert.rejects(async () => {
+      await service.getTopTracks(user.id)
+    }, /Spotify API error 401/)
+  })
+})

--- a/backend/tests/unit/spotify_service.spec.ts
+++ b/backend/tests/unit/spotify_service.spec.ts
@@ -314,4 +314,53 @@ test.group('SpotifyService - API fetch', (group) => {
       await service.getTopTracks(user.id)
     }, /Spotify API error 401/)
   })
+
+  test('spotifyGet retries once on 429 respecting Retry-After and succeeds', async ({ assert }) => {
+    const user = await createLinkedUser('rate_limited')
+    let calls = 0
+    const sleepCalls: number[] = []
+
+    // Override sleep to avoid actual delay in tests
+    ;(service as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async (
+      ms: number
+    ) => {
+      sleepCalls.push(ms)
+    }
+
+    globalThis.fetch = async () => {
+      calls += 1
+      if (calls === 1) {
+        return new Response('{"error":{"status":429}}', {
+          status: 429,
+          headers: { 'Content-Type': 'application/json', 'Retry-After': '1' },
+        })
+      }
+      return new Response(JSON.stringify({ items: [{ id: 'ok' }] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const data = (await service.getTopTracks(user.id)) as {
+      items: { id: string }[]
+    }
+    assert.equal(calls, 2)
+    assert.equal(data.items[0].id, 'ok')
+    assert.deepEqual(sleepCalls, [1000])
+  })
+
+  test('spotifyGet gives up after exhausting 429 retries', async ({ assert }) => {
+    const user = await createLinkedUser('rate_limited_exhaust')
+    ;(service as unknown as { sleep: (ms: number) => Promise<void> }).sleep = async () => {}
+
+    globalThis.fetch = async () =>
+      new Response('{"error":{"status":429}}', {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    await assert.rejects(async () => {
+      await service.getTopTracks(user.id)
+    }, /rate limited/)
+  })
 })

--- a/backend/tests/utils/user_integration_helpers.ts
+++ b/backend/tests/utils/user_integration_helpers.ts
@@ -1,0 +1,21 @@
+import UserIntegration from '#models/user_integration'
+import User from '#models/user'
+import { Group } from '@japa/runner/core'
+import { DateTime } from 'luxon'
+
+export function deleteUserIntegrations(group: Group) {
+  let testStartTime: DateTime
+
+  group.setup(() => {
+    testStartTime = DateTime.now()
+  })
+
+  group.each.teardown(async () => {
+    await UserIntegration.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+  })
+
+  group.teardown(async () => {
+    await UserIntegration.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+    await User.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+  })
+}

--- a/front-mobile/app/(tabs)/profile/index.tsx
+++ b/front-mobile/app/(tabs)/profile/index.tsx
@@ -1,13 +1,6 @@
 import { MaterialIcons } from "@expo/vector-icons";
 import React from "react";
-import {
-  View,
-  Text,
-  StyleSheet,
-  ScrollView,
-  Image,
-  Pressable,
-} from "react-native";
+import { View, Text, StyleSheet, ScrollView, Pressable } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Colors } from "@/constants/Colors";
 import { useAuthStore } from "@/stores/authStore";
@@ -18,21 +11,6 @@ const MOCK_STATS = {
   matchs: 87,
   gamesPlayed: 23,
 };
-
-// TODO: à modifier plus tard - remplacer par des données récupérées depuis l'API
-const MOCK_TOP_ARTISTS = [
-  { id: "1", name: "Daft Punk", avatarUrl: null },
-  { id: "2", name: "Stromae", avatarUrl: null },
-  { id: "3", name: "Aya Nakamura", avatarUrl: null },
-];
-
-// TODO: à modifier plus tard - remplacer par des données récupérées depuis l'API
-const MOCK_TOP_GENRES = [
-  { id: "1", name: "Électro", percentage: 45 },
-  { id: "2", name: "Pop", percentage: 30 },
-  { id: "3", name: "Hip-Hop", percentage: 15 },
-  { id: "4", name: "Rock", percentage: 10 },
-];
 
 // TODO: à modifier plus tard - remplacer par des données récupérées depuis l'API
 const MOCK_BADGES = [
@@ -137,100 +115,6 @@ export default function ProfileScreen() {
             <StatCard label="Matchs" value={MOCK_STATS.matchs} />
             <StatCard label="Jeux joués" value={MOCK_STATS.gamesPlayed} />
           </View>
-        </View>
-
-        {/* ── Mes préférences ── */}
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Mes préférences</Text>
-
-          <Text style={styles.subSectionTitle}>TOP Artistes</Text>
-          <View style={styles.podium}>
-            {/* 2e place */}
-            <View style={styles.podiumItem}>
-              <Text style={styles.podiumMedal}>🥈</Text>
-              <View style={[styles.podiumAvatar, styles.podiumAvatar2]}>
-                {MOCK_TOP_ARTISTS[1]?.avatarUrl ? (
-                  <Image
-                    source={{ uri: MOCK_TOP_ARTISTS[1].avatarUrl }}
-                    style={styles.podiumAvatarImage2}
-                  />
-                ) : (
-                  <Text style={styles.podiumAvatarFallback}>🎤</Text>
-                )}
-              </View>
-              <Text style={styles.podiumName} numberOfLines={1}>
-                {MOCK_TOP_ARTISTS[1]?.name}
-              </Text>
-              <View style={[styles.podiumBase, styles.podiumBase2]}>
-                <Text style={styles.podiumRank}>2</Text>
-              </View>
-            </View>
-
-            {/* 1re place */}
-            <View style={styles.podiumItem}>
-              <Text style={styles.podiumMedal}>🥇</Text>
-              <View style={[styles.podiumAvatar, styles.podiumAvatar1]}>
-                {MOCK_TOP_ARTISTS[0]?.avatarUrl ? (
-                  <Image
-                    source={{ uri: MOCK_TOP_ARTISTS[0].avatarUrl }}
-                    style={styles.podiumAvatarImage1}
-                  />
-                ) : (
-                  <Text style={[styles.podiumAvatarFallback, { fontSize: 30 }]}>
-                    🎤
-                  </Text>
-                )}
-              </View>
-              <Text
-                style={[styles.podiumName, styles.podiumName1]}
-                numberOfLines={1}
-              >
-                {MOCK_TOP_ARTISTS[0]?.name}
-              </Text>
-              <View style={[styles.podiumBase, styles.podiumBase1]}>
-                <Text style={[styles.podiumRank, styles.podiumRank1]}>1</Text>
-              </View>
-            </View>
-
-            {/* 3e place */}
-            <View style={styles.podiumItem}>
-              <Text style={styles.podiumMedal}>🥉</Text>
-              <View style={[styles.podiumAvatar, styles.podiumAvatar3]}>
-                {MOCK_TOP_ARTISTS[2]?.avatarUrl ? (
-                  <Image
-                    source={{ uri: MOCK_TOP_ARTISTS[2].avatarUrl }}
-                    style={styles.podiumAvatarImage3}
-                  />
-                ) : (
-                  <Text style={[styles.podiumAvatarFallback, { fontSize: 18 }]}>
-                    🎤
-                  </Text>
-                )}
-              </View>
-              <Text style={styles.podiumName} numberOfLines={1}>
-                {MOCK_TOP_ARTISTS[2]?.name}
-              </Text>
-              <View style={[styles.podiumBase, styles.podiumBase3]}>
-                <Text style={styles.podiumRank}>3</Text>
-              </View>
-            </View>
-          </View>
-
-          <Text style={styles.subSectionTitle}>TOP Genres</Text>
-          {MOCK_TOP_GENRES.map((genre) => (
-            <View key={genre.id} style={styles.genreRow}>
-              <Text style={styles.genreName}>{genre.name}</Text>
-              <View style={styles.progressBar}>
-                <View
-                  style={[
-                    styles.progressFill,
-                    { width: `${genre.percentage}%` },
-                  ]}
-                />
-              </View>
-              <Text style={styles.genrePercent}>{genre.percentage}%</Text>
-            </View>
-          ))}
         </View>
 
         {/* ── Succès & Récompenses ── */}
@@ -359,23 +243,6 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: "600",
   },
-  settingsButton: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-    borderWidth: 1,
-    borderColor: Colors.dark.icon,
-    borderRadius: 20,
-    paddingHorizontal: 14,
-    paddingVertical: 6,
-  },
-  settingsIcon: {
-    fontSize: 14,
-  },
-  settingsText: {
-    color: Colors.dark.icon,
-    fontSize: 13,
-  },
 
   // Sections
   section: {
@@ -396,13 +263,6 @@ const styles = StyleSheet.create({
     color: Colors.dark.text,
     marginBottom: 14,
     textAlign: "center",
-  },
-  subSectionTitle: {
-    fontSize: 14,
-    fontWeight: "600",
-    color: Colors.dark.icon,
-    marginBottom: 10,
-    marginTop: 4,
   },
 
   // Stats
@@ -429,128 +289,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: Colors.dark.icon,
     textAlign: "center",
-  },
-
-  // Podium TOP Artistes
-  podium: {
-    flexDirection: "row",
-    alignItems: "flex-end",
-    justifyContent: "center",
-    gap: 8,
-    marginBottom: 18,
-  },
-  podiumItem: {
-    flex: 1,
-    alignItems: "center",
-  },
-  podiumMedal: {
-    fontSize: 20,
-    marginBottom: 6,
-  },
-  podiumAvatar: {
-    borderRadius: 100,
-    backgroundColor: "#1A1A1A",
-    borderWidth: 2,
-    alignItems: "center",
-    justifyContent: "center",
-    marginBottom: 6,
-  },
-  podiumAvatar1: {
-    width: 72,
-    height: 72,
-    borderColor: "#FFD700",
-  },
-  podiumAvatar2: {
-    width: 56,
-    height: 56,
-    borderColor: "#C0C0C0",
-  },
-  podiumAvatar3: {
-    width: 48,
-    height: 48,
-    borderColor: "#CD7F32",
-  },
-  podiumAvatarImage1: { width: 72, height: 72, borderRadius: 36 },
-  podiumAvatarImage2: { width: 56, height: 56, borderRadius: 28 },
-  podiumAvatarImage3: { width: 48, height: 48, borderRadius: 24 },
-  podiumAvatarFallback: {
-    fontSize: 22,
-  },
-  podiumName: {
-    fontSize: 11,
-    color: Colors.dark.text,
-    textAlign: "center",
-    fontWeight: "600",
-    marginBottom: 6,
-  },
-  podiumName1: {
-    fontSize: 12,
-    color: "#FFD700",
-  },
-  podiumBase: {
-    width: "100%",
-    alignItems: "center",
-    justifyContent: "center",
-    borderTopLeftRadius: 6,
-    borderTopRightRadius: 6,
-  },
-  podiumBase1: {
-    height: 70,
-    backgroundColor: "#2A2200",
-    borderTopWidth: 2,
-    borderColor: "#FFD700",
-  },
-  podiumBase2: {
-    height: 50,
-    backgroundColor: "#1E1E1E",
-    borderTopWidth: 2,
-    borderColor: "#C0C0C0",
-  },
-  podiumBase3: {
-    height: 35,
-    backgroundColor: "#1A1209",
-    borderTopWidth: 2,
-    borderColor: "#CD7F32",
-  },
-  podiumRank: {
-    fontSize: 16,
-    fontWeight: "800",
-    color: Colors.dark.icon,
-  },
-  podiumRank1: {
-    color: "#FFD700",
-    fontSize: 20,
-  },
-
-  // Genres
-  genreRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    marginBottom: 10,
-    gap: 10,
-  },
-  genreName: {
-    width: 72,
-    fontSize: 13,
-    color: Colors.dark.text,
-  },
-  progressBar: {
-    flex: 1,
-    height: 8,
-    backgroundColor: "#2A2A2A",
-    borderRadius: 4,
-    overflow: "hidden",
-  },
-  progressFill: {
-    height: "100%",
-    backgroundColor: Colors.primary.CTA,
-    borderRadius: 4,
-  },
-  genrePercent: {
-    width: 36,
-    fontSize: 12,
-    color: Colors.dark.icon,
-    textAlign: "right",
   },
 
   // Badges

--- a/front-mobile/app/_layout.tsx
+++ b/front-mobile/app/_layout.tsx
@@ -66,6 +66,8 @@ export default function RootLayout() {
         <Stack screenOptions={{ headerShown: false }}>
           <Stack.Screen name="auth" />
           <Stack.Screen name="(tabs)" />
+          <Stack.Screen name="settings" />
+          <Stack.Screen name="integrations" />
           <Stack.Screen
             name="+not-found"
             options={{ headerShown: true, title: "Page introuvable" }}

--- a/front-mobile/app/integrations/_layout.tsx
+++ b/front-mobile/app/integrations/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from "expo-router";
+
+export default function IntegrationsLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="index" options={{ title: "Intégrations" }} />
+      <Stack.Screen
+        name="spotify-stats"
+        options={{ title: "Mes stats Spotify" }}
+      />
+    </Stack>
+  );
+}

--- a/front-mobile/app/integrations/index.tsx
+++ b/front-mobile/app/integrations/index.tsx
@@ -1,0 +1,152 @@
+import { router } from "expo-router";
+import { StyleSheet, Text, View } from "react-native";
+import Button from "@/components/Button";
+import Header from "@/components/Header";
+import { Colors } from "@/constants/Colors";
+import { useToast } from "@/components/Toast";
+import { useSpotifyIntegration } from "@/hooks/useSpotifyIntegration";
+
+export default function IntegrationsScreen() {
+  const { status, isLoading, isConnecting, connect, disconnect } =
+    useSpotifyIntegration();
+  const { show } = useToast();
+
+  const handleConnect = async () => {
+    const result = await connect();
+    if (result === "ok") {
+      show({ type: "success", message: "Spotify connecté" });
+    } else if (result === "error") {
+      show({ type: "error", message: "La connexion Spotify a échoué" });
+    }
+  };
+
+  const handleDisconnect = async () => {
+    await disconnect();
+    show({ type: "success", message: "Spotify déconnecté" });
+  };
+
+  const connected = status?.connected === true;
+
+  return (
+    <View style={styles.container}>
+      <Header title="Intégrations" variant="withBack" />
+
+      <View style={styles.content}>
+        <Text style={styles.description}>
+          Connecte ton compte Spotify pour que Rythmix personnalise ton
+          expérience avec tes goûts musicaux.
+        </Text>
+
+        <View style={styles.card}>
+          <View style={styles.cardHeader}>
+            <View style={styles.providerBadge}>
+              <Text style={styles.providerIcon}>🎧</Text>
+            </View>
+            <View style={styles.cardHeaderText}>
+              <Text style={styles.cardTitle}>Spotify</Text>
+              <Text
+                style={[
+                  styles.cardStatus,
+                  connected ? styles.cardStatusOn : styles.cardStatusOff,
+                ]}
+              >
+                {isLoading
+                  ? "Chargement…"
+                  : connected
+                    ? "Connecté"
+                    : "Non connecté"}
+              </Text>
+            </View>
+          </View>
+
+          {connected ? (
+            <View style={styles.buttonGroup}>
+              <Button
+                title="Voir mes stats"
+                onPress={() =>
+                  router.push({ pathname: "/integrations/spotify-stats" })
+                }
+              />
+              <Button
+                title="Déconnecter"
+                variant="cancel"
+                onPress={handleDisconnect}
+              />
+            </View>
+          ) : (
+            <Button
+              title="Connecter Spotify"
+              onPress={handleConnect}
+              loading={isConnecting}
+              disabled={isConnecting}
+            />
+          )}
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 20,
+    paddingTop: 20,
+  },
+  description: {
+    color: Colors.dark.icon,
+    fontSize: 14,
+    lineHeight: 20,
+    marginBottom: 20,
+  },
+  card: {
+    backgroundColor: "#1A1A1A",
+    borderRadius: 16,
+    padding: 18,
+    borderWidth: 1,
+    borderColor: "#2A2A2A",
+  },
+  cardHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    marginBottom: 16,
+  },
+  providerBadge: {
+    width: 48,
+    height: 48,
+    borderRadius: 12,
+    backgroundColor: "#1ED760",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  providerIcon: {
+    fontSize: 22,
+  },
+  cardHeaderText: {
+    flex: 1,
+  },
+  cardTitle: {
+    color: Colors.dark.text,
+    fontSize: 16,
+    fontWeight: "700",
+    marginBottom: 2,
+  },
+  cardStatus: {
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  cardStatusOn: {
+    color: "#1ED760",
+  },
+  cardStatusOff: {
+    color: Colors.dark.icon,
+  },
+  buttonGroup: {
+    gap: 10,
+  },
+});

--- a/front-mobile/app/integrations/spotify-stats.tsx
+++ b/front-mobile/app/integrations/spotify-stats.tsx
@@ -1,0 +1,275 @@
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import Header from "@/components/Header";
+import { Colors } from "@/constants/Colors";
+import { useSpotifyStats, SpotifyStatsType } from "@/hooks/useSpotifyStats";
+import {
+  SpotifyArtist,
+  SpotifyRecentlyPlayedItem,
+  SpotifyTrack,
+} from "@/types/spotify";
+
+const TABS: { key: SpotifyStatsType; label: string }[] = [
+  { key: "topTracks", label: "Top titres" },
+  { key: "topArtists", label: "Top artistes" },
+  { key: "recentlyPlayed", label: "Récents" },
+];
+
+export default function SpotifyStatsScreen() {
+  const [active, setActive] = useState<SpotifyStatsType>("topTracks");
+  const { tracks, artists, recentlyPlayed, isLoading, error } = useSpotifyStats(
+    { type: active },
+  );
+
+  return (
+    <View style={styles.container}>
+      <Header title="Mes stats Spotify" variant="withBack" />
+
+      <View style={styles.tabs}>
+        {TABS.map((tab) => (
+          <Pressable
+            key={tab.key}
+            style={[styles.tab, active === tab.key && styles.tabActive]}
+            onPress={() => setActive(tab.key)}
+          >
+            <Text
+              style={[
+                styles.tabLabel,
+                active === tab.key && styles.tabLabelActive,
+              ]}
+            >
+              {tab.label}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      <View style={styles.content}>
+        {isLoading ? (
+          <View style={styles.centered}>
+            <ActivityIndicator color={Colors.primary.survol} />
+          </View>
+        ) : error ? (
+          <View style={styles.centered}>
+            <Text style={styles.errorText}>{error}</Text>
+          </View>
+        ) : active === "topTracks" ? (
+          <TrackList tracks={tracks} />
+        ) : active === "topArtists" ? (
+          <ArtistList artists={artists} />
+        ) : (
+          <RecentlyPlayedList items={recentlyPlayed} />
+        )}
+      </View>
+    </View>
+  );
+}
+
+function TrackList({ tracks }: { tracks: SpotifyTrack[] }) {
+  if (tracks.length === 0) return <EmptyState label="Aucun titre à afficher" />;
+  return (
+    <FlatList
+      data={tracks}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item, index }) => (
+        <View style={styles.row}>
+          <Text style={styles.rank}>{index + 1}</Text>
+          {item.album?.images?.[0]?.url ? (
+            <Image
+              source={{ uri: item.album.images[0].url }}
+              style={styles.cover}
+            />
+          ) : (
+            <View style={[styles.cover, styles.coverFallback]}>
+              <Text>🎵</Text>
+            </View>
+          )}
+          <View style={styles.rowText}>
+            <Text style={styles.rowTitle} numberOfLines={1}>
+              {item.name}
+            </Text>
+            <Text style={styles.rowSubtitle} numberOfLines={1}>
+              {item.artists.map((a) => a.name).join(", ")}
+            </Text>
+          </View>
+        </View>
+      )}
+      contentContainerStyle={styles.listContent}
+    />
+  );
+}
+
+function ArtistList({ artists }: { artists: SpotifyArtist[] }) {
+  if (artists.length === 0)
+    return <EmptyState label="Aucun artiste à afficher" />;
+  return (
+    <FlatList
+      data={artists}
+      keyExtractor={(item) => item.id}
+      renderItem={({ item, index }) => (
+        <View style={styles.row}>
+          <Text style={styles.rank}>{index + 1}</Text>
+          {item.images?.[0]?.url ? (
+            <Image source={{ uri: item.images[0].url }} style={styles.cover} />
+          ) : (
+            <View style={[styles.cover, styles.coverFallback]}>
+              <Text>🎤</Text>
+            </View>
+          )}
+          <View style={styles.rowText}>
+            <Text style={styles.rowTitle} numberOfLines={1}>
+              {item.name}
+            </Text>
+            <Text style={styles.rowSubtitle} numberOfLines={1}>
+              {item.genres?.slice(0, 2).join(", ") ?? ""}
+            </Text>
+          </View>
+        </View>
+      )}
+      contentContainerStyle={styles.listContent}
+    />
+  );
+}
+
+function RecentlyPlayedList({ items }: { items: SpotifyRecentlyPlayedItem[] }) {
+  if (items.length === 0) return <EmptyState label="Aucune écoute récente" />;
+  return (
+    <FlatList
+      data={items}
+      keyExtractor={(item, idx) => `${item.track.id}-${item.played_at}-${idx}`}
+      renderItem={({ item }) => (
+        <View style={styles.row}>
+          {item.track.album?.images?.[0]?.url ? (
+            <Image
+              source={{ uri: item.track.album.images[0].url }}
+              style={styles.cover}
+            />
+          ) : (
+            <View style={[styles.cover, styles.coverFallback]}>
+              <Text>🎵</Text>
+            </View>
+          )}
+          <View style={styles.rowText}>
+            <Text style={styles.rowTitle} numberOfLines={1}>
+              {item.track.name}
+            </Text>
+            <Text style={styles.rowSubtitle} numberOfLines={1}>
+              {item.track.artists.map((a) => a.name).join(", ")}
+            </Text>
+          </View>
+        </View>
+      )}
+      contentContainerStyle={styles.listContent}
+    />
+  );
+}
+
+function EmptyState({ label }: { label: string }) {
+  return (
+    <View style={styles.centered}>
+      <Text style={styles.emptyText}>{label}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+  },
+  tabs: {
+    marginTop: 12,
+    flexDirection: "row",
+    gap: 6,
+    paddingHorizontal: 16,
+    marginBottom: 8,
+  },
+  tab: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 10,
+    backgroundColor: "#1A1A1A",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#2A2A2A",
+  },
+  tabActive: {
+    backgroundColor: Colors.primary.CTADark,
+    borderColor: Colors.primary.survol,
+  },
+  tabLabel: {
+    color: Colors.dark.icon,
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  tabLabelActive: {
+    color: Colors.primary.survol,
+  },
+  content: {
+    flex: 1,
+  },
+  listContent: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    gap: 10,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    backgroundColor: "#1A1A1A",
+    borderRadius: 12,
+    padding: 10,
+  },
+  rank: {
+    width: 22,
+    textAlign: "center",
+    color: Colors.primary.survol,
+    fontWeight: "700",
+    fontSize: 14,
+  },
+  cover: {
+    width: 48,
+    height: 48,
+    borderRadius: 8,
+    backgroundColor: "#222",
+  },
+  coverFallback: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  rowText: {
+    flex: 1,
+  },
+  rowTitle: {
+    color: Colors.dark.text,
+    fontSize: 14,
+    fontWeight: "600",
+  },
+  rowSubtitle: {
+    color: Colors.dark.icon,
+    fontSize: 12,
+    marginTop: 2,
+  },
+  centered: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  errorText: {
+    color: Colors.game.error,
+    fontSize: 14,
+  },
+  emptyText: {
+    color: Colors.dark.icon,
+    fontSize: 14,
+  },
+});

--- a/front-mobile/app/settings.tsx
+++ b/front-mobile/app/settings.tsx
@@ -1,4 +1,6 @@
-import { ScrollView, StyleSheet, Switch, View } from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import { Pressable, ScrollView, StyleSheet, Switch, View } from "react-native";
 import Header from "@/components/Header";
 import { ThemedText } from "@/components/ThemedText";
 import { Colors } from "@/constants/Colors";
@@ -33,6 +35,25 @@ export default function SettingsScreen() {
             thumbColor={errorAnimationsEnabled ? Colors.primary.survol : "#888"}
           />
         </View>
+
+        <ThemedText style={styles.sectionTitle}>Intégrations</ThemedText>
+
+        <Pressable
+          style={styles.row}
+          onPress={() => router.push("/integrations")}
+        >
+          <View style={styles.rowText}>
+            <ThemedText style={styles.rowLabel}>Services musicaux</ThemedText>
+            <ThemedText style={styles.rowDescription}>
+              Connecte Spotify pour enrichir ton expérience
+            </ThemedText>
+          </View>
+          <MaterialIcons
+            name="chevron-right"
+            size={22}
+            color={Colors.dark.icon}
+          />
+        </Pressable>
       </ScrollView>
     </View>
   );

--- a/front-mobile/hooks/__tests__/useSpotifyIntegration.test.ts
+++ b/front-mobile/hooks/__tests__/useSpotifyIntegration.test.ts
@@ -1,0 +1,203 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import * as WebBrowser from "expo-web-browser";
+import * as Linking from "expo-linking";
+import { useSpotifyIntegration } from "../useSpotifyIntegration";
+import { disconnectSpotify, getSpotifyStatus } from "@/services/spotifyService";
+import { useAuthStore } from "@/stores/authStore";
+
+jest.mock("expo-web-browser", () => ({
+  openAuthSessionAsync: jest.fn(),
+}));
+
+jest.mock("expo-linking", () => ({
+  addEventListener: jest.fn(() => ({ remove: jest.fn() })),
+  parse: jest.fn(),
+  createURL: jest.fn(() => "frontmobile://spotify-linked"),
+}));
+
+jest.mock("@/services/spotifyService", () => ({
+  getSpotifyStatus: jest.fn(),
+  disconnectSpotify: jest.fn(),
+  buildSpotifyAuthUrl: jest.fn(
+    () =>
+      "https://api/auth/spotify/redirect?token=t&returnUrl=frontmobile%3A%2F%2Fspotify-linked",
+  ),
+}));
+
+const mockGetState = jest.fn(() => ({ token: "my-token" as string | null }));
+
+jest.mock("@/stores/authStore", () => ({
+  useAuthStore: Object.assign(jest.fn(), { getState: jest.fn() }),
+}));
+
+const mockGetStatus = getSpotifyStatus as jest.MockedFunction<
+  typeof getSpotifyStatus
+>;
+const mockDisconnect = disconnectSpotify as jest.MockedFunction<
+  typeof disconnectSpotify
+>;
+const mockOpenAuth = WebBrowser.openAuthSessionAsync as jest.MockedFunction<
+  typeof WebBrowser.openAuthSessionAsync
+>;
+const mockParse = Linking.parse as jest.MockedFunction<typeof Linking.parse>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetState.mockReturnValue({ token: "my-token" });
+  (useAuthStore.getState as jest.Mock).mockImplementation(mockGetState);
+});
+
+describe("useSpotifyIntegration", () => {
+  it("fetches the status on mount", async () => {
+    mockGetStatus.mockResolvedValueOnce({
+      connected: false,
+      providerUserId: null,
+      scopes: null,
+    });
+
+    const { result } = renderHook(() => useSpotifyIntegration());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.status?.connected).toBe(false);
+  });
+
+  it("surfaces errors on status failure", async () => {
+    mockGetStatus.mockRejectedValueOnce(new Error("boom"));
+
+    const { result } = renderHook(() => useSpotifyIntegration());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.error).toBe("boom");
+  });
+
+  it("returns error when token is missing on connect()", async () => {
+    mockGetState.mockReturnValue({ token: null });
+    mockGetStatus.mockResolvedValueOnce({
+      connected: false,
+      providerUserId: null,
+      scopes: null,
+    });
+    mockGetStatus.mockRejectedValueOnce(new Error("unauthorized"));
+
+    const { result } = renderHook(() => useSpotifyIntegration());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let outcome: string = "";
+    await act(async () => {
+      outcome = await result.current.connect();
+    });
+    expect(outcome).toBe("error");
+    expect(mockOpenAuth).not.toHaveBeenCalled();
+  });
+
+  it("refreshes status when WebBrowser returns status=ok", async () => {
+    // 1) mount: not connected
+    mockGetStatus.mockResolvedValueOnce({
+      connected: false,
+      providerUserId: null,
+      scopes: null,
+    });
+    // 2) warmup inside connect(): still not connected
+    mockGetStatus.mockResolvedValueOnce({
+      connected: false,
+      providerUserId: null,
+      scopes: null,
+    });
+    // 3) refresh after WebBrowser success: connected
+    mockGetStatus.mockResolvedValueOnce({
+      connected: true,
+      providerUserId: "spotify-1",
+      scopes: "user-read-email",
+    });
+
+    mockOpenAuth.mockResolvedValueOnce({
+      type: "success",
+      url: "frontmobile://spotify-linked?status=ok",
+    } as Awaited<ReturnType<typeof WebBrowser.openAuthSessionAsync>>);
+    mockParse.mockReturnValueOnce({
+      queryParams: { status: "ok" },
+    } as unknown as ReturnType<typeof Linking.parse>);
+
+    const { result } = renderHook(() => useSpotifyIntegration());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let outcome: string = "";
+    await act(async () => {
+      outcome = await result.current.connect();
+    });
+
+    expect(outcome).toBe("ok");
+    // 1) on mount, 2) warmup inside connect(), 3) after success refresh
+    expect(mockGetStatus).toHaveBeenCalledTimes(3);
+    expect(result.current.status?.connected).toBe(true);
+  });
+
+  it("maps cancelled sessions to 'cancelled'", async () => {
+    mockGetStatus.mockResolvedValueOnce({
+      connected: false,
+      providerUserId: null,
+      scopes: null,
+    });
+    mockOpenAuth.mockResolvedValueOnce({ type: "cancel" } as Awaited<
+      ReturnType<typeof WebBrowser.openAuthSessionAsync>
+    >);
+
+    const { result } = renderHook(() => useSpotifyIntegration());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let outcome: string = "";
+    await act(async () => {
+      outcome = await result.current.connect();
+    });
+    expect(outcome).toBe("cancelled");
+  });
+
+  it("reports error and reason when callback returns status=error", async () => {
+    mockGetStatus.mockResolvedValueOnce({
+      connected: false,
+      providerUserId: null,
+      scopes: null,
+    });
+    mockOpenAuth.mockResolvedValueOnce({
+      type: "success",
+      url: "frontmobile://spotify-linked?status=error&reason=access_denied",
+    } as Awaited<ReturnType<typeof WebBrowser.openAuthSessionAsync>>);
+    mockParse.mockReturnValueOnce({
+      queryParams: { status: "error", reason: "access_denied" },
+    } as unknown as ReturnType<typeof Linking.parse>);
+
+    const { result } = renderHook(() => useSpotifyIntegration());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    let outcome: string = "";
+    await act(async () => {
+      outcome = await result.current.connect();
+    });
+
+    expect(outcome).toBe("error");
+    expect(result.current.error).toBe("access_denied");
+  });
+
+  it("calls disconnectSpotify and refreshes the status", async () => {
+    mockGetStatus.mockResolvedValue({
+      connected: true,
+      providerUserId: "a",
+      scopes: null,
+    });
+    mockDisconnect.mockResolvedValueOnce(undefined);
+
+    const { result } = renderHook(() => useSpotifyIntegration());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(async () => {
+      await result.current.disconnect();
+    });
+    expect(mockDisconnect).toHaveBeenCalled();
+    // 1) on mount refresh, 2) refresh after disconnect
+    expect(mockGetStatus).toHaveBeenCalledTimes(2);
+  });
+});

--- a/front-mobile/hooks/__tests__/useSpotifyIntegration.test.ts
+++ b/front-mobile/hooks/__tests__/useSpotifyIntegration.test.ts
@@ -2,8 +2,11 @@ import { act, renderHook, waitFor } from "@testing-library/react-native";
 import * as WebBrowser from "expo-web-browser";
 import * as Linking from "expo-linking";
 import { useSpotifyIntegration } from "../useSpotifyIntegration";
-import { disconnectSpotify, getSpotifyStatus } from "@/services/spotifyService";
-import { useAuthStore } from "@/stores/authStore";
+import {
+  disconnectSpotify,
+  getSpotifyStatus,
+  initSpotifyAuth,
+} from "@/services/spotifyService";
 
 jest.mock("expo-web-browser", () => ({
   openAuthSessionAsync: jest.fn(),
@@ -18,16 +21,7 @@ jest.mock("expo-linking", () => ({
 jest.mock("@/services/spotifyService", () => ({
   getSpotifyStatus: jest.fn(),
   disconnectSpotify: jest.fn(),
-  buildSpotifyAuthUrl: jest.fn(
-    () =>
-      "https://api/auth/spotify/redirect?token=t&returnUrl=frontmobile%3A%2F%2Fspotify-linked",
-  ),
-}));
-
-const mockGetState = jest.fn(() => ({ token: "my-token" as string | null }));
-
-jest.mock("@/stores/authStore", () => ({
-  useAuthStore: Object.assign(jest.fn(), { getState: jest.fn() }),
+  initSpotifyAuth: jest.fn(),
 }));
 
 const mockGetStatus = getSpotifyStatus as jest.MockedFunction<
@@ -36,6 +30,9 @@ const mockGetStatus = getSpotifyStatus as jest.MockedFunction<
 const mockDisconnect = disconnectSpotify as jest.MockedFunction<
   typeof disconnectSpotify
 >;
+const mockInitAuth = initSpotifyAuth as jest.MockedFunction<
+  typeof initSpotifyAuth
+>;
 const mockOpenAuth = WebBrowser.openAuthSessionAsync as jest.MockedFunction<
   typeof WebBrowser.openAuthSessionAsync
 >;
@@ -43,8 +40,6 @@ const mockParse = Linking.parse as jest.MockedFunction<typeof Linking.parse>;
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockGetState.mockReturnValue({ token: "my-token" });
-  (useAuthStore.getState as jest.Mock).mockImplementation(mockGetState);
 });
 
 describe("useSpotifyIntegration", () => {
@@ -74,14 +69,13 @@ describe("useSpotifyIntegration", () => {
     expect(result.current.error).toBe("boom");
   });
 
-  it("returns error when token is missing on connect()", async () => {
-    mockGetState.mockReturnValue({ token: null });
+  it("returns error when init endpoint fails", async () => {
     mockGetStatus.mockResolvedValueOnce({
       connected: false,
       providerUserId: null,
       scopes: null,
     });
-    mockGetStatus.mockRejectedValueOnce(new Error("unauthorized"));
+    mockInitAuth.mockRejectedValueOnce(new Error("unauthorized"));
 
     const { result } = renderHook(() => useSpotifyIntegration());
     await waitFor(() => expect(result.current.isLoading).toBe(false));
@@ -95,25 +89,20 @@ describe("useSpotifyIntegration", () => {
   });
 
   it("refreshes status when WebBrowser returns status=ok", async () => {
-    // 1) mount: not connected
     mockGetStatus.mockResolvedValueOnce({
       connected: false,
       providerUserId: null,
       scopes: null,
     });
-    // 2) warmup inside connect(): still not connected
-    mockGetStatus.mockResolvedValueOnce({
-      connected: false,
-      providerUserId: null,
-      scopes: null,
-    });
-    // 3) refresh after WebBrowser success: connected
     mockGetStatus.mockResolvedValueOnce({
       connected: true,
       providerUserId: "spotify-1",
       scopes: "user-read-email",
     });
 
+    mockInitAuth.mockResolvedValueOnce({
+      authorizeUrl: "https://accounts.spotify.com/authorize?state=abc",
+    });
     mockOpenAuth.mockResolvedValueOnce({
       type: "success",
       url: "frontmobile://spotify-linked?status=ok",
@@ -131,8 +120,11 @@ describe("useSpotifyIntegration", () => {
     });
 
     expect(outcome).toBe("ok");
-    // 1) on mount, 2) warmup inside connect(), 3) after success refresh
-    expect(mockGetStatus).toHaveBeenCalledTimes(3);
+    expect(mockInitAuth).toHaveBeenCalledWith("frontmobile://spotify-linked");
+    expect(mockOpenAuth).toHaveBeenCalledWith(
+      "https://accounts.spotify.com/authorize?state=abc",
+      "frontmobile://spotify-linked",
+    );
     expect(result.current.status?.connected).toBe(true);
   });
 
@@ -141,6 +133,9 @@ describe("useSpotifyIntegration", () => {
       connected: false,
       providerUserId: null,
       scopes: null,
+    });
+    mockInitAuth.mockResolvedValueOnce({
+      authorizeUrl: "https://accounts.spotify.com/authorize?state=abc",
     });
     mockOpenAuth.mockResolvedValueOnce({ type: "cancel" } as Awaited<
       ReturnType<typeof WebBrowser.openAuthSessionAsync>
@@ -161,6 +156,9 @@ describe("useSpotifyIntegration", () => {
       connected: false,
       providerUserId: null,
       scopes: null,
+    });
+    mockInitAuth.mockResolvedValueOnce({
+      authorizeUrl: "https://accounts.spotify.com/authorize?state=abc",
     });
     mockOpenAuth.mockResolvedValueOnce({
       type: "success",
@@ -197,7 +195,6 @@ describe("useSpotifyIntegration", () => {
       await result.current.disconnect();
     });
     expect(mockDisconnect).toHaveBeenCalled();
-    // 1) on mount refresh, 2) refresh after disconnect
     expect(mockGetStatus).toHaveBeenCalledTimes(2);
   });
 });

--- a/front-mobile/hooks/__tests__/useSpotifyStats.test.ts
+++ b/front-mobile/hooks/__tests__/useSpotifyStats.test.ts
@@ -1,0 +1,105 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { useSpotifyStats } from "../useSpotifyStats";
+import {
+  getRecentlyPlayed,
+  getTopArtists,
+  getTopTracks,
+} from "@/services/spotifyService";
+
+jest.mock("@/services/spotifyService", () => ({
+  getTopTracks: jest.fn(),
+  getTopArtists: jest.fn(),
+  getRecentlyPlayed: jest.fn(),
+}));
+
+const mockGetTopTracks = getTopTracks as jest.MockedFunction<
+  typeof getTopTracks
+>;
+const mockGetTopArtists = getTopArtists as jest.MockedFunction<
+  typeof getTopArtists
+>;
+const mockGetRecentlyPlayed = getRecentlyPlayed as jest.MockedFunction<
+  typeof getRecentlyPlayed
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useSpotifyStats", () => {
+  it("fetches top tracks when type=topTracks", async () => {
+    mockGetTopTracks.mockResolvedValueOnce({
+      items: [
+        {
+          id: "t1",
+          name: "Track",
+          duration_ms: 1,
+          artists: [{ id: "a1", name: "Artist" }],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() =>
+      useSpotifyStats({ type: "topTracks", timeRange: "short_term", limit: 5 }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetTopTracks).toHaveBeenCalledWith({
+      timeRange: "short_term",
+      limit: 5,
+    });
+    expect(result.current.tracks).toHaveLength(1);
+  });
+
+  it("fetches top artists when type=topArtists", async () => {
+    mockGetTopArtists.mockResolvedValueOnce({
+      items: [{ id: "a1", name: "Artist" }],
+    });
+    const { result } = renderHook(() =>
+      useSpotifyStats({ type: "topArtists" }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetTopArtists).toHaveBeenCalledWith({
+      timeRange: "medium_term",
+      limit: 20,
+    });
+    expect(result.current.artists).toHaveLength(1);
+  });
+
+  it("fetches recently played when type=recentlyPlayed", async () => {
+    mockGetRecentlyPlayed.mockResolvedValueOnce({
+      items: [
+        {
+          played_at: "2024-01-01",
+          track: {
+            id: "t1",
+            name: "T",
+            duration_ms: 1,
+            artists: [{ id: "a", name: "A" }],
+          },
+        },
+      ],
+    });
+    const { result } = renderHook(() =>
+      useSpotifyStats({ type: "recentlyPlayed" }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetRecentlyPlayed).toHaveBeenCalledWith({ limit: 20 });
+    expect(result.current.recentlyPlayed).toHaveLength(1);
+  });
+
+  it("captures error message on failure", async () => {
+    mockGetTopTracks.mockRejectedValueOnce(new Error("network"));
+    const { result } = renderHook(() => useSpotifyStats({ type: "topTracks" }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe("network");
+  });
+
+  it("does not fetch when enabled is false", async () => {
+    const { result } = renderHook(() =>
+      useSpotifyStats({ type: "topTracks", enabled: false }),
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetTopTracks).not.toHaveBeenCalled();
+  });
+});

--- a/front-mobile/hooks/useSpotifyIntegration.ts
+++ b/front-mobile/hooks/useSpotifyIntegration.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import * as WebBrowser from "expo-web-browser";
+import * as Linking from "expo-linking";
+import {
+  buildSpotifyAuthUrl,
+  disconnectSpotify,
+  getSpotifyStatus,
+} from "@/services/spotifyService";
+import { SpotifyStatus } from "@/types/spotify";
+import { useAuthStore } from "@/stores/authStore";
+
+export interface UseSpotifyIntegration {
+  status: SpotifyStatus | null;
+  isLoading: boolean;
+  isConnecting: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  connect: () => Promise<"ok" | "cancelled" | "error">;
+  disconnect: () => Promise<void>;
+}
+
+export function useSpotifyIntegration(): UseSpotifyIntegration {
+  const [status, setStatus] = useState<SpotifyStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isConnecting, setIsConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isMountedRef = useRef(true);
+  const returnUrl = useMemo(() => Linking.createURL("spotify-linked"), []);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (isMountedRef.current) setIsLoading(true);
+    try {
+      const data = await getSpotifyStatus();
+      if (isMountedRef.current) {
+        setStatus(data);
+        setError(null);
+      }
+    } catch (err) {
+      if (isMountedRef.current) {
+        setStatus(null);
+        setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    } finally {
+      if (isMountedRef.current) setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    const subscription = Linking.addEventListener("url", ({ url }) => {
+      if (url.startsWith(returnUrl)) {
+        void refresh();
+      }
+    });
+    return () => subscription.remove();
+  }, [refresh, returnUrl]);
+
+  const connect = useCallback(async (): Promise<
+    "ok" | "cancelled" | "error"
+  > => {
+    setIsConnecting(true);
+    try {
+      // Warm up the access token: a 401 here triggers the apiClient
+      // refresh flow and updates the Zustand store with a fresh token.
+      try {
+        await getSpotifyStatus();
+      } catch {
+        // Ignore — we only care about forcing a token refresh.
+      }
+
+      const currentToken = useAuthStore.getState().token;
+      if (!currentToken) {
+        setError("Session expired, please log in again");
+        return "error";
+      }
+
+      const result = await WebBrowser.openAuthSessionAsync(
+        buildSpotifyAuthUrl(currentToken, returnUrl),
+        returnUrl,
+      );
+
+      if (result.type === "success") {
+        const parsed = Linking.parse(result.url);
+        const status = parsed.queryParams?.status;
+        if (status === "ok") {
+          await refresh();
+          return "ok";
+        }
+        const reason = parsed.queryParams?.reason;
+        setError(typeof reason === "string" ? reason : "spotify_error");
+        return "error";
+      }
+
+      if (result.type === "cancel" || result.type === "dismiss") {
+        return "cancelled";
+      }
+
+      setError("spotify_error");
+      return "error";
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "spotify_error");
+      return "error";
+    } finally {
+      if (isMountedRef.current) setIsConnecting(false);
+    }
+  }, [refresh, returnUrl]);
+
+  const disconnect = useCallback(async () => {
+    try {
+      await disconnectSpotify();
+    } catch (err) {
+      if (isMountedRef.current) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    }
+    await refresh();
+  }, [refresh]);
+
+  return {
+    status,
+    isLoading,
+    isConnecting,
+    error,
+    refresh,
+    connect,
+    disconnect,
+  };
+}

--- a/front-mobile/hooks/useSpotifyIntegration.ts
+++ b/front-mobile/hooks/useSpotifyIntegration.ts
@@ -2,12 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as WebBrowser from "expo-web-browser";
 import * as Linking from "expo-linking";
 import {
-  buildSpotifyAuthUrl,
   disconnectSpotify,
   getSpotifyStatus,
+  initSpotifyAuth,
 } from "@/services/spotifyService";
 import { SpotifyStatus } from "@/types/spotify";
-import { useAuthStore } from "@/stores/authStore";
 
 export interface UseSpotifyIntegration {
   status: SpotifyStatus | null;
@@ -71,22 +70,10 @@ export function useSpotifyIntegration(): UseSpotifyIntegration {
   > => {
     setIsConnecting(true);
     try {
-      // Warm up the access token: a 401 here triggers the apiClient
-      // refresh flow and updates the Zustand store with a fresh token.
-      try {
-        await getSpotifyStatus();
-      } catch {
-        // Ignore — we only care about forcing a token refresh.
-      }
-
-      const currentToken = useAuthStore.getState().token;
-      if (!currentToken) {
-        setError("Session expired, please log in again");
-        return "error";
-      }
+      const { authorizeUrl } = await initSpotifyAuth(returnUrl);
 
       const result = await WebBrowser.openAuthSessionAsync(
-        buildSpotifyAuthUrl(currentToken, returnUrl),
+        authorizeUrl,
         returnUrl,
       );
 

--- a/front-mobile/hooks/useSpotifyStats.ts
+++ b/front-mobile/hooks/useSpotifyStats.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getRecentlyPlayed,
+  getTopArtists,
+  getTopTracks,
+} from "@/services/spotifyService";
+import {
+  SpotifyArtist,
+  SpotifyRecentlyPlayedItem,
+  SpotifyTimeRange,
+  SpotifyTrack,
+} from "@/types/spotify";
+
+export type SpotifyStatsType = "topTracks" | "topArtists" | "recentlyPlayed";
+
+export interface UseSpotifyStatsOptions {
+  type: SpotifyStatsType;
+  timeRange?: SpotifyTimeRange;
+  limit?: number;
+  enabled?: boolean;
+}
+
+export interface UseSpotifyStatsResult {
+  tracks: SpotifyTrack[];
+  artists: SpotifyArtist[];
+  recentlyPlayed: SpotifyRecentlyPlayedItem[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useSpotifyStats({
+  type,
+  timeRange = "medium_term",
+  limit = 20,
+  enabled = true,
+}: UseSpotifyStatsOptions): UseSpotifyStatsResult {
+  const [tracks, setTracks] = useState<SpotifyTrack[]>([]);
+  const [artists, setArtists] = useState<SpotifyArtist[]>([]);
+  const [recentlyPlayed, setRecentlyPlayed] = useState<
+    SpotifyRecentlyPlayedItem[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isMountedRef = useRef(true);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+
+    const requestId = ++requestIdRef.current;
+    if (isMountedRef.current) {
+      setIsLoading(true);
+      setError(null);
+    }
+
+    try {
+      if (type === "topTracks") {
+        const data = await getTopTracks({ timeRange, limit });
+        if (isMountedRef.current && requestIdRef.current === requestId) {
+          setTracks(data.items ?? []);
+        }
+      } else if (type === "topArtists") {
+        const data = await getTopArtists({ timeRange, limit });
+        if (isMountedRef.current && requestIdRef.current === requestId) {
+          setArtists(data.items ?? []);
+        }
+      } else {
+        const data = await getRecentlyPlayed({ limit });
+        if (isMountedRef.current && requestIdRef.current === requestId) {
+          setRecentlyPlayed(data.items ?? []);
+        }
+      }
+    } catch (err) {
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    } finally {
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setIsLoading(false);
+      }
+    }
+  }, [enabled, type, timeRange, limit]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { tracks, artists, recentlyPlayed, isLoading, error, refresh };
+}

--- a/front-mobile/services/__tests__/spotifyService.test.ts
+++ b/front-mobile/services/__tests__/spotifyService.test.ts
@@ -1,22 +1,24 @@
 process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
 
 import {
-  buildSpotifyAuthUrl,
   disconnectSpotify,
   getRecentlyPlayed,
   getSpotifyStatus,
   getTopArtists,
   getTopTracks,
+  initSpotifyAuth,
 } from "../spotifyService";
-import { del, get } from "../api";
+import { del, get, post } from "../api";
 
 jest.mock("../api", () => ({
   get: jest.fn(),
   del: jest.fn(),
+  post: jest.fn(),
 }));
 
 const mockGet = get as jest.MockedFunction<typeof get>;
 const mockDel = del as jest.MockedFunction<typeof del>;
+const mockPost = post as jest.MockedFunction<typeof post>;
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -70,10 +72,14 @@ describe("spotifyService", () => {
     );
   });
 
-  it("buildSpotifyAuthUrl appends the user token and returnUrl", () => {
-    const url = buildSpotifyAuthUrl("my-token", "frontmobile://spotify-linked");
-    expect(url).toContain("/api/auth/spotify/redirect");
-    expect(url).toContain("token=my-token");
-    expect(url).toContain("returnUrl=frontmobile%3A%2F%2Fspotify-linked");
+  it("initSpotifyAuth posts the returnUrl to /api/auth/spotify/init", async () => {
+    mockPost.mockResolvedValueOnce({
+      authorizeUrl: "https://accounts.spotify.com/authorize?state=abc",
+    });
+    const result = await initSpotifyAuth("frontmobile://spotify-linked");
+    expect(mockPost).toHaveBeenCalledWith("/api/auth/spotify/init", {
+      returnUrl: "frontmobile://spotify-linked",
+    });
+    expect(result.authorizeUrl).toContain("accounts.spotify.com");
   });
 });

--- a/front-mobile/services/__tests__/spotifyService.test.ts
+++ b/front-mobile/services/__tests__/spotifyService.test.ts
@@ -1,0 +1,79 @@
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
+
+import {
+  buildSpotifyAuthUrl,
+  disconnectSpotify,
+  getRecentlyPlayed,
+  getSpotifyStatus,
+  getTopArtists,
+  getTopTracks,
+} from "../spotifyService";
+import { del, get } from "../api";
+
+jest.mock("../api", () => ({
+  get: jest.fn(),
+  del: jest.fn(),
+}));
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+const mockDel = del as jest.MockedFunction<typeof del>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("spotifyService", () => {
+  it("getSpotifyStatus hits /api/me/spotify/status", async () => {
+    mockGet.mockResolvedValueOnce({
+      connected: true,
+      providerUserId: "abc",
+      scopes: "user-read-email",
+    });
+    const result = await getSpotifyStatus();
+    expect(mockGet).toHaveBeenCalledWith("/api/me/spotify/status");
+    expect(result.connected).toBe(true);
+  });
+
+  it("disconnectSpotify calls DELETE /api/me/spotify", async () => {
+    mockDel.mockResolvedValueOnce(undefined);
+    await disconnectSpotify();
+    expect(mockDel).toHaveBeenCalledWith("/api/me/spotify");
+  });
+
+  it("getTopTracks serializes timeRange and limit", async () => {
+    mockGet.mockResolvedValueOnce({ items: [] });
+    await getTopTracks({ timeRange: "short_term", limit: 10 });
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/me/spotify/top-tracks?timeRange=short_term&limit=10",
+    );
+  });
+
+  it("getTopTracks skips undefined query params", async () => {
+    mockGet.mockResolvedValueOnce({ items: [] });
+    await getTopTracks();
+    expect(mockGet).toHaveBeenCalledWith("/api/me/spotify/top-tracks");
+  });
+
+  it("getTopArtists sends timeRange", async () => {
+    mockGet.mockResolvedValueOnce({ items: [] });
+    await getTopArtists({ timeRange: "long_term" });
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/me/spotify/top-artists?timeRange=long_term",
+    );
+  });
+
+  it("getRecentlyPlayed sends limit only", async () => {
+    mockGet.mockResolvedValueOnce({ items: [] });
+    await getRecentlyPlayed({ limit: 5 });
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/me/spotify/recently-played?limit=5",
+    );
+  });
+
+  it("buildSpotifyAuthUrl appends the user token and returnUrl", () => {
+    const url = buildSpotifyAuthUrl("my-token", "frontmobile://spotify-linked");
+    expect(url).toContain("/api/auth/spotify/redirect");
+    expect(url).toContain("token=my-token");
+    expect(url).toContain("returnUrl=frontmobile%3A%2F%2Fspotify-linked");
+  });
+});

--- a/front-mobile/services/api.ts
+++ b/front-mobile/services/api.ts
@@ -1,7 +1,7 @@
 import { getToken, getRefreshToken } from "./storage";
 import { ApiError } from "@/types/auth";
 
-const BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+export const BASE_URL = process.env.EXPO_PUBLIC_API_URL;
 
 // Gestion du refresh en cours
 let isRefreshing = false;

--- a/front-mobile/services/spotifyService.ts
+++ b/front-mobile/services/spotifyService.ts
@@ -1,4 +1,4 @@
-import { BASE_URL, del, get } from "./api";
+import { del, get, post } from "./api";
 import {
   SpotifyArtist,
   SpotifyPaged,
@@ -58,13 +58,11 @@ export const getRecentlyPlayed = (
     `/api/me/spotify/recently-played${buildQuery({ limit: options.limit })}`,
   );
 
-export const buildSpotifyAuthUrl = (
-  userToken: string,
+export interface SpotifyInitResponse {
+  authorizeUrl: string;
+}
+
+export const initSpotifyAuth = (
   returnUrl: string,
-): string => {
-  const params = new URLSearchParams({
-    token: userToken,
-    returnUrl,
-  });
-  return `${BASE_URL ?? ""}/api/auth/spotify/redirect?${params.toString()}`;
-};
+): Promise<SpotifyInitResponse> =>
+  post<SpotifyInitResponse>("/api/auth/spotify/init", { returnUrl });

--- a/front-mobile/services/spotifyService.ts
+++ b/front-mobile/services/spotifyService.ts
@@ -1,0 +1,70 @@
+import { BASE_URL, del, get } from "./api";
+import {
+  SpotifyArtist,
+  SpotifyPaged,
+  SpotifyRecentlyPlayedItem,
+  SpotifyStatus,
+  SpotifyTimeRange,
+  SpotifyTrack,
+} from "@/types/spotify";
+
+export const getSpotifyStatus = (): Promise<SpotifyStatus> =>
+  get<SpotifyStatus>("/api/me/spotify/status");
+
+export const disconnectSpotify = (): Promise<void> => del("/api/me/spotify");
+
+interface TopQueryOptions {
+  timeRange?: SpotifyTimeRange;
+  limit?: number;
+}
+
+const buildQuery = (options: {
+  [key: string]: string | number | undefined;
+}): string => {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(options)) {
+    if (value !== undefined && value !== null) {
+      params.set(key, String(value));
+    }
+  }
+  const serialized = params.toString();
+  return serialized ? `?${serialized}` : "";
+};
+
+export const getTopTracks = (
+  options: TopQueryOptions = {},
+): Promise<SpotifyPaged<SpotifyTrack>> =>
+  get<SpotifyPaged<SpotifyTrack>>(
+    `/api/me/spotify/top-tracks${buildQuery({
+      timeRange: options.timeRange,
+      limit: options.limit,
+    })}`,
+  );
+
+export const getTopArtists = (
+  options: TopQueryOptions = {},
+): Promise<SpotifyPaged<SpotifyArtist>> =>
+  get<SpotifyPaged<SpotifyArtist>>(
+    `/api/me/spotify/top-artists${buildQuery({
+      timeRange: options.timeRange,
+      limit: options.limit,
+    })}`,
+  );
+
+export const getRecentlyPlayed = (
+  options: { limit?: number } = {},
+): Promise<{ items: SpotifyRecentlyPlayedItem[] }> =>
+  get<{ items: SpotifyRecentlyPlayedItem[] }>(
+    `/api/me/spotify/recently-played${buildQuery({ limit: options.limit })}`,
+  );
+
+export const buildSpotifyAuthUrl = (
+  userToken: string,
+  returnUrl: string,
+): string => {
+  const params = new URLSearchParams({
+    token: userToken,
+    returnUrl,
+  });
+  return `${BASE_URL ?? ""}/api/auth/spotify/redirect?${params.toString()}`;
+};

--- a/front-mobile/types/spotify.ts
+++ b/front-mobile/types/spotify.ts
@@ -1,0 +1,53 @@
+export type SpotifyTimeRange = "short_term" | "medium_term" | "long_term";
+
+export interface SpotifyStatus {
+  connected: boolean;
+  providerUserId: string | null;
+  scopes: string | null;
+}
+
+export interface SpotifyImage {
+  url: string;
+  width: number | null;
+  height: number | null;
+}
+
+export interface SpotifyArtist {
+  id: string;
+  name: string;
+  images?: SpotifyImage[];
+  genres?: string[];
+  popularity?: number;
+  external_urls?: { spotify?: string };
+}
+
+export interface SpotifyAlbum {
+  id: string;
+  name: string;
+  images?: SpotifyImage[];
+  release_date?: string;
+}
+
+export interface SpotifyTrack {
+  id: string;
+  name: string;
+  duration_ms: number;
+  explicit?: boolean;
+  popularity?: number;
+  preview_url?: string | null;
+  album?: SpotifyAlbum;
+  artists: { id: string; name: string }[];
+  external_urls?: { spotify?: string };
+}
+
+export interface SpotifyPaged<T> {
+  items: T[];
+  total?: number;
+  limit?: number;
+  next?: string | null;
+}
+
+export interface SpotifyRecentlyPlayedItem {
+  played_at: string;
+  track: SpotifyTrack;
+}


### PR DESCRIPTION
## Description

Intégration complète de Spotify via OAuth 2.0 Authorization Code : nouvelle table `user_integrations` multi-providers avec tokens chiffrés, endpoints `/api/auth/spotify/*` (redirect + callback) et `/api/me/spotify/*` (status, top-tracks, top-artists, recently-played, unlink), refresh de token automatique. Côté mobile, écran **Intégrations** dans les Paramètres permettant de connecter/déconnecter Spotify, plus écran **Mes stats Spotify** avec 3 onglets (Top titres, Top artistes, Écoutes récentes). Comprend la doc `backend/docs/spotify-guidelines.md` (règles officielles Spotify pour l'IA) et une couverture de tests étendue (coverage > 96 % sur les 3 fichiers Spotify backend).

## Parcours utilisateur

1. Ouvrir l'app, se connecter avec un compte dont le mail Spotify figure sur la whitelist Dev Mode de l'app Spotify
2. Aller sur **Profil → icône Paramètres** (header en haut à droite)
3. Dans **Paramètres**, scroller jusqu'à la section **Intégrations** puis toucher **Services musicaux**
4. Sur l'écran **Intégrations**, vérifier que la carte Spotify affiche « Non connecté » puis toucher **Connecter Spotify**
5. Dans le WebBrowser qui s'ouvre, se connecter à Spotify et accepter les scopes demandés (`user-read-email`, `user-top-read`, `user-read-recently-played`)
6. L'app doit se rouvrir automatiquement via le deep link et afficher un toast « Spotify connecté » ; la carte passe à « Connecté »
7. Toucher **Voir mes stats** : l'écran **Mes stats Spotify** s'ouvre sur l'onglet **Top titres**
8. Changer d'onglet pour **Top artistes** puis **Récents**, vérifier que chaque liste charge (loader visible pendant le fetch) et affiche les bons items (rang, pochette, titre, artistes)
9. Revenir à l'écran Intégrations et toucher **Déconnecter** : toast « Spotify déconnecté » et la carte repasse à « Non connecté »
10. (Optionnel, régressions) Vérifier dans **Profil** que l'écran reste inchangé (stats mock, succès, activités récentes, déconnexion)