### PR TITLE
MIX-295 test: cover track_interactions_* error branches to reach 100% coverage

### DIFF
--- a/backend/tests/functional/track_interactions_controller.spec.ts
+++ b/backend/tests/functional/track_interactions_controller.spec.ts
@@ -130,6 +130,16 @@ test.group('TrackInteractionsController - index', (group) => {
     assert.equal(response.body().interactions[0].userId, userA.id)
   })
 
+  test('returns 422 when the action query param is invalid', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('ti_invalid_filter')
+
+    const response = await client
+      .get('/api/me/swipemix/interactions?action=maybe')
+      .bearerToken(token)
+
+    response.assertStatus(422)
+  })
+
   test('filters by action query param', async ({ client, assert }) => {
     const { token } = await createAuthenticatedUser('ti_filter')
 

--- a/backend/tests/unit/track_interactions_controller.spec.ts
+++ b/backend/tests/unit/track_interactions_controller.spec.ts
@@ -1,0 +1,104 @@
+import { test } from '@japa/runner'
+import TrackInteractionsController from '#controllers/track_interactions_controller'
+import { HttpContext } from '@adonisjs/core/http'
+import { makeResponse } from '#tests/utils/http_helpers'
+
+function makeCtx(overrides: Partial<HttpContext> = {}) {
+  const response = makeResponse()
+  const auth = { getUserOrFail: () => ({ id: 'user-1' }) } as any
+  const request = {
+    validateUsing: async () => ({
+      deezerTrackId: '1',
+      action: 'liked',
+    }),
+    qs: () => ({}),
+  } as any
+
+  return {
+    response,
+    ctx: { auth, request, response, ...overrides } as unknown as HttpContext,
+  }
+}
+
+test.group('TrackInteractionsController - Unit', () => {
+  test('index returns 500 when the service throws an unexpected error', async ({ assert }) => {
+    const service = {
+      getByUserId: () => {
+        throw new Error('boom')
+      },
+    } as any
+    const controller = new TrackInteractionsController(service)
+    const { response, ctx } = makeCtx()
+
+    await controller.index(ctx)
+
+    assert.equal(response.statusCode, 500)
+    assert.equal(response.body.message, 'Error while fetching track interactions')
+  })
+
+  test('upsert forwards the service error status and message when service returns ServiceError', async ({
+    assert,
+  }) => {
+    const service = {
+      upsertInteraction: async () => ({
+        error: 'One or more fields exceed maximum length',
+        status: 400,
+      }),
+    } as any
+    const controller = new TrackInteractionsController(service)
+    const { response, ctx } = makeCtx()
+
+    await controller.upsert(ctx)
+
+    assert.equal(response.statusCode, 400)
+    assert.equal(response.body.message, 'One or more fields exceed maximum length')
+  })
+
+  test('upsert returns 500 when the service throws an unexpected error', async ({ assert }) => {
+    const service = {
+      upsertInteraction: async () => {
+        throw new Error('boom')
+      },
+    } as any
+    const controller = new TrackInteractionsController(service)
+    const { response, ctx } = makeCtx()
+
+    await controller.upsert(ctx)
+
+    assert.equal(response.statusCode, 500)
+    assert.equal(response.body.message, 'Error while upserting track interaction')
+  })
+
+  test('delete returns 500 when the service throws an unexpected error', async ({ assert }) => {
+    const service = {
+      deleteInteraction: async () => {
+        throw new Error('boom')
+      },
+    } as any
+    const controller = new TrackInteractionsController(service)
+    const { response, ctx } = makeCtx({ params: { deezerTrackId: '1' } } as any)
+
+    await controller.delete(ctx)
+
+    assert.equal(response.statusCode, 500)
+    assert.equal(response.body.message, 'Error while deleting track interaction')
+  })
+
+  test('delete forwards the service error status and message when interaction is missing', async ({
+    assert,
+  }) => {
+    const service = {
+      deleteInteraction: async () => ({
+        error: 'Track interaction not found',
+        status: 404,
+      }),
+    } as any
+    const controller = new TrackInteractionsController(service)
+    const { response, ctx } = makeCtx({ params: { deezerTrackId: '1' } } as any)
+
+    await controller.delete(ctx)
+
+    assert.equal(response.statusCode, 404)
+    assert.equal(response.body.message, 'Track interaction not found')
+  })
+})

--- a/backend/tests/unit/track_interactions_service.spec.ts
+++ b/backend/tests/unit/track_interactions_service.spec.ts
@@ -103,4 +103,119 @@ test.group('TrackInteractionsService', (group) => {
       .first()
     assert.isNull(exists)
   })
+
+  test('upsertInteraction maps Postgres 22001 (string too long) to 400', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('svc_22001')
+
+    const originalUpdateOrCreate = UserTrackInteraction.updateOrCreate
+    UserTrackInteraction.updateOrCreate = (async () => {
+      const error: any = new Error('value too long for type character varying')
+      error.code = '22001'
+      throw error
+    }) as typeof UserTrackInteraction.updateOrCreate
+
+    try {
+      const result = await service.upsertInteraction({
+        userId: user.id,
+        deezerTrackId: '1',
+        action: InteractionAction.Liked,
+      })
+
+      assert.notInstanceOf(result, UserTrackInteraction)
+      if (!(result instanceof UserTrackInteraction)) {
+        assert.equal(result.error, 'One or more fields exceed maximum length')
+        assert.equal(result.status, 400)
+      }
+    } finally {
+      UserTrackInteraction.updateOrCreate = originalUpdateOrCreate
+    }
+  })
+
+  test('upsertInteraction rethrows unknown database errors', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('svc_rethrow')
+
+    const originalUpdateOrCreate = UserTrackInteraction.updateOrCreate
+    UserTrackInteraction.updateOrCreate = (async () => {
+      const error: any = new Error('unexpected db failure')
+      error.code = '42P01'
+      throw error
+    }) as typeof UserTrackInteraction.updateOrCreate
+
+    try {
+      await service.upsertInteraction({
+        userId: user.id,
+        deezerTrackId: '1',
+        action: InteractionAction.Liked,
+      })
+      assert.fail('Should have thrown')
+    } catch (error: any) {
+      assert.equal(error.message, 'unexpected db failure')
+    } finally {
+      UserTrackInteraction.updateOrCreate = originalUpdateOrCreate
+    }
+  })
+
+  test('deleteInteraction handles array-shaped delete count (driver quirk)', async ({ assert }) => {
+    const originalQuery = UserTrackInteraction.query
+    UserTrackInteraction.query = (() =>
+      ({
+        where() {
+          return this
+        },
+        async delete() {
+          return [1] as unknown as number
+        },
+      }) as any) as typeof UserTrackInteraction.query
+
+    try {
+      const result = await service.deleteInteraction('user-id', '42')
+      assert.notProperty(result, 'error')
+    } finally {
+      UserTrackInteraction.query = originalQuery
+    }
+  })
+
+  test('deleteInteraction returns 404 when array-shaped delete count is empty', async ({
+    assert,
+  }) => {
+    const originalQuery = UserTrackInteraction.query
+    UserTrackInteraction.query = (() =>
+      ({
+        where() {
+          return this
+        },
+        async delete() {
+          return [] as unknown as number
+        },
+      }) as any) as typeof UserTrackInteraction.query
+
+    try {
+      const result = await service.deleteInteraction('user-id', '42')
+      assert.containsSubset(result, { status: 404 })
+    } finally {
+      UserTrackInteraction.query = originalQuery
+    }
+  })
+
+  test('deleteInteraction handles number-shaped delete count (driver quirk)', async ({
+    assert,
+  }) => {
+    const originalQuery = UserTrackInteraction.query
+    UserTrackInteraction.query = (() =>
+      ({
+        where() {
+          return this
+        },
+        async delete() {
+          return 1
+        },
+      }) as any) as typeof UserTrackInteraction.query
+
+    try {
+      const result = await service.deleteInteraction('user-id', '42')
+      assert.notProperty(result, 'error')
+    } finally {
+      UserTrackInteraction.query = originalQuery
+    }
+  })
 })


### PR DESCRIPTION
## Description

Ajoute les tests unitaires et fonctionnels manquants pour couvrir les branches d'erreur de `track_interactions_controller.ts` et `track_interactions_service.ts`, qui étaient tombées sous le seuil 100% imposé par MIX-288. La CI `Backend CI / Run tests with coverage` ne bloque plus les PR staging ← main.

## Parcours utilisateur

1. Checkout de la branche `MIX-295`
2. Lancer `docker exec rythmix-backend-1 npm run test:coverage`
3. Vérifier que les 461 tests passent et que `track_interactions_controller.ts` et `track_interactions_service.ts` affichent **100%** sur `stmts`, `branches`, `functions` et `lines`
4. Vérifier que la step `Run tests with coverage` du workflow `Backend CI` est verte sur cette PR