### PR TITLE
HOTFIX-enable-core-games-seeder fix: enable blind test and plus ou moins in game seeder

### DIFF
--- a/backend/database/seeders/game_seeder.ts
+++ b/backend/database/seeders/game_seeder.ts
@@ -8,7 +8,7 @@ export default class extends BaseSeeder {
         name: 'Blind Test',
         description: 'Devinez les morceaux le plus rapidement possible en temps réel.',
         isMultiplayer: false,
-        isEnabled: false,
+        isEnabled: true,
       },
       {
         name: 'Qui dit ça ?',
@@ -32,7 +32,7 @@ export default class extends BaseSeeder {
         name: 'Plus ou Moins',
         description: 'Comparez la popularité des artistes : streams, abonnés, récompenses.',
         isMultiplayer: false,
-        isEnabled: false,
+        isEnabled: true,
       },
       {
         name: 'Fausse Punch',


### PR DESCRIPTION
## Description
Le seeder `game_seeder.ts` marquait Blind Test et Plus ou Moins comme désactivés (`isEnabled: false`) alors que ces jeux sont prêts à être joués. Passage de `isEnabled` à `true` pour ces deux jeux (Tracklist et Blurchette le sont déjà).

## Parcours utilisateur
1. Reset DB et re-run les seeders : `docker exec rythmix-backend-1 node ace migration:fresh --seed`
2. Vérifier en SQL : `docker exec rythmix-database-1 psql -U <user> -d <db> -c "SELECT name, is_enabled FROM games ORDER BY id;"`
3. Confirmer que Blind Test, Tracklist, Blurchette et Plus ou Moins sont à `is_enabled = true`
4. Sur la mobile, ouvrir l'écran de sélection de jeux : ces 4 jeux doivent être listés et jouables