### PR TITLE
MIX-241 feat: add google oauth sign-in via @adonisjs/ally

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -36,3 +36,8 @@ SPOTIFY_CLIENT_SECRET=
 SPOTIFY_CALLBACK_URL=http://localhost:3333/api/auth/spotify/callback
 # Deep link scheme used to return to the mobile app after OAuth. Defaults to "frontmobile".
 SPOTIFY_DEEP_LINK_SCHEME=frontmobile
+
+# Google OAuth sign-in (https://console.cloud.google.com/apis/credentials)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_CALLBACK_URL=http://localhost:3333/api/auth/google/callback

--- a/backend/.env.prod.example
+++ b/backend/.env.prod.example
@@ -27,3 +27,14 @@ MAIL_FROM_NAME="Rythmix App"
 # Frontend URL for email verification links
 FRONTEND_URL=http://localhost:3000
 LIMITER_STORE=database
+
+# Spotify OAuth (https://developer.spotify.com/dashboard)
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+SPOTIFY_CALLBACK_URL=https://api.yourdomain.com/api/auth/spotify/callback
+SPOTIFY_DEEP_LINK_SCHEME=frontmobile
+
+# Google OAuth (https://console.cloud.google.com/apis/credentials)
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_CALLBACK_URL=https://api.yourdomain.com/api/auth/google/callback

--- a/backend/.env.test
+++ b/backend/.env.test
@@ -35,3 +35,8 @@ SPOTIFY_CLIENT_ID=test_client_id
 SPOTIFY_CLIENT_SECRET=test_client_secret
 SPOTIFY_CALLBACK_URL=http://localhost:3333/api/auth/spotify/callback
 SPOTIFY_DEEP_LINK_SCHEME=frontmobile
+
+# Google OAuth (dummy values for testing)
+GOOGLE_CLIENT_ID=test_google_client_id
+GOOGLE_CLIENT_SECRET=test_google_client_secret
+GOOGLE_CALLBACK_URL=http://localhost:3333/api/auth/google/callback

--- a/backend/app/controllers/google_auth_controller.ts
+++ b/backend/app/controllers/google_auth_controller.ts
@@ -1,0 +1,59 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import logger from '@adonisjs/core/services/logger'
+import { ApiOperation, ApiResponse } from '@foadonis/openapi/decorators'
+import { AuthService } from '#services/auth_service'
+
+@inject()
+export default class GoogleAuthController {
+  constructor(private readonly authService: AuthService) {}
+
+  @ApiOperation({
+    summary: 'Redirect to Google OAuth consent',
+    description: 'Redirects the user to the Google sign-in consent page.',
+  })
+  @ApiResponse({ status: 302, description: 'Redirect to Google' })
+  async redirect({ ally, response }: HttpContext) {
+    const url = await ally.use('google').redirectUrl()
+    return response.redirect(url)
+  }
+
+  @ApiOperation({
+    summary: 'Google OAuth callback',
+    description:
+      'Handles the Google OAuth callback, creates the user if needed, and returns access and refresh tokens.',
+  })
+  @ApiResponse({ status: 200, description: 'Authentication successful' })
+  @ApiResponse({ status: 400, description: 'Google returned an error or no email' })
+  @ApiResponse({ status: 401, description: 'User cancelled the Google sign-in' })
+  @ApiResponse({ status: 500, description: 'Unexpected failure during token exchange' })
+  async callback({ ally, response }: HttpContext) {
+    const google = ally.use('google')
+
+    if (google.accessDenied()) {
+      return response.unauthorized({ message: 'Google sign-in was cancelled' })
+    }
+
+    if (google.hasError()) {
+      return response.badRequest({ message: 'Google sign-in failed' })
+    }
+
+    try {
+      const googleUser = await google.user()
+
+      if (!googleUser.email) {
+        return response.badRequest({ message: 'Google did not return an email' })
+      }
+
+      const { accessToken, refreshToken } = await this.authService.loginOrCreateFromGoogle({
+        email: googleUser.email,
+        name: googleUser.name,
+      })
+
+      return response.ok({ accessToken, refreshToken })
+    } catch (error: unknown) {
+      logger.error({ err: error }, 'Google OAuth callback failed')
+      return response.internalServerError({ message: 'Google sign-in failed' })
+    }
+  }
+}

