### PR TITLE
chore: fix Discord QR rendering and make it scannable without dev-client

### DIFF
--- a/.github/workflows/eas-staging.yml
+++ b/.github/workflows/eas-staging.yml
@@ -60,15 +60,19 @@ jobs:
           cat update.json
           GROUP=$(jq -r '.[0].group' update.json)
           BRANCH=$(jq -r '.[0].branch' update.json)
+          RUNTIME_VERSION=$(jq -r '.[0].runtimeVersion' update.json)
+          CREATED_AT=$(jq -r '.[0].createdAt' update.json)
           PROJECT_ID=$(jq -r '.[0].projectId // "160a02f5-15f4-41a9-bdd9-e402672188b0"' update.json)
-          APP_SCHEME=$(jq -r '.expo.scheme' app.json)
+          SLUG=$(jq -r '.expo.slug' app.json)
           COMMIT_MSG=$(git log -1 --pretty=%s)
-          QR_URL="https://qr.expo.dev/eas-update?appScheme=${APP_SCHEME}&projectId=${PROJECT_ID}&groupId=${GROUP}"
           UPDATE_URL="https://expo.dev/accounts/aldo26/projects/front-mobile/updates/${GROUP}"
+          PREVIEW_URL="https://expo.dev/preview/update?message=$(printf %s "$COMMIT_MSG" | jq -sRr @uri)&updateRuntimeVersion=${RUNTIME_VERSION}&createdAt=$(printf %s "$CREATED_AT" | jq -sRr @uri)&slug=${SLUG}&projectId=${PROJECT_ID}&group=${GROUP}"
+          QR_URL="https://api.qrserver.com/v1/create-qr-code/?size=400x400&margin=10&data=$(printf %s "$PREVIEW_URL" | jq -sRr @uri)"
           {
             echo "group=$GROUP"
             echo "branch=$BRANCH"
             echo "update_url=$UPDATE_URL"
+            echo "preview_url=$PREVIEW_URL"
             echo "qr_url=$QR_URL"
             echo "commit_msg=$COMMIT_MSG"
           } >> "$GITHUB_OUTPUT"
@@ -90,7 +94,8 @@ jobs:
             `${{ steps.update.outputs.commit_msg }}`
 
             🌿 Branch : `${{ steps.update.outputs.branch }}` — commit `${{ github.sha }}`
-            🔗 ${{ steps.update.outputs.update_url }}
+            🔗 Preview : ${{ steps.update.outputs.preview_url }}
+            📊 Détails : ${{ steps.update.outputs.update_url }}
 
-            📷 Scanne avec ton dev-client :
+            📷 Scanne le QR (ouvre la page preview avec boutons Expo Go / dev-client) :
             ${{ steps.update.outputs.qr_url }}


### PR DESCRIPTION
## Problem
After merging #140, the Discord notification showed a link to the QR page instead of rendering the QR inline, and scanning the QR did nothing.

Root causes:
1. `qr.expo.dev/eas-update` returns an HTML landing page, not a PNG — Discord can't inline it
2. The URL it encodes is `exp+frontmobile://expo-development-client/...`, which requires a dev-client build installed on the phone. Without it, the scheme doesn't resolve.

## Fix
1. Switch the QR image URL to `api.qrserver.com/v1/create-qr-code/?...` which always returns PNG → Discord inlines it automatically.
2. Encode the Expo preview URL `https://expo.dev/preview/update?...` (instead of the deep link). Scanning lands on a web page with proper Expo Go / dev-client launch buttons — works regardless of local setup.
3. Also surface both the preview URL (main target) and the raw update details URL (for deeper inspection).

## Test plan

- [ ] Trigger the workflow via `Actions → EAS Staging → Run workflow` (or merge a front-mobile change)
- [ ] Verify Discord message shows the QR as an inline image
- [ ] Scan with phone camera → lands on `expo.dev/preview/update?...` with functional launch buttons