### PR TITLE
chore: point Discord QR to Expo dashboard preview URL

### DIFF
--- a/.github/workflows/eas-staging.yml
+++ b/.github/workflows/eas-staging.yml
@@ -67,8 +67,7 @@ jobs:
           COMMIT_MSG=$(git log -1 --pretty=%s)
           UPDATE_URL="https://expo.dev/accounts/aldo26/projects/front-mobile/updates/${GROUP}"
           PREVIEW_URL="https://expo.dev/preview/update?message=$(printf %s "$COMMIT_MSG" | jq -sRr @uri)&updateRuntimeVersion=${RUNTIME_VERSION}&createdAt=$(printf %s "$CREATED_AT" | jq -sRr @uri)&slug=${SLUG}&projectId=${PROJECT_ID}&group=${GROUP}"
-          EXPO_GO_DEEPLINK="exp://u.expo.dev/${PROJECT_ID}?channel-name=${BRANCH}&runtime-version=$(printf %s "$RUNTIME_VERSION" | jq -sRr @uri)"
-          QR_URL="https://api.qrserver.com/v1/create-qr-code/?size=400x400&margin=10&data=$(printf %s "$EXPO_GO_DEEPLINK" | jq -sRr @uri)"
+          QR_URL="https://api.qrserver.com/v1/create-qr-code/?size=400x400&margin=10&data=$(printf %s "$PREVIEW_URL" | jq -sRr @uri)"
           {
             echo "group=$GROUP"
             echo "branch=$BRANCH"
@@ -97,5 +96,5 @@ jobs:
             🌿 Branch : `${{ steps.update.outputs.branch }}` — commit `${{ github.sha }}`
             📊 Détails : ${{ steps.update.outputs.update_url }}
 
-            📷 Scanne avec l'app Expo Go (aucun login requis) :
+            📷 Scanne le QR (login Expo requis — demander les identifiants au propriétaire) :
             ${{ steps.update.outputs.qr_url }}


### PR DESCRIPTION
## Description
Le QR publié dans Discord lors d'un merge sur `staging` pointait vers un deep link Expo Go (`exp://u.expo.dev/...`) qui ne peut pas charger un EAS Update (Expo Go embarque son propre bundle JS). Le QR est désormais encodé depuis l'URL `expo.dev/preview/update?...` : il ouvre la page dashboard Expo avec les boutons « Open in Expo Go / dev-client », ce qui permet aux testeurs de récupérer l'update sur un build dédié. Un compte Expo est requis pour visualiser la page — les identifiants seront partagés aux testeurs.

## Parcours utilisateur
1. Merger une PR sur la branche `staging` (ou déclencher le workflow `EAS Staging` manuellement via GitHub Actions).
2. Attendre la fin du job `update` dans l'onglet Actions.
3. Ouvrir le canal Discord staging et vérifier qu'un message contient le commit, la branche, le lien « Détails » et une image de QR code.
4. Scanner le QR code avec un téléphone : la page `expo.dev/preview/update` s'ouvre dans le navigateur.
5. Se connecter avec le compte Expo partagé puis cliquer sur « Open in Expo Go » ou « Open in development build » selon la cible.