--- a/backend/app/controllers/google_auth_controller.ts
+++ b/backend/app/controllers/google_auth_controller.ts
@@ -14,7 +14,7 @@ export default class GoogleAuthController {
   })
   @ApiResponse({ status: 302, description: 'Redirect to Google' })
   async redirect({ ally, response }: HttpContext) {
-    const url = await ally.use('google').redirectUrl()
+    const url = await ally.use('google').stateless().redirectUrl()
     return response.redirect(url)
   }
 
@@ -28,7 +28,7 @@ export default class GoogleAuthController {
   @ApiResponse({ status: 401, description: 'User cancelled the Google sign-in' })
   @ApiResponse({ status: 500, description: 'Unexpected failure during token exchange' })
   async callback({ ally, response }: HttpContext) {
-    const google = ally.use('google')
+    const google = ally.use('google').stateless()
 
     if (google.accessDenied()) {
       return response.unauthorized({ message: 'Google sign-in was cancelled' })

--- a/backend/app/services/auth_service.ts
+++ b/backend/app/services/auth_service.ts
@@ -37,13 +37,14 @@ export class AuthService {
   }
 
   async loginOrCreateFromGoogle(profile: { email: string; name?: string | null }) {
-    let user = await User.findBy('email', profile.email)
+    const normalizedEmail = profile.email.trim().toLowerCase()
+    let user = await User.findBy('email', normalizedEmail)
 
     if (!user) {
       const parts = (profile.name ?? '').trim().split(/\s+/).filter(Boolean)
       user = await User.create({
-        email: profile.email,
-        username: await this.generateUniqueUsername(profile.email),
+        email: normalizedEmail,
+        username: await this.generateUniqueUsername(normalizedEmail),
         password: randomBytes(32).toString('hex'),
         firstName: parts[0] ?? null,
         lastName: parts.length > 1 ? parts.slice(1).join(' ') : null,
@@ -238,7 +239,13 @@ export class AuthService {
     const existing = await User.findBy('username', candidate)
     if (!existing) return candidate
 
-    return `${candidate.slice(0, 43)}_${randomBytes(3).toString('hex')}`
+    let username = candidate
+
+    while (await User.findBy('username', username)) {
+      username = `${candidate.slice(0, 43)}_${randomBytes(3).toString('hex')}`
+    }
+
+    return username
   }
 
   private async generateRefreshToken(user: User) {

--- a/backend/app/services/auth_service.ts
+++ b/backend/app/services/auth_service.ts
@@ -36,6 +36,25 @@ export class AuthService {
     return user
   }
 
+  async loginOrCreateFromGoogle(profile: { email: string; name?: string | null }) {
+    let user = await User.findBy('email', profile.email)
+
+    if (!user) {
+      const parts = (profile.name ?? '').trim().split(/\s+/).filter(Boolean)
+      user = await User.create({
+        email: profile.email,
+        username: await this.generateUniqueUsername(profile.email),
+        password: randomBytes(32).toString('hex'),
+        firstName: parts[0] ?? null,
+        lastName: parts.length > 1 ? parts.slice(1).join(' ') : null,
+        role: 'user',
+        emailVerifiedAt: DateTime.now(),
+      })
+    }
+
+    return this.issueTokens(user)
+  }
+
   async login(email: string, password: string) {
     const user = await User.findBy('email', email)
 
@@ -58,17 +77,7 @@ export class AuthService {
       throw new Error('Email not verified')
     }
 
-    const accessToken = await User.accessTokens.create(user, ['*'], {
-      expiresIn: '15 minutes',
-    })
-
-    const refreshToken = await this.generateRefreshToken(user)
-
-    return {
-      user,
-      accessToken: accessToken.value!.release(),
-      refreshToken: refreshToken.token,
-    }
+    return this.issueTokens(user)
   }
 
   async refresh(refreshTokenValue: string) {
@@ -203,6 +212,33 @@ export class AuthService {
 
   async cleanExpiredTokens() {
     await RefreshToken.query().where('expiresAt', '<', DateTime.now().toSQL()).delete()
+  }
+
+  private async issueTokens(user: User) {
+    const accessToken = await User.accessTokens.create(user, ['*'], {
+      expiresIn: '15 minutes',
+    })
+    const refreshToken = await this.generateRefreshToken(user)
+
+    return {
+      user,
+      accessToken: accessToken.value!.release(),
+      refreshToken: refreshToken.token,
+    }
+  }
+
+  private async generateUniqueUsername(email: string): Promise<string> {
+    const sanitized = email
+      .split('@')[0]
+      .toLowerCase()
+      .replace(/[^a-z0-9]/g, '')
+    const base = sanitized.length >= 3 ? sanitized : `${sanitized}user`
+    const candidate = base.slice(0, 50)
+
+    const existing = await User.findBy('username', candidate)
+    if (!existing) return candidate
+
+    return `${candidate.slice(0, 43)}_${randomBytes(3).toString('hex')}`
   }
 
   private async generateRefreshToken(user: User) {

--- a/backend/config/ally.ts
+++ b/backend/config/ally.ts
@@ -8,6 +8,12 @@ const allyConfig = defineConfig({
     callbackUrl: env.get('SPOTIFY_CALLBACK_URL'),
     scopes: ['user-read-email', 'user-top-read', 'user-read-recently-played'],
   }),
+  google: services.google({
+    clientId: env.get('GOOGLE_CLIENT_ID'),
+    clientSecret: env.get('GOOGLE_CLIENT_SECRET'),
+    callbackUrl: env.get('GOOGLE_CALLBACK_URL'),
+    scopes: ['userinfo.email', 'userinfo.profile'],
+  }),
 })
 
 export default allyConfig

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1866,7 +1866,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@japa/assert/-/assert-4.0.1.tgz",
       "integrity": "sha512-n/dA9DVLNvM/Bw8DtN8kBdPjYsSHe3XTRjF5+U8vlzDavpW9skUANl2CHR1K/TBWZxwMfGi15SJIjo6UCs09AA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/macroable": "^1.0.4",
@@ -3273,7 +3273,7 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
       "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*"
@@ -3290,7 +3290,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3832,7 +3832,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4166,7 +4166,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
       "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
@@ -4229,7 +4229,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
       "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 16"
@@ -4746,7 +4746,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6994,7 +6994,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
       "integrity": "sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lowercase-keys": {
@@ -7693,7 +7693,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"

--- a/backend/start/env.ts
+++ b/backend/start/env.ts
@@ -64,4 +64,13 @@ export default await Env.create(new URL('../', import.meta.url), {
   SPOTIFY_CLIENT_SECRET: Env.schema.string(),
   SPOTIFY_CALLBACK_URL: Env.schema.string(),
   SPOTIFY_DEEP_LINK_SCHEME: Env.schema.string.optional(),
+
+  /*
+  |----------------------------------------------------------
+  | Variables for Google OAuth sign-in (@adonisjs/ally)
+  |----------------------------------------------------------
+  */
+  GOOGLE_CLIENT_ID: Env.schema.string(),
+  GOOGLE_CLIENT_SECRET: Env.schema.string(),
+  GOOGLE_CALLBACK_URL: Env.schema.string(),
 })

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -14,6 +14,7 @@ const FavoriteGamesController = () => import('#controllers/favorite_games_contro
 const UserAchievementsController = () => import('#controllers/user_achievements_controller')
 const ProfileController = () => import('#controllers/profile_controller')
 const SpotifyAuthController = () => import('#controllers/spotify_auth_controller')
+const GoogleAuthController = () => import('#controllers/google_auth_controller')
 const MeIntegrationsController = () => import('#controllers/me_integrations_controller')
 
 // Register OpenAPI/Swagger routes: /docs, /docs.json, /docs.yaml
@@ -56,6 +57,8 @@ router
         router.get('/me', [AuthController, 'me']).use(middleware.auth())
         router.post('/spotify/init', [SpotifyAuthController, 'init']).use(middleware.auth())
         router.get('/spotify/callback', [SpotifyAuthController, 'callback'])
+        router.get('/google/redirect', [GoogleAuthController, 'redirect'])
+        router.get('/google/callback', [GoogleAuthController, 'callback'])
       })
       .prefix('/auth')
 

--- a/backend/tests/functional/google_auth_controller.spec.ts
+++ b/backend/tests/functional/google_auth_controller.spec.ts
@@ -1,0 +1,165 @@
+import { test } from '@japa/runner'
+import { Group } from '@japa/runner/core'
+import { HttpContext } from '@adonisjs/core/http'
+import User from '#models/user'
+import { deleteAuthData } from '#tests/utils/auth_cleanup_helpers'
+
+interface AllyMockScenario {
+  denied?: boolean
+  error?: boolean
+  userResponse?: { email: string | null; name?: string | null }
+  throwOnUser?: unknown
+}
+
+function buildFakeAlly(scenario: AllyMockScenario) {
+  return {
+    use() {
+      return {
+        async redirectUrl() {
+          return 'https://accounts.google.com/o/oauth2/v2/auth?client_id=test'
+        },
+        accessDenied() {
+          return scenario.denied === true
+        },
+        hasError() {
+          return scenario.error === true
+        },
+        async user() {
+          if ('throwOnUser' in scenario) throw scenario.throwOnUser
+          return scenario.userResponse ?? { email: 'default@example.com', name: 'Default User' }
+        },
+      }
+    },
+  }
+}
+
+function installAllyMock(scenario: AllyMockScenario) {
+  const fake = buildFakeAlly(scenario)
+  Object.defineProperty(HttpContext.prototype, 'ally', {
+    get() {
+      return fake
+    },
+    configurable: true,
+    enumerable: false,
+  })
+}
+
+function useAllyMock(group: Group) {
+  let originalDescriptor: PropertyDescriptor | undefined
+
+  group.setup(() => {
+    originalDescriptor = Object.getOwnPropertyDescriptor(HttpContext.prototype, 'ally')
+  })
+
+  group.each.teardown(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(HttpContext.prototype, 'ally', originalDescriptor)
+    } else {
+      delete (HttpContext.prototype as unknown as { ally?: unknown }).ally
+    }
+  })
+}
+
+test.group('GoogleAuthController - Redirect', (group) => {
+  useAllyMock(group)
+
+  test('GET /api/auth/google/redirect redirects to the Google consent URL', async ({
+    client,
+    assert,
+  }) => {
+    installAllyMock({})
+
+    const response = await client.get('/api/auth/google/redirect').redirects(0)
+
+    response.assertStatus(302)
+    assert.include(response.headers().location as string, 'accounts.google.com/o/oauth2/v2/auth')
+  })
+})
+
+test.group('GoogleAuthController - Callback', (group) => {
+  deleteAuthData(group)
+  useAllyMock(group)
+
+  test('callback returns 401 when Google access is denied', async ({ client }) => {
+    installAllyMock({ denied: true })
+
+    const response = await client.get('/api/auth/google/callback')
+
+    response.assertStatus(401)
+    response.assertBodyContains({ message: 'Google sign-in was cancelled' })
+  })
+
+  test('callback returns 400 when Google returned an error', async ({ client }) => {
+    installAllyMock({ error: true })
+
+    const response = await client.get('/api/auth/google/callback')
+
+    response.assertStatus(400)
+    response.assertBodyContains({ message: 'Google sign-in failed' })
+  })
+
+  test('callback returns 400 when Google does not return an email', async ({ client }) => {
+    installAllyMock({ userResponse: { email: null, name: 'No Email' } })
+
+    const response = await client.get('/api/auth/google/callback')
+
+    response.assertStatus(400)
+    response.assertBodyContains({ message: 'Google did not return an email' })
+  })
+
+  test('callback creates a new user and returns tokens when email is unknown', async ({
+    client,
+    assert,
+  }) => {
+    const email = `google_new_${Date.now()}@example.com`
+    installAllyMock({ userResponse: { email, name: 'Jane Doe' } })
+
+    const response = await client.get('/api/auth/google/callback')
+
+    response.assertStatus(200)
+    const body = response.body() as { accessToken: string; refreshToken: string }
+    assert.isString(body.accessToken)
+    assert.isString(body.refreshToken)
+    assert.include(body.refreshToken, '.')
+
+    const user = await User.findBy('email', email)
+    assert.isNotNull(user)
+    assert.equal(user!.firstName, 'Jane')
+    assert.equal(user!.lastName, 'Doe')
+    assert.isNotNull(user!.emailVerifiedAt)
+  })
+
+  test('callback signs in an existing user and returns tokens', async ({ client, assert }) => {
+    const email = `google_existing_${Date.now()}@example.com`
+    const existing = await User.create({
+      email,
+      username: `existing_${Date.now()}`,
+      password: 'password123',
+      role: 'user',
+    })
+
+    installAllyMock({
+      userResponse: { email, name: 'Should Not Override' },
+    })
+
+    const response = await client.get('/api/auth/google/callback')
+
+    response.assertStatus(200)
+    const body = response.body() as { accessToken: string; refreshToken: string }
+    assert.isString(body.accessToken)
+    assert.isString(body.refreshToken)
+
+    const usersWithEmail = await User.query().where('email', email)
+    assert.lengthOf(usersWithEmail, 1)
+    assert.equal(usersWithEmail[0].id, existing.id)
+  })
+
+  test('callback returns 500 when google.user() throws', async ({ client }) => {
+    installAllyMock({ throwOnUser: new Error('boom') })
+
+    const response = await client.get('/api/auth/google/callback')
+
+    response.assertStatus(500)
+    response.assertBodyContains({ message: 'Google sign-in failed' })
+  })
+})

--- a/backend/tests/functional/google_auth_controller.spec.ts
+++ b/backend/tests/functional/google_auth_controller.spec.ts
@@ -14,7 +14,10 @@ interface AllyMockScenario {
 function buildFakeAlly(scenario: AllyMockScenario) {
   return {
     use() {
-      return {
+      const driver = {
+        stateless() {
+          return driver
+        },
         async redirectUrl() {
           return 'https://accounts.google.com/o/oauth2/v2/auth?client_id=test'
         },
@@ -29,6 +32,7 @@ function buildFakeAlly(scenario: AllyMockScenario) {
           return scenario.userResponse ?? { email: 'default@example.com', name: 'Default User' }
         },
       }
+      return driver
     },
   }
 }

--- a/backend/tests/unit/auth_service_google.spec.ts
+++ b/backend/tests/unit/auth_service_google.spec.ts
@@ -1,0 +1,91 @@
+import { test } from '@japa/runner'
+import User from '#models/user'
+import { AuthService } from '#services/auth_service'
+import { deleteAuthData } from '#tests/utils/auth_cleanup_helpers'
+
+test.group('AuthService - loginOrCreateFromGoogle', (group) => {
+  let authService: AuthService
+
+  deleteAuthData(group)
+
+  group.each.setup(async () => {
+    authService = new AuthService()
+  })
+
+  test('creates a new user with split first/last name and verified email', async ({ assert }) => {
+    const email = `svc_google_new_${Date.now()}@example.com`
+
+    const result = await authService.loginOrCreateFromGoogle({ email, name: 'John Michael Doe' })
+
+    assert.isString(result.accessToken)
+    assert.isString(result.refreshToken)
+    assert.equal(result.user.email, email)
+    assert.equal(result.user.firstName, 'John')
+    assert.equal(result.user.lastName, 'Michael Doe')
+    assert.isNotNull(result.user.emailVerifiedAt)
+    assert.equal(result.user.role, 'user')
+  })
+
+  test('creates a user with null firstName/lastName when name is null', async ({ assert }) => {
+    const email = `svc_google_noname_${Date.now()}@example.com`
+
+    const result = await authService.loginOrCreateFromGoogle({ email, name: null })
+
+    assert.isNull(result.user.firstName)
+    assert.isNull(result.user.lastName)
+  })
+
+  test('creates a user with only firstName when Google name has one word', async ({ assert }) => {
+    const email = `svc_google_single_${Date.now()}@example.com`
+
+    const result = await authService.loginOrCreateFromGoogle({ email, name: 'Madonna' })
+
+    assert.equal(result.user.firstName, 'Madonna')
+    assert.isNull(result.user.lastName)
+  })
+
+  test('reuses an existing user when the email is already registered', async ({ assert }) => {
+    const email = `svc_google_existing_${Date.now()}@example.com`
+    const existing = await User.create({
+      email,
+      username: `svc_existing_${Date.now()}`,
+      password: 'password123',
+      firstName: 'Original',
+      lastName: 'Name',
+      role: 'user',
+    })
+
+    const result = await authService.loginOrCreateFromGoogle({ email, name: 'Ignored Name' })
+
+    assert.equal(result.user.id, existing.id)
+    assert.equal(result.user.firstName, 'Original')
+    assert.equal(result.user.lastName, 'Name')
+  })
+
+  test('appends a random suffix when the derived username is already taken', async ({ assert }) => {
+    const timestamp = Date.now()
+    const desiredUsername = `collide${timestamp}`
+    await User.create({
+      email: `other_${timestamp}@example.com`,
+      username: desiredUsername,
+      password: 'password123',
+      role: 'user',
+    })
+
+    const result = await authService.loginOrCreateFromGoogle({
+      email: `${desiredUsername}@gmail.com`,
+      name: 'Collision User',
+    })
+
+    assert.notEqual(result.user.username, desiredUsername)
+    assert.match(result.user.username, new RegExp(`^${desiredUsername}_[a-f0-9]{6}$`))
+  })
+
+  test('pads short local-parts so the username respects the 3-char minimum', async ({ assert }) => {
+    const email = `ab@example-${Date.now()}.com`
+
+    const result = await authService.loginOrCreateFromGoogle({ email, name: null })
+
+    assert.equal(result.user.username, 'abuser')
+  })
+})


### PR DESCRIPTION
This pull request adds support for Google OAuth sign-in to the backend, alongside Spotify, allowing users to authenticate with their Google accounts. It introduces a new `GoogleAuthController`, updates environment and configuration files, and provides comprehensive tests for the new authentication flow. Additionally, the `AuthService` is refactored to support Google sign-in and to simplify token issuance.

**Google OAuth Integration**

* Added new `GoogleAuthController` with endpoints for redirecting to Google and handling the OAuth callback, including error handling and user creation/sign-in logic. (`backend/app/controllers/google_auth_controller.ts` [backend/app/controllers/google_auth_controller.tsR1-R59](diffhunk://#diff-ece0b35892c7928bb1a16d71c25451235b272dda9a78fdba322ea862879a1fe9R1-R59))
* Registered Google OAuth routes in `routes.ts` and imported the new controller. (`backend/start/routes.ts` [[1]](diffhunk://#diff-e72f182eae9caec3ef631c012ab133853f783154427bd6ef9cff6ccd21364d80R17) [[2]](diffhunk://#diff-e72f182eae9caec3ef631c012ab133853f783154427bd6ef9cff6ccd21364d80R60-R61)
* Configured Google as an OAuth provider in `ally.ts`, reading credentials and callback URL from environment variables. (`backend/config/ally.ts` [backend/config/ally.tsR11-R16](diffhunk://#diff-2c544001ae25d611f590acb0eef93d4c6745c2cb45a6a2bb22d0fcccc7be9501R11-R16))
* Added Google OAuth environment variables to `.env.example`, `.env.prod.example`, `.env.test`, and validated them in `start/env.ts`. [[1]](diffhunk://#diff-361f2d0f55c49b270125820efb10f0d9433ced883e9d59b1f58c27b877dc2080R39-R43) [[2]](diffhunk://#diff-2f6ac0f7b472560ee2aa2daf2feae36629b03a65bd4ba3cff700b86db09edc71R30-R40) [[3]](diffhunk://#diff-abdc3f8116bdae58e3b19b0077699716a606138f13cd13f6ea94072e93893b21R38-R42) [[4]](diffhunk://#diff-06070215b0200d812222b842c159a48f5983396d8754b92e5bb4600efa545e89R67-R75)

**AuthService Refactoring**

* Added `loginOrCreateFromGoogle` method to handle user lookup/creation and token issuance for Google sign-in, including unique username generation and verified email handling. (`backend/app/services/auth_service.ts` Fe8768b9L36R35, [backend/app/services/auth_service.tsR217-R243](diffhunk://#diff-baca155e1e254205cf53ca724a6b7d2373e1eb9213b6b5e3987f24d63e0c5655R217-R243))
* Refactored token issuance logic into a private `issueTokens` method, used by both password and Google login flows. (`backend/app/services/auth_service.ts` [[1]](diffhunk://#diff-baca155e1e254205cf53ca724a6b7d2373e1eb9213b6b5e3987f24d63e0c5655L61-R80) [[2]](diffhunk://#diff-baca155e1e254205cf53ca724a6b7d2373e1eb9213b6b5e3987f24d63e0c5655R217-R243)

**Testing**

* Added functional tests for the Google OAuth flow, covering redirect, error cases, new user creation, and existing user sign-in. (`backend/tests/functional/google_auth_controller.spec.ts` [backend/tests/functional/google_auth_controller.spec.tsR1-R165](diffhunk://#diff-9db0de3f5579c73053377d8e8d15fd2f6c23fa8ab331b83690ecb1c8354ea00dR1-R165))
* Added unit tests for `AuthService.loginOrCreateFromGoogle`, testing user creation, username generation, and email handling logic. (`backend/tests/unit/auth_service_google.spec.ts` [backend/tests/unit/auth_service_google.spec.tsR1-R91](diffhunk://#diff-6ce86f0a5d6230a0240b500b579ab0638417d7b7fb5bf11b8faad008cecdeb7bR1-R91))