### PR TITLE
chore: encode Expo Go deep link in Discord QR (no auth needed)

### DIFF
--- a/.github/workflows/eas-staging.yml
+++ b/.github/workflows/eas-staging.yml
@@ -67,7 +67,8 @@ jobs:
           COMMIT_MSG=$(git log -1 --pretty=%s)
           UPDATE_URL="https://expo.dev/accounts/aldo26/projects/front-mobile/updates/${GROUP}"
           PREVIEW_URL="https://expo.dev/preview/update?message=$(printf %s "$COMMIT_MSG" | jq -sRr @uri)&updateRuntimeVersion=${RUNTIME_VERSION}&createdAt=$(printf %s "$CREATED_AT" | jq -sRr @uri)&slug=${SLUG}&projectId=${PROJECT_ID}&group=${GROUP}"
-          QR_URL="https://api.qrserver.com/v1/create-qr-code/?size=400x400&margin=10&data=$(printf %s "$PREVIEW_URL" | jq -sRr @uri)"
+          EXPO_GO_DEEPLINK="exp://u.expo.dev/${PROJECT_ID}?channel-name=${BRANCH}&runtime-version=$(printf %s "$RUNTIME_VERSION" | jq -sRr @uri)"
+          QR_URL="https://api.qrserver.com/v1/create-qr-code/?size=400x400&margin=10&data=$(printf %s "$EXPO_GO_DEEPLINK" | jq -sRr @uri)"
           {
             echo "group=$GROUP"
             echo "branch=$BRANCH"
@@ -94,8 +95,7 @@ jobs:
             `${{ steps.update.outputs.commit_msg }}`
 
             🌿 Branch : `${{ steps.update.outputs.branch }}` — commit `${{ github.sha }}`
-            🔗 Preview : ${{ steps.update.outputs.preview_url }}
             📊 Détails : ${{ steps.update.outputs.update_url }}
 
-            📷 Scanne le QR (ouvre la page preview avec boutons Expo Go / dev-client) :
+            📷 Scanne avec l'app Expo Go (aucun login requis) :
             ${{ steps.update.outputs.qr_url }}


### PR DESCRIPTION
## Change
QR now encodes `exp://u.expo.dev/<projectId>?channel-name=staging&runtime-version=<rv>` instead of the expo.dev preview web URL.

## Why
The expo.dev preview page requires a logged-in Expo account with access to a private project. The direct deep link bypasses the web entirely — scanning with a phone that has Expo Go installed loads the update immediately.

## Requirement
Testers need **Expo Go** installed on their phone (free, public app stores). SDK must match (project is on SDK 54, Expo Go supports it).

## Test plan
- [ ] Trigger workflow via `Actions → EAS Staging → Run workflow`
- [ ] Scan QR from Discord with phone camera → opens Expo Go → loads the update
- [ ] Works without any Expo account login