### PR TITLE
MIX-309 feat: replace blindtest genre selection with curated deezer playlists

### DIFF
--- a/backend/app/controllers/curated_playlists_controller.ts
+++ b/backend/app/controllers/curated_playlists_controller.ts
@@ -1,0 +1,64 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import logger from '@adonisjs/core/services/logger'
+import {
+  CuratedPlaylistService,
+  DeezerPlaylistFetchError,
+  PlaylistNotFoundError,
+} from '#services/curated_playlist_service'
+import { curatedPlaylistTracksValidator } from '#validators/curated_playlist_validator'
+import { ApiOperation, ApiParam, ApiResponse } from '@foadonis/openapi/decorators'
+
+@inject()
+export default class CuratedPlaylistsController {
+  constructor(private readonly curatedPlaylistService: CuratedPlaylistService) {}
+
+  @ApiOperation({
+    summary: 'List Blindtest curated playlists',
+    description: 'Returns the curated playlists displayed in the Blindtest game.',
+  })
+  @ApiResponse({ status: 200, description: 'Playlists retrieved successfully' })
+  @ApiResponse({ status: 500, description: 'Failed to fetch curated playlists' })
+  public async index({ response }: HttpContext) {
+    try {
+      const playlists = await this.curatedPlaylistService.listPlaylists()
+      return response.ok({ playlists })
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to fetch curated playlists')
+      return response.internalServerError({ message: 'Failed to fetch curated playlists' })
+    }
+  }
+
+  @ApiOperation({
+    summary: 'Get a random sample of tracks for a curated playlist',
+    description:
+      'Fetches the curated playlist tracks from Deezer, shuffles them, and returns up to `count` items.',
+  })
+  @ApiParam({ name: 'id', description: 'Curated playlist ID', required: true })
+  @ApiResponse({ status: 200, description: 'Tracks retrieved successfully' })
+  @ApiResponse({ status: 404, description: 'Curated playlist not found' })
+  @ApiResponse({ status: 502, description: 'Failed to fetch tracks from Deezer' })
+  public async tracks({ params, request, response }: HttpContext) {
+    try {
+      const { count } = await request.validateUsing(curatedPlaylistTracksValidator, {
+        data: request.qs(),
+      })
+      const playlistId = Number(params.id)
+      if (!Number.isFinite(playlistId)) {
+        return response.badRequest({ message: 'Invalid playlist id' })
+      }
+
+      const tracks = await this.curatedPlaylistService.getRandomTracks(playlistId, count)
+      return response.ok({ tracks })
+    } catch (error) {
+      if (error instanceof PlaylistNotFoundError) {
+        return response.notFound({ message: 'Curated playlist not found' })
+      }
+      if (error instanceof DeezerPlaylistFetchError) {
+        logger.error({ err: error }, 'Deezer playlist fetch failed')
+        return response.status(502).json({ message: 'Failed to fetch tracks from Deezer' })
+      }
+      throw error
+    }
+  }
+}

--- a/backend/app/models/curated_playlist.ts
+++ b/backend/app/models/curated_playlist.ts
@@ -1,0 +1,37 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column } from '@adonisjs/lucid/orm'
+import { ApiProperty } from '@foadonis/openapi/decorators'
+
+export default class CuratedPlaylist extends BaseModel {
+  @ApiProperty({ description: 'Curated playlist unique identifier', example: 1 })
+  @column({ isPrimary: true })
+  declare id: number
+
+  @ApiProperty({ description: 'Deezer playlist ID', example: 908622995 })
+  @column()
+  declare deezerPlaylistId: number
+
+  @ApiProperty({ description: 'Display name shown in the app', example: 'Rap FR Essentials' })
+  @column()
+  declare name: string
+
+  @ApiProperty({ description: 'Genre label associated with the playlist', example: 'Rap FR' })
+  @column()
+  declare genreLabel: string
+
+  @ApiProperty({ description: 'Cover image URL', example: 'https://e-cdns-images.dzcdn.net/...' })
+  @column()
+  declare coverUrl: string | null
+
+  @ApiProperty({ description: 'Total number of tracks in the Deezer playlist', example: 1731 })
+  @column()
+  declare trackCount: number
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @ApiProperty({ description: 'Last update timestamp' })
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/backend/app/services/curated_playlist_service.ts
+++ b/backend/app/services/curated_playlist_service.ts
@@ -58,8 +58,20 @@ export class DeezerPlaylistFetchError extends Error {
 const DEEZER_API_BASE = 'https://api.deezer.com'
 const DEFAULT_TRACK_COUNT = 50
 const PAGE_SIZE = 500
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+interface CacheEntry {
+  tracks: DeezerPlaylistTrack[]
+  expiresAt: number
+}
 
 export class CuratedPlaylistService {
+  private static cache = new Map<number, CacheEntry>()
+
+  static clearCache() {
+    CuratedPlaylistService.cache.clear()
+  }
+
   async listPlaylists(): Promise<CuratedPlaylist[]> {
     return CuratedPlaylist.query().orderBy('id', 'asc')
   }
@@ -77,10 +89,25 @@ export class CuratedPlaylistService {
       throw new PlaylistNotFoundError(playlistId)
     }
 
-    const tracks = await this.fetchDeezerPlaylistTracks(playlist.deezerPlaylistId)
-    const unique = this.dedupeById(tracks)
+    const unique = await this.getUniqueDeezerTracks(playlist.deezerPlaylistId)
     const shuffled = this.shuffle(unique)
     return shuffled.slice(0, Math.max(0, count))
+  }
+
+  protected async getUniqueDeezerTracks(deezerPlaylistId: number): Promise<DeezerPlaylistTrack[]> {
+    const now = Date.now()
+    const cached = CuratedPlaylistService.cache.get(deezerPlaylistId)
+    if (cached && cached.expiresAt > now) {
+      return cached.tracks
+    }
+
+    const tracks = await this.fetchDeezerPlaylistTracks(deezerPlaylistId)
+    const unique = this.dedupeById(tracks)
+    CuratedPlaylistService.cache.set(deezerPlaylistId, {
+      tracks: unique,
+      expiresAt: now + CACHE_TTL_MS,
+    })
+    return unique
   }
 
   protected dedupeById(tracks: DeezerPlaylistTrack[]): DeezerPlaylistTrack[] {
@@ -97,26 +124,27 @@ export class CuratedPlaylistService {
   protected async fetchDeezerPlaylistTracks(
     deezerPlaylistId: number
   ): Promise<DeezerPlaylistTrack[]> {
-    // Deezer paginates /playlist/:id/tracks (default limit=25, max=500). To make every
-    // track of the playlist eligible we probe for the total, then fetch every page in
-    // parallel.
-    const probe = await this.requestDeezer(
+    // Deezer paginates /playlist/:id/tracks (default limit=25, max=500). The first page
+    // also returns `total`, so we use it both to seed the result and to compute the
+    // remaining pages — saves one round-trip vs. a dedicated probe call.
+    const firstPage = await this.requestDeezer(
       deezerPlaylistId,
-      `${DEEZER_API_BASE}/playlist/${deezerPlaylistId}/tracks?limit=1`
+      `${DEEZER_API_BASE}/playlist/${deezerPlaylistId}/tracks?limit=${PAGE_SIZE}&index=0`
     )
-    const total = probe.total ?? 0
-    if (total === 0) return []
+    const data = firstPage.data ?? []
+    const total = firstPage.total ?? data.length
+    if (total <= PAGE_SIZE) return data
 
-    const pageCount = Math.ceil(total / PAGE_SIZE)
+    const remainingPages = Math.ceil(total / PAGE_SIZE) - 1
     const pages = await Promise.all(
-      Array.from({ length: pageCount }, (_, page) =>
+      Array.from({ length: remainingPages }, (_, i) =>
         this.requestDeezer(
           deezerPlaylistId,
-          `${DEEZER_API_BASE}/playlist/${deezerPlaylistId}/tracks?limit=${PAGE_SIZE}&index=${page * PAGE_SIZE}`
+          `${DEEZER_API_BASE}/playlist/${deezerPlaylistId}/tracks?limit=${PAGE_SIZE}&index=${(i + 1) * PAGE_SIZE}`
         )
       )
     )
-    return pages.flatMap((p) => p.data)
+    return [data, ...pages.map((p) => p.data ?? [])].flat()
   }
 
   protected async requestDeezer(

--- a/backend/app/services/curated_playlist_service.ts
+++ b/backend/app/services/curated_playlist_service.ts
@@ -144,7 +144,7 @@ export class CuratedPlaylistService {
         )
       )
     )
-    return [data, ...pages.map((p) => p.data ?? [])].flat()
+    return [data, ...pages.map((p) => p.data)].flat()
   }
 
   protected async requestDeezer(

--- a/backend/app/services/curated_playlist_service.ts
+++ b/backend/app/services/curated_playlist_service.ts
@@ -1,0 +1,148 @@
+import CuratedPlaylist from '#models/curated_playlist'
+
+interface DeezerPlaylistTrackArtist {
+  id: number
+  name: string
+  picture?: string
+  picture_small?: string
+  picture_medium?: string
+  picture_big?: string
+  picture_xl?: string
+}
+
+interface DeezerPlaylistTrackAlbum {
+  id: number
+  title: string
+  cover?: string
+  cover_small?: string
+  cover_medium?: string
+  cover_big?: string
+  cover_xl?: string
+}
+
+export interface DeezerPlaylistTrack {
+  id: number
+  title: string
+  title_short: string
+  preview: string
+  duration: number
+  artist: DeezerPlaylistTrackArtist
+  album: DeezerPlaylistTrackAlbum
+}
+
+interface DeezerPlaylistTracksResponse {
+  data: DeezerPlaylistTrack[]
+  total?: number
+  next?: string
+}
+
+export class PlaylistNotFoundError extends Error {
+  constructor(public playlistId: number) {
+    super(`Curated playlist with id ${playlistId} not found`)
+    this.name = 'PlaylistNotFoundError'
+  }
+}
+
+export class DeezerPlaylistFetchError extends Error {
+  constructor(
+    public deezerPlaylistId: number,
+    public status?: number
+  ) {
+    super(
+      `Failed to fetch Deezer playlist ${deezerPlaylistId}${status ? ` (status ${status})` : ''}`
+    )
+    this.name = 'DeezerPlaylistFetchError'
+  }
+}
+
+const DEEZER_API_BASE = 'https://api.deezer.com'
+const DEFAULT_TRACK_COUNT = 50
+const PAGE_SIZE = 500
+
+export class CuratedPlaylistService {
+  async listPlaylists(): Promise<CuratedPlaylist[]> {
+    return CuratedPlaylist.query().orderBy('id', 'asc')
+  }
+
+  async findById(id: number): Promise<CuratedPlaylist | null> {
+    return CuratedPlaylist.query().where('id', id).first()
+  }
+
+  async getRandomTracks(
+    playlistId: number,
+    count: number = DEFAULT_TRACK_COUNT
+  ): Promise<DeezerPlaylistTrack[]> {
+    const playlist = await this.findById(playlistId)
+    if (!playlist) {
+      throw new PlaylistNotFoundError(playlistId)
+    }
+
+    const tracks = await this.fetchDeezerPlaylistTracks(playlist.deezerPlaylistId)
+    const unique = this.dedupeById(tracks)
+    const shuffled = this.shuffle(unique)
+    return shuffled.slice(0, Math.max(0, count))
+  }
+
+  protected dedupeById(tracks: DeezerPlaylistTrack[]): DeezerPlaylistTrack[] {
+    const seen = new Set<number>()
+    const result: DeezerPlaylistTrack[] = []
+    for (const track of tracks) {
+      if (seen.has(track.id)) continue
+      seen.add(track.id)
+      result.push(track)
+    }
+    return result
+  }
+
+  protected async fetchDeezerPlaylistTracks(
+    deezerPlaylistId: number
+  ): Promise<DeezerPlaylistTrack[]> {
+    // Deezer paginates /playlist/:id/tracks (default limit=25, max=500). To make every
+    // track of the playlist eligible we probe for the total, then fetch every page in
+    // parallel.
+    const probe = await this.requestDeezer(
+      deezerPlaylistId,
+      `${DEEZER_API_BASE}/playlist/${deezerPlaylistId}/tracks?limit=1`
+    )
+    const total = probe.total ?? 0
+    if (total === 0) return []
+
+    const pageCount = Math.ceil(total / PAGE_SIZE)
+    const pages = await Promise.all(
+      Array.from({ length: pageCount }, (_, page) =>
+        this.requestDeezer(
+          deezerPlaylistId,
+          `${DEEZER_API_BASE}/playlist/${deezerPlaylistId}/tracks?limit=${PAGE_SIZE}&index=${page * PAGE_SIZE}`
+        )
+      )
+    )
+    return pages.flatMap((p) => p.data)
+  }
+
+  protected async requestDeezer(
+    deezerPlaylistId: number,
+    url: string
+  ): Promise<DeezerPlaylistTracksResponse> {
+    let response: Response
+    try {
+      response = await fetch(url)
+    } catch {
+      throw new DeezerPlaylistFetchError(deezerPlaylistId)
+    }
+
+    if (!response.ok) {
+      throw new DeezerPlaylistFetchError(deezerPlaylistId, response.status)
+    }
+
+    return (await response.json()) as DeezerPlaylistTracksResponse
+  }
+
+  protected shuffle<T>(items: T[]): T[] {
+    const copy = [...items]
+    for (let i = copy.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[copy[i], copy[j]] = [copy[j], copy[i]]
+    }
+    return copy
+  }
+}

--- a/backend/app/validators/curated_playlist_validator.ts
+++ b/backend/app/validators/curated_playlist_validator.ts
@@ -1,0 +1,7 @@
+import vine from '@vinejs/vine'
+
+export const curatedPlaylistTracksValidator = vine.compile(
+  vine.object({
+    count: vine.number().min(1).max(100).optional(),
+  })
+)

--- a/backend/database/migrations/1777476752300_create_curated_playlists_table.ts
+++ b/backend/database/migrations/1777476752300_create_curated_playlists_table.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'curated_playlists'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table.bigInteger('deezer_playlist_id').notNullable().unique()
+      table.string('name').notNullable()
+      table.string('genre_label').notNullable()
+      table.string('cover_url').nullable()
+      table.integer('track_count').notNullable().defaultTo(0)
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/backend/database/seeders/curated_playlist_seeder.ts
+++ b/backend/database/seeders/curated_playlist_seeder.ts
@@ -1,0 +1,80 @@
+import { BaseSeeder } from '@adonisjs/lucid/seeders'
+import CuratedPlaylist from '#models/curated_playlist'
+
+export default class extends BaseSeeder {
+  async run() {
+    const playlists = [
+      {
+        deezerPlaylistId: 15223693943,
+        name: 'Rap FR',
+        genreLabel: 'Rap FR',
+        coverUrl:
+          'https://cdn-images.dzcdn.net/images/playlist/bdc88ba888bbb3ba037f895204faaf09/500x500-000000-80-0-0.jpg',
+        trackCount: 1731,
+      },
+      {
+        deezerPlaylistId: 15223877503,
+        name: 'Rap US',
+        genreLabel: 'Rap US',
+        coverUrl:
+          'https://cdn-images.dzcdn.net/images/playlist/d70276193e9eb1dc63c2e562f4695167/500x500-000000-80-0-0.jpg',
+        trackCount: 1920,
+      },
+      {
+        deezerPlaylistId: 15223879163,
+        name: 'Pop International',
+        genreLabel: 'Pop',
+        coverUrl:
+          'https://cdn-images.dzcdn.net/images/playlist/94e5101fad07fdfecf4464c651affda6/500x500-000000-80-0-0.jpg',
+        trackCount: 1836,
+      },
+      {
+        deezerPlaylistId: 15223880283,
+        name: 'Variété FR / Pop FR',
+        genreLabel: 'Variété FR',
+        coverUrl:
+          'https://cdn-images.dzcdn.net/images/playlist/f9d01feb9271c5efa03f83fb7718c5dc/500x500-000000-80-0-0.jpg',
+        trackCount: 1696,
+      },
+      {
+        deezerPlaylistId: 15223881203,
+        name: 'Rock',
+        genreLabel: 'Rock',
+        coverUrl:
+          'https://cdn-images.dzcdn.net/images/playlist/d559fcba2f94a54d743de840767d0625/500x500-000000-80-0-0.jpg',
+        trackCount: 1999,
+      },
+      {
+        deezerPlaylistId: 15223882443,
+        name: 'R&B / Soul',
+        genreLabel: 'R&B / Soul',
+        coverUrl:
+          'https://cdn-images.dzcdn.net/images/playlist/da74fab5093777b1dcdd1126d88678fb/500x500-000000-80-0-0.jpg',
+        trackCount: 1686,
+      },
+      {
+        deezerPlaylistId: 15223883403,
+        name: 'Électro / EDM',
+        genreLabel: 'Électro',
+        coverUrl:
+          'https://cdn-images.dzcdn.net/images/playlist/6ff6f20406c0934487f03aa93fe03aa0/500x500-000000-80-0-0.jpg',
+        trackCount: 1954,
+      },
+      {
+        deezerPlaylistId: 15223883723,
+        name: 'Latino',
+        genreLabel: 'Latino',
+        coverUrl:
+          'https://cdn-images.dzcdn.net/images/playlist/ff0c1ba48d4b5230fd5444a47a7d66a6/500x500-000000-80-0-0.jpg',
+        trackCount: 1842,
+      },
+    ]
+
+    for (const playlist of playlists) {
+      await CuratedPlaylist.updateOrCreate(
+        { deezerPlaylistId: playlist.deezerPlaylistId },
+        playlist
+      )
+    }
+  }
+}

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -16,6 +16,7 @@ const ProfileController = () => import('#controllers/profile_controller')
 const SpotifyAuthController = () => import('#controllers/spotify_auth_controller')
 const GoogleAuthController = () => import('#controllers/google_auth_controller')
 const MeIntegrationsController = () => import('#controllers/me_integrations_controller')
+const CuratedPlaylistsController = () => import('#controllers/curated_playlists_controller')
 
 // Register OpenAPI/Swagger routes: /docs, /docs.json, /docs.yaml
 openapi.registerRoutes('/docs')
@@ -116,6 +117,12 @@ router
       .group(() => {
         router.get('/', [GamesController, 'index']).use(middleware.silentAuth())
         router.post('/', [GamesController, 'create']).use(middleware.role({ roles: ['admin'] }))
+        router
+          .get('/blindtest/playlists', [CuratedPlaylistsController, 'index'])
+          .use(middleware.auth())
+        router
+          .get('/blindtest/playlists/:id/tracks', [CuratedPlaylistsController, 'tracks'])
+          .use(middleware.auth())
         router.get('/:id', [GamesController, 'show']).use(middleware.silentAuth())
         router.patch('/:id', [GamesController, 'update']).use(middleware.role({ roles: ['admin'] }))
         router

--- a/backend/tests/functional/curated_playlists_controller.spec.ts
+++ b/backend/tests/functional/curated_playlists_controller.spec.ts
@@ -1,0 +1,157 @@
+import { test } from '@japa/runner'
+import CuratedPlaylist from '#models/curated_playlist'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteCuratedPlaylists } from '#tests/utils/curated_playlist_helpers'
+
+const sampleDeezerTracks = [
+  {
+    id: 1,
+    title: 'Song A',
+    title_short: 'Song A',
+    preview: 'https://preview/a.mp3',
+    duration: 30,
+    artist: { id: 11, name: 'Artist A' },
+    album: { id: 111, title: 'Album A' },
+  },
+  {
+    id: 2,
+    title: 'Song B',
+    title_short: 'Song B',
+    preview: 'https://preview/b.mp3',
+    duration: 30,
+    artist: { id: 12, name: 'Artist B' },
+    album: { id: 112, title: 'Album B' },
+  },
+]
+
+test.group('CuratedPlaylistsController - GET /api/games/blindtest/playlists', (group) => {
+  deleteCuratedPlaylists(group)
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('requires authentication', async ({ client }) => {
+    const response = await client.get('/api/games/blindtest/playlists')
+    response.assertStatus(401)
+  })
+
+  test('returns the list of curated playlists for an authenticated user', async ({
+    client,
+    assert,
+  }) => {
+    const { token } = await createAuthenticatedUser('curated_index')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 2000,
+      name: 'Hits FR',
+      genreLabel: 'Pop FR',
+      coverUrl: 'https://cover.example/fr.jpg',
+    })
+
+    const response = await client.get('/api/games/blindtest/playlists').bearerToken(token)
+
+    response.assertStatus(200)
+    const playlists = response.body().playlists
+    assert.isArray(playlists)
+    assert.exists(playlists.find((p: { id: number }) => p.id === playlist.id))
+  })
+})
+
+test.group(
+  'CuratedPlaylistsController - GET /api/games/blindtest/playlists/:id/tracks',
+  (group) => {
+    deleteCuratedPlaylists(group)
+    let originalFetch: typeof fetch
+
+    group.each.setup(() => {
+      originalFetch = globalThis.fetch
+    })
+
+    group.each.teardown(() => {
+      globalThis.fetch = originalFetch
+    })
+
+    test('requires authentication', async ({ client }) => {
+      const response = await client.get('/api/games/blindtest/playlists/1/tracks')
+      response.assertStatus(401)
+    })
+
+    test('returns 404 when playlist is unknown', async ({ client }) => {
+      const { token } = await createAuthenticatedUser('curated_404')
+      const response = await client
+        .get('/api/games/blindtest/playlists/999999/tracks')
+        .bearerToken(token)
+
+      response.assertStatus(404)
+      response.assertBodyContains({ message: 'Curated playlist not found' })
+    })
+
+    test('returns a sample of tracks fetched from Deezer', async ({ client, assert }) => {
+      const { token } = await createAuthenticatedUser('curated_tracks_ok')
+      const playlist = await CuratedPlaylist.create({
+        deezerPlaylistId: 3000,
+        name: 'Rap FR',
+        genreLabel: 'Rap FR',
+        coverUrl: null,
+      })
+
+      let calledUrl: string | null = null
+      globalThis.fetch = async (input) => {
+        calledUrl = typeof input === 'string' ? input : (input as URL).toString()
+        return new Response(
+          JSON.stringify({ data: sampleDeezerTracks, total: sampleDeezerTracks.length }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+      }
+
+      const response = await client
+        .get(`/api/games/blindtest/playlists/${playlist.id}/tracks?count=2`)
+        .bearerToken(token)
+
+      response.assertStatus(200)
+      const tracks = response.body().tracks
+      assert.equal(tracks.length, 2)
+      assert.include(calledUrl!, '/playlist/3000/tracks')
+    })
+
+    test('returns 502 when Deezer fails', async ({ client }) => {
+      const { token } = await createAuthenticatedUser('curated_tracks_502')
+      const playlist = await CuratedPlaylist.create({
+        deezerPlaylistId: 3010,
+        name: 'Will fail',
+        genreLabel: 'Rock',
+        coverUrl: null,
+      })
+
+      globalThis.fetch = async () => new Response('boom', { status: 503 })
+
+      const response = await client
+        .get(`/api/games/blindtest/playlists/${playlist.id}/tracks`)
+        .bearerToken(token)
+
+      response.assertStatus(502)
+      response.assertBodyContains({ message: 'Failed to fetch tracks from Deezer' })
+    })
+
+    test('rejects invalid count query parameter', async ({ client }) => {
+      const { token } = await createAuthenticatedUser('curated_tracks_invalid')
+      const playlist = await CuratedPlaylist.create({
+        deezerPlaylistId: 3020,
+        name: 'Invalid count',
+        genreLabel: 'Rock',
+        coverUrl: null,
+      })
+
+      const response = await client
+        .get(`/api/games/blindtest/playlists/${playlist.id}/tracks?count=999`)
+        .bearerToken(token)
+
+      response.assertStatus(422)
+    })
+  }
+)

--- a/backend/tests/functional/curated_playlists_controller.spec.ts
+++ b/backend/tests/functional/curated_playlists_controller.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '@japa/runner'
 import CuratedPlaylist from '#models/curated_playlist'
+import { CuratedPlaylistService } from '#services/curated_playlist_service'
 import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
 import { deleteCuratedPlaylists } from '#tests/utils/curated_playlist_helpers'
 
@@ -30,10 +31,12 @@ test.group('CuratedPlaylistsController - GET /api/games/blindtest/playlists', (g
 
   group.each.setup(() => {
     originalFetch = globalThis.fetch
+    CuratedPlaylistService.clearCache()
   })
 
   group.each.teardown(() => {
     globalThis.fetch = originalFetch
+    CuratedPlaylistService.clearCache()
   })
 
   test('requires authentication', async ({ client }) => {
@@ -70,10 +73,12 @@ test.group(
 
     group.each.setup(() => {
       originalFetch = globalThis.fetch
+      CuratedPlaylistService.clearCache()
     })
 
     group.each.teardown(() => {
       globalThis.fetch = originalFetch
+      CuratedPlaylistService.clearCache()
     })
 
     test('requires authentication', async ({ client }) => {

--- a/backend/tests/unit/curated_playlist_service.spec.ts
+++ b/backend/tests/unit/curated_playlist_service.spec.ts
@@ -1,0 +1,268 @@
+import { test } from '@japa/runner'
+import CuratedPlaylist from '#models/curated_playlist'
+import { CuratedPlaylistService } from '#services/curated_playlist_service'
+import { deleteCuratedPlaylists } from '#tests/utils/curated_playlist_helpers'
+
+const sampleDeezerTracks = [
+  {
+    id: 1,
+    title: 'Track 1',
+    title_short: 'Track 1',
+    preview: 'https://preview/1.mp3',
+    duration: 30,
+    artist: { id: 11, name: 'Artist 1' },
+    album: { id: 111, title: 'Album 1' },
+  },
+  {
+    id: 2,
+    title: 'Track 2',
+    title_short: 'Track 2',
+    preview: 'https://preview/2.mp3',
+    duration: 30,
+    artist: { id: 12, name: 'Artist 2' },
+    album: { id: 112, title: 'Album 2' },
+  },
+  {
+    id: 3,
+    title: 'Track 3',
+    title_short: 'Track 3',
+    preview: 'https://preview/3.mp3',
+    duration: 30,
+    artist: { id: 13, name: 'Artist 3' },
+    album: { id: 113, title: 'Album 3' },
+  },
+]
+
+test.group('CuratedPlaylistService', (group) => {
+  deleteCuratedPlaylists(group)
+
+  let service: CuratedPlaylistService
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    service = new CuratedPlaylistService()
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('listPlaylists returns playlists ordered by id', async ({ assert }) => {
+    const p1 = await CuratedPlaylist.create({
+      deezerPlaylistId: 1001,
+      name: 'P1',
+      genreLabel: 'Rap FR',
+      coverUrl: null,
+    })
+    const p2 = await CuratedPlaylist.create({
+      deezerPlaylistId: 1002,
+      name: 'P2',
+      genreLabel: 'Pop',
+      coverUrl: 'https://cover/2.jpg',
+    })
+
+    const result = await service.listPlaylists()
+    const ids = result.map((p) => p.id)
+    assert.includeMembers(ids, [p1.id, p2.id])
+    const indexes = [ids.indexOf(p1.id), ids.indexOf(p2.id)]
+    assert.isBelow(indexes[0], indexes[1])
+  })
+
+  test('findById returns the playlist when present', async ({ assert }) => {
+    const p = await CuratedPlaylist.create({
+      deezerPlaylistId: 1010,
+      name: 'Find',
+      genreLabel: 'Rock',
+      coverUrl: null,
+    })
+    const found = await service.findById(p.id)
+    assert.isNotNull(found)
+    assert.equal(found?.id, p.id)
+  })
+
+  test('findById returns null when missing', async ({ assert }) => {
+    const found = await service.findById(999_999)
+    assert.isNull(found)
+  })
+
+  test('getRandomTracks throws PlaylistNotFoundError when playlist is unknown', async ({
+    assert,
+  }) => {
+    await assert.rejects(async () => {
+      await service.getRandomTracks(999_999)
+    }, /not found/)
+  })
+
+  test('getRandomTracks returns up to count tracks from Deezer', async ({ assert }) => {
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 1020,
+      name: 'Sample',
+      genreLabel: 'Hits',
+      coverUrl: null,
+    })
+
+    let calledUrl: string | null = null
+    globalThis.fetch = async (input) => {
+      calledUrl = typeof input === 'string' ? input : (input as URL).toString()
+      return new Response(
+        JSON.stringify({ data: sampleDeezerTracks, total: sampleDeezerTracks.length }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const tracks = await service.getRandomTracks(playlist.id, 2)
+    assert.equal(tracks.length, 2)
+    assert.include(calledUrl!, '/playlist/1020/tracks')
+    for (const track of tracks) {
+      assert.exists(sampleDeezerTracks.find((t) => t.id === track.id))
+    }
+  })
+
+  test('getRandomTracks paginates through every page when the playlist exceeds the page size', async ({
+    assert,
+  }) => {
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 1025,
+      name: 'Huge',
+      genreLabel: 'Hits',
+      coverUrl: null,
+    })
+
+    const buildTrack = (id: number) => ({
+      id,
+      title: `Track ${id}`,
+      title_short: `Track ${id}`,
+      preview: `https://preview/${id}.mp3`,
+      duration: 30,
+      artist: { id: id * 10, name: `Artist ${id}` },
+      album: { id: id * 100, title: `Album ${id}` },
+    })
+
+    const calledUrls: string[] = []
+    globalThis.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      calledUrls.push(url)
+      // Probe call (limit=1, no index)
+      if (url.includes('limit=1') && !url.includes('limit=500')) {
+        return new Response(JSON.stringify({ data: [], total: 1200 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+      // Page calls return distinct tracks per page so we can verify dedupe-friendly merging
+      const indexMatch = url.match(/index=(\d+)/)
+      const offset = indexMatch ? Number(indexMatch[1]) : 0
+      const data = Array.from({ length: 5 }, (_, i) => buildTrack(offset + i + 1))
+      return new Response(JSON.stringify({ data, total: 1200 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+
+    const tracks = await service.getRandomTracks(playlist.id, 100)
+    const pageCalls = calledUrls.filter((u) => u.includes('limit=500'))
+    assert.equal(pageCalls.length, Math.ceil(1200 / 500))
+    const offsets = pageCalls.map((u) => Number(u.match(/index=(\d+)/)![1])).sort((a, b) => a - b)
+    assert.deepEqual(offsets, [0, 500, 1000])
+    assert.equal(tracks.length, 15)
+  })
+
+  test('getRandomTracks returns all tracks when count exceeds total', async ({ assert }) => {
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 1030,
+      name: 'Full',
+      genreLabel: 'Hits',
+      coverUrl: null,
+    })
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: sampleDeezerTracks, total: sampleDeezerTracks.length }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const tracks = await service.getRandomTracks(playlist.id, 50)
+    assert.equal(tracks.length, sampleDeezerTracks.length)
+  })
+
+  test('getRandomTracks dedupes tracks by id before sampling', async ({ assert }) => {
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 1035,
+      name: 'Dup',
+      genreLabel: 'Hits',
+      coverUrl: null,
+    })
+
+    const duplicated = [
+      sampleDeezerTracks[0],
+      sampleDeezerTracks[0],
+      sampleDeezerTracks[1],
+      sampleDeezerTracks[1],
+      sampleDeezerTracks[2],
+    ]
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({ data: duplicated, total: duplicated.length }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const tracks = await service.getRandomTracks(playlist.id, 50)
+    const ids = tracks.map((t) => t.id)
+    assert.equal(tracks.length, 3)
+    assert.deepEqual([...new Set(ids)].sort(), ids.slice().sort())
+  })
+
+  test('getRandomTracks returns empty array when Deezer returns no data', async ({ assert }) => {
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 1040,
+      name: 'Empty',
+      genreLabel: 'Hits',
+      coverUrl: null,
+    })
+
+    globalThis.fetch = async () =>
+      new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+
+    const tracks = await service.getRandomTracks(playlist.id, 10)
+    assert.deepEqual(tracks, [])
+  })
+
+  test('getRandomTracks throws DeezerPlaylistFetchError on non-2xx response', async ({
+    assert,
+  }) => {
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 1050,
+      name: 'Failing',
+      genreLabel: 'Hits',
+      coverUrl: null,
+    })
+
+    globalThis.fetch = async () => new Response('boom', { status: 500 })
+
+    await assert.rejects(async () => {
+      await service.getRandomTracks(playlist.id)
+    }, /Failed to fetch Deezer playlist/)
+  })
+
+  test('getRandomTracks throws DeezerPlaylistFetchError on network failure', async ({ assert }) => {
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 1060,
+      name: 'Network failing',
+      genreLabel: 'Hits',
+      coverUrl: null,
+    })
+
+    globalThis.fetch = async () => {
+      throw new TypeError('network down')
+    }
+
+    await assert.rejects(async () => {
+      await service.getRandomTracks(playlist.id)
+    }, /Failed to fetch Deezer playlist/)
+  })
+})

--- a/backend/tests/unit/curated_playlist_service.spec.ts
+++ b/backend/tests/unit/curated_playlist_service.spec.ts
@@ -42,10 +42,12 @@ test.group('CuratedPlaylistService', (group) => {
   group.each.setup(() => {
     service = new CuratedPlaylistService()
     originalFetch = globalThis.fetch
+    CuratedPlaylistService.clearCache()
   })
 
   group.each.teardown(() => {
     globalThis.fetch = originalFetch
+    CuratedPlaylistService.clearCache()
   })
 
   test('listPlaylists returns playlists ordered by id', async ({ assert }) => {

--- a/backend/tests/unit/curated_playlist_service.spec.ts
+++ b/backend/tests/unit/curated_playlist_service.spec.ts
@@ -267,4 +267,34 @@ test.group('CuratedPlaylistService', (group) => {
       await service.getRandomTracks(playlist.id)
     }, /Failed to fetch Deezer playlist/)
   })
+
+  test('getRandomTracks hits the cache on the second call for the same playlist', async ({
+    assert,
+  }) => {
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 1070,
+      name: 'Cached',
+      genreLabel: 'Hits',
+      coverUrl: null,
+    })
+
+    let fetchCallCount = 0
+    globalThis.fetch = async () => {
+      fetchCallCount += 1
+      return new Response(
+        JSON.stringify({ data: sampleDeezerTracks, total: sampleDeezerTracks.length }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } }
+      )
+    }
+
+    await service.getRandomTracks(playlist.id, 2)
+    const firstCallCount = fetchCallCount
+
+    await service.getRandomTracks(playlist.id, 2)
+    assert.equal(fetchCallCount, firstCallCount)
+
+    CuratedPlaylistService.clearCache()
+    await service.getRandomTracks(playlist.id, 2)
+    assert.isAbove(fetchCallCount, firstCallCount)
+  })
 })

--- a/backend/tests/unit/curated_playlists_controller.spec.ts
+++ b/backend/tests/unit/curated_playlists_controller.spec.ts
@@ -1,0 +1,113 @@
+import { test } from '@japa/runner'
+import CuratedPlaylistsController from '#controllers/curated_playlists_controller'
+import { CuratedPlaylistService } from '#services/curated_playlist_service'
+import { HttpContext } from '@adonisjs/core/http'
+
+const makeMockResponse = () => {
+  return {
+    statusCode: 0,
+    body: null as unknown,
+    okBody: null as unknown,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(payload: unknown) {
+      this.body = payload
+      return this
+    },
+    ok(payload: unknown) {
+      this.statusCode = 200
+      this.okBody = payload
+      this.body = payload
+      return this
+    },
+    notFound(payload: unknown) {
+      this.statusCode = 404
+      this.body = payload
+      return this
+    },
+    badRequest(payload: unknown) {
+      this.statusCode = 400
+      this.body = payload
+      return this
+    },
+    internalServerError(payload: unknown) {
+      this.statusCode = 500
+      this.body = payload
+      return this
+    },
+  }
+}
+
+test.group('CuratedPlaylistsController - Unit Tests for Edge Cases', () => {
+  test('index returns 500 when the service throws', async ({ assert }) => {
+    const service = new CuratedPlaylistService()
+    const controller = new CuratedPlaylistsController(service)
+
+    const original = service.listPlaylists
+    service.listPlaylists = async () => {
+      throw new Error('listing failed')
+    }
+
+    const mockResponse = makeMockResponse()
+    const ctx = { response: mockResponse } as unknown as HttpContext
+
+    try {
+      await controller.index(ctx)
+      assert.equal(mockResponse.statusCode, 500)
+      assert.deepEqual(mockResponse.body, {
+        message: 'Failed to fetch curated playlists',
+      })
+    } finally {
+      service.listPlaylists = original
+    }
+  })
+
+  test('tracks returns 400 when the playlist id is not numeric', async ({ assert }) => {
+    const service = new CuratedPlaylistService()
+    const controller = new CuratedPlaylistsController(service)
+
+    const mockResponse = makeMockResponse()
+    const ctx = {
+      params: { id: 'not-a-number' },
+      request: {
+        qs: () => ({}),
+        validateUsing: async () => ({ count: undefined }),
+      },
+      response: mockResponse,
+    } as unknown as HttpContext
+
+    await controller.tracks(ctx)
+    assert.equal(mockResponse.statusCode, 400)
+    assert.deepEqual(mockResponse.body, { message: 'Invalid playlist id' })
+  })
+
+  test('tracks rethrows unexpected errors', async ({ assert }) => {
+    const service = new CuratedPlaylistService()
+    const controller = new CuratedPlaylistsController(service)
+
+    const original = service.getRandomTracks
+    service.getRandomTracks = async () => {
+      throw new Error('totally unexpected')
+    }
+
+    const mockResponse = makeMockResponse()
+    const ctx = {
+      params: { id: '42' },
+      request: {
+        qs: () => ({}),
+        validateUsing: async () => ({ count: undefined }),
+      },
+      response: mockResponse,
+    } as unknown as HttpContext
+
+    try {
+      await assert.rejects(async () => {
+        await controller.tracks(ctx)
+      }, /totally unexpected/)
+    } finally {
+      service.getRandomTracks = original
+    }
+  })
+})

--- a/backend/tests/utils/curated_playlist_helpers.ts
+++ b/backend/tests/utils/curated_playlist_helpers.ts
@@ -1,0 +1,15 @@
+import CuratedPlaylist from '#models/curated_playlist'
+import { Group } from '@japa/runner/core'
+import { DateTime } from 'luxon'
+
+export function deleteCuratedPlaylists(group: Group) {
+  let testStartTime: DateTime
+
+  group.setup(() => {
+    testStartTime = DateTime.now()
+  })
+
+  group.teardown(async () => {
+    await CuratedPlaylist.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+  })
+}

--- a/front-mobile/app/(tabs)/games/blindtest/game.tsx
+++ b/front-mobile/app/(tabs)/games/blindtest/game.tsx
@@ -6,7 +6,7 @@ import Button from "@/components/Button";
 import Header from "@/components/Header";
 import { Colors } from "@/constants/Colors";
 import { useBlindtestGame } from "@/hooks/feature/blindtest/useBlindtestGame";
-import BlindtestGenreSelection from "@/components/feature/blindtest/BlindtestGenreSelection";
+import BlindtestPlaylistSelection from "@/components/feature/blindtest/BlindtestPlaylistSelection";
 import BlindtestReadyScreen from "@/components/feature/blindtest/BlindtestReadyScreen";
 import BlindtestPlayingScreen from "@/components/feature/blindtest/BlindtestPlayingScreen";
 import BlindtestRoundReveal from "@/components/feature/blindtest/BlindtestRoundReveal";
@@ -15,8 +15,8 @@ import BlindtestResultScreen from "@/components/feature/blindtest/BlindtestResul
 export default function BlindtestGameScreen() {
   const {
     gameState,
-    genres,
-    loadingGenres,
+    playlists,
+    loadingPlaylists,
     loadingTracks,
     currentTrack,
     currentFeaturingNames,
@@ -71,14 +71,14 @@ export default function BlindtestGameScreen() {
     );
   }
 
-  if (gameState === "genreSelection") {
+  if (gameState === "playlistSelection") {
     return (
-      <BlindtestGenreSelection
+      <BlindtestPlaylistSelection
         sessionId={sessionId}
-        genres={genres}
-        loadingGenres={loadingGenres}
+        playlists={playlists}
+        loadingPlaylists={loadingPlaylists}
         loadingTracks={loadingTracks}
-        onSelectGenre={startGame}
+        onSelectPlaylist={startGame}
         onSave={autoSave}
       />
     );

--- a/front-mobile/components/feature/blindtest/BlindtestPlaylistSelection.tsx
+++ b/front-mobile/components/feature/blindtest/BlindtestPlaylistSelection.tsx
@@ -1,36 +1,36 @@
 import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import GameLayout from "@/components/GameLayout";
-import GenreSelector from "@/components/GenreSelector";
+import PlaylistSelector from "@/components/feature/blindtest/PlaylistSelector";
 import { Colors } from "@/constants/Colors";
-import { DeezerGenre } from "@/services/deezer-api";
+import { CuratedPlaylist } from "@/services/curatedPlaylistService";
 
-interface BlindtestGenreSelectionProps {
+interface BlindtestPlaylistSelectionProps {
   sessionId: string | null;
-  genres: DeezerGenre[];
-  loadingGenres: boolean;
+  playlists: CuratedPlaylist[];
+  loadingPlaylists: boolean;
   loadingTracks: boolean;
-  onSelectGenre: (genre: DeezerGenre) => void;
+  onSelectPlaylist: (playlist: CuratedPlaylist) => void;
   onSave: () => Promise<void>;
 }
 
-export default function BlindtestGenreSelection({
+export default function BlindtestPlaylistSelection({
   sessionId,
-  genres,
-  loadingGenres,
+  playlists,
+  loadingPlaylists,
   loadingTracks,
-  onSelectGenre,
+  onSelectPlaylist,
   onSave,
-}: BlindtestGenreSelectionProps) {
+}: BlindtestPlaylistSelectionProps) {
   return (
     <GameLayout title="Blind Test" sessionId={sessionId} onSave={onSave}>
       <View style={styles.container}>
         <View style={styles.setupContainer}>
-          <GenreSelector
-            genres={genres}
-            loading={loadingGenres}
+          <PlaylistSelector
+            playlists={playlists}
+            loading={loadingPlaylists}
             disabled={loadingTracks}
-            onSelect={onSelectGenre}
+            onSelect={onSelectPlaylist}
           />
 
           {loadingTracks && (

--- a/front-mobile/components/feature/blindtest/BlindtestResultScreen.tsx
+++ b/front-mobile/components/feature/blindtest/BlindtestResultScreen.tsx
@@ -55,8 +55,8 @@ export default function BlindtestResultScreen({
             Récapitulatif
           </ThemedText>
 
-          {completedRounds.map((round) => (
-            <View key={round.trackId} style={styles.roundRow}>
+          {completedRounds.map((round, index) => (
+            <View key={`${round.trackId}-${index}`} style={styles.roundRow}>
               <Image
                 source={{ uri: round.coverUrl }}
                 style={styles.roundCover}

--- a/front-mobile/components/feature/blindtest/PlaylistSelector.tsx
+++ b/front-mobile/components/feature/blindtest/PlaylistSelector.tsx
@@ -1,0 +1,117 @@
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import { CuratedPlaylist } from "@/services/curatedPlaylistService";
+
+interface PlaylistSelectorProps {
+  playlists: CuratedPlaylist[];
+  loading: boolean;
+  disabled?: boolean;
+  onSelect: (playlist: CuratedPlaylist) => void;
+}
+
+export default function PlaylistSelector({
+  playlists,
+  loading,
+  disabled = false,
+  onSelect,
+}: PlaylistSelectorProps) {
+  return (
+    <View style={styles.container}>
+      <ThemedText type="title" style={styles.title}>
+        Choisis la playlist
+      </ThemedText>
+
+      {loading ? (
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.primary.survol} />
+        </View>
+      ) : (
+        <FlatList
+          data={playlists}
+          keyExtractor={(item) => item.id.toString()}
+          contentContainerStyle={styles.list}
+          renderItem={({ item }) => (
+            <TouchableOpacity
+              style={styles.row}
+              onPress={() => onSelect(item)}
+              disabled={disabled}
+              activeOpacity={0.7}
+              testID={`playlist-row-${item.id}`}
+            >
+              {item.coverUrl ? (
+                <Image source={{ uri: item.coverUrl }} style={styles.cover} />
+              ) : (
+                <View style={[styles.cover, styles.coverPlaceholder]} />
+              )}
+              <View style={styles.info}>
+                <ThemedText type="title" style={styles.name} numberOfLines={1}>
+                  {item.name}
+                </ThemedText>
+                <ThemedText style={styles.trackCount}>
+                  {item.trackCount} morceaux
+                </ThemedText>
+              </View>
+            </TouchableOpacity>
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  title: {
+    textAlign: "center",
+    marginBottom: 20,
+    marginTop: 20,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  list: {
+    paddingBottom: 20,
+    gap: 12,
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 12,
+    padding: 12,
+    gap: 14,
+  },
+  cover: {
+    width: 64,
+    height: 64,
+    borderRadius: 8,
+  },
+  coverPlaceholder: {
+    backgroundColor: "rgba(255, 255, 255, 0.1)",
+  },
+  info: {
+    flex: 1,
+  },
+  name: {
+    color: "white",
+    fontSize: 22,
+    lineHeight: 26,
+  },
+  trackCount: {
+    color: "#999",
+    fontSize: 14,
+    marginTop: 4,
+  },
+});

--- a/front-mobile/hooks/feature/blindtest/__tests__/useBlindtestGame.test.ts
+++ b/front-mobile/hooks/feature/blindtest/__tests__/useBlindtestGame.test.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor, act } from "@testing-library/react-native";
 import { useBlindtestGame, getFeaturing } from "../useBlindtestGame";
-import { deezerAPI, DeezerGenre, DeezerTrack } from "@/services/deezer-api";
+import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
 import { useLocalSearchParams } from "expo-router";
 import {
   createGameSession,
@@ -11,22 +11,27 @@ import {
   getGameState,
   deleteGameState,
 } from "@/services/gameStorageService";
+import {
+  CuratedPlaylist,
+  CuratedPlaylistTrack,
+  getCuratedPlaylists,
+  getCuratedPlaylistTracks,
+} from "@/services/curatedPlaylistService";
 import { useAuthStore } from "@/stores/authStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useToast } from "@/components/Toast";
 import { useErrorFeedback } from "@/hooks/useErrorFeedback";
-import { useGenres } from "@/hooks/useGenres";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
 
 jest.mock("@/services/deezer-api");
 jest.mock("@/services/cache-manager");
 jest.mock("@/services/gameSessionService");
 jest.mock("@/services/gameStorageService");
+jest.mock("@/services/curatedPlaylistService");
 jest.mock("@/stores/authStore");
 jest.mock("@/stores/settingsStore");
 jest.mock("@/components/Toast");
 jest.mock("@/hooks/useErrorFeedback");
-jest.mock("@/hooks/useGenres");
 jest.mock("@/hooks/useAudioPlayer");
 jest.mock("expo-router", () => ({
   useLocalSearchParams: jest.fn(),
@@ -52,13 +57,19 @@ const mockGetGameState = getGameState as jest.MockedFunction<
 const mockDeleteGameState = deleteGameState as jest.MockedFunction<
   typeof deleteGameState
 >;
+const mockGetCuratedPlaylists = getCuratedPlaylists as jest.MockedFunction<
+  typeof getCuratedPlaylists
+>;
+const mockGetCuratedPlaylistTracks =
+  getCuratedPlaylistTracks as jest.MockedFunction<
+    typeof getCuratedPlaylistTracks
+  >;
 const mockUseAuthStore = useAuthStore as unknown as jest.Mock;
 const mockUseSettingsStore = useSettingsStore as unknown as jest.Mock;
 const mockUseToast = useToast as jest.MockedFunction<typeof useToast>;
 const mockUseErrorFeedback = useErrorFeedback as jest.MockedFunction<
   typeof useErrorFeedback
 >;
-const mockUseGenres = useGenres as jest.MockedFunction<typeof useGenres>;
 const mockUseAudioPlayer = useAudioPlayer as jest.MockedFunction<
   typeof useAudioPlayer
 >;
@@ -93,15 +104,16 @@ const buildTrack = (
     type: "track",
   }) as unknown as DeezerTrack;
 
-const sampleGenre: DeezerGenre = {
-  id: 132,
-  name: "Pop",
-  picture: "",
-  picture_small: "",
-  picture_medium: "",
-  picture_big: "",
-  picture_xl: "",
-} as unknown as DeezerGenre;
+const samplePlaylist: CuratedPlaylist = {
+  id: 1,
+  deezerPlaylistId: 1996494362,
+  name: "Top France",
+  genreLabel: "Hits FR",
+  coverUrl: "https://cover.example/fr.jpg",
+  trackCount: 1500,
+  createdAt: "2026-04-29T10:00:00.000Z",
+  updatedAt: "2026-04-29T10:00:00.000Z",
+};
 
 const sampleTracks = [
   buildTrack(1, "Bohemian Rhapsody", "Queen"),
@@ -110,6 +122,16 @@ const sampleTracks = [
   buildTrack(4, "Smells Like Teen Spirit", "Nirvana"),
   buildTrack(5, "Hotel California", "Eagles"),
 ];
+
+const samplePlaylistTracks: CuratedPlaylistTrack[] = sampleTracks.map((t) => ({
+  id: t.id,
+  title: t.title,
+  title_short: t.title_short,
+  preview: t.preview,
+  duration: t.duration,
+  artist: { id: t.artist.id, name: t.artist.name },
+  album: { id: t.album.id, title: t.album.title },
+}));
 
 describe("getFeaturing", () => {
   it("returns featuring names from contributors", () => {
@@ -156,11 +178,6 @@ describe("useBlindtestGame", () => {
       errorMessage: null,
       triggerError: mockTriggerError,
     });
-    mockUseGenres.mockReturnValue({
-      genres: [sampleGenre],
-      loadingGenres: false,
-      reloadGenres: jest.fn(),
-    });
     mockUseAudioPlayer.mockReturnValue({
       play: mockAudioPlay,
       stop: mockAudioStop,
@@ -177,10 +194,8 @@ describe("useBlindtestGame", () => {
       error: null,
     });
 
-    mockDeezerAPI.getGenreTracks.mockResolvedValue({
-      data: sampleTracks,
-    } as never);
-    // getTrack returns the same track (enriched with contributors in real API)
+    mockGetCuratedPlaylists.mockResolvedValue([samplePlaylist]);
+    mockGetCuratedPlaylistTracks.mockResolvedValue(samplePlaylistTracks);
     mockDeezerAPI.getTrack.mockImplementation(
       async (id: number) =>
         sampleTracks.find((t) => t.id === id) as DeezerTrack,
@@ -196,21 +211,32 @@ describe("useBlindtestGame", () => {
     jest.useRealTimers();
   });
 
-  it("starts in genreSelection state", () => {
+  it("starts in playlistSelection state and loads curated playlists", async () => {
     const { result } = renderHook(() => useBlindtestGame());
-    expect(result.current.gameState).toBe("genreSelection");
+    expect(result.current.gameState).toBe("playlistSelection");
     expect(result.current.currentTrack).toBeNull();
     expect(result.current.totalRounds).toBe(0);
+
+    await waitFor(() => {
+      expect(mockGetCuratedPlaylists).toHaveBeenCalled();
+      expect(result.current.playlists).toEqual([samplePlaylist]);
+      expect(result.current.loadingPlaylists).toBe(false);
+    });
   });
 
   it("startGame transitions to ready state after fetching tracks", async () => {
     const { result } = renderHook(() => useBlindtestGame());
 
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
     await act(async () => {
-      await result.current.startGame(sampleGenre);
+      await result.current.startGame(samplePlaylist);
     });
 
-    expect(mockDeezerAPI.getGenreTracks).toHaveBeenCalledWith(132, 50);
+    expect(mockGetCuratedPlaylistTracks).toHaveBeenCalledWith(
+      samplePlaylist.id,
+      50,
+    );
     expect(mockDeezerAPI.getTrack).toHaveBeenCalledTimes(5);
     expect(mockCreateGameSession).toHaveBeenCalledWith(
       expect.objectContaining({ gameId: 556, status: "active" }),
@@ -218,13 +244,16 @@ describe("useBlindtestGame", () => {
     expect(result.current.sessionId).toBe("session-bt");
     expect(result.current.gameState).toBe("ready");
     expect(result.current.totalRounds).toBe(5);
+    expect(result.current.selectedPlaylist).toEqual(samplePlaylist);
   });
 
   it("beginPlaying transitions from ready to playing", async () => {
     const { result } = renderHook(() => useBlindtestGame());
 
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
     await act(async () => {
-      await result.current.startGame(sampleGenre);
+      await result.current.startGame(samplePlaylist);
     });
 
     expect(result.current.gameState).toBe("ready");
@@ -239,21 +268,38 @@ describe("useBlindtestGame", () => {
   });
 
   it("shows error when no tracks have valid previews", async () => {
-    const noPreviewTracks = sampleTracks.map((t) => ({
+    const noPreviewTracks = samplePlaylistTracks.map((t) => ({
       ...t,
       preview: "",
     }));
-    mockDeezerAPI.getGenreTracks.mockResolvedValue({
-      data: noPreviewTracks,
-    } as never);
+    mockGetCuratedPlaylistTracks.mockResolvedValue(noPreviewTracks);
 
     const { result } = renderHook(() => useBlindtestGame());
 
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
     await act(async () => {
-      await result.current.startGame(sampleGenre);
+      await result.current.startGame(samplePlaylist);
     });
 
-    expect(result.current.gameState).toBe("genreSelection");
+    expect(result.current.gameState).toBe("playlistSelection");
+    expect(mockShow).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error" }),
+    );
+  });
+
+  it("shows error when curated playlist tracks endpoint returns nothing", async () => {
+    mockGetCuratedPlaylistTracks.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useBlindtestGame());
+
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
+    await act(async () => {
+      await result.current.startGame(samplePlaylist);
+    });
+
+    expect(result.current.gameState).toBe("playlistSelection");
     expect(mockShow).toHaveBeenCalledWith(
       expect.objectContaining({ type: "error" }),
     );
@@ -262,8 +308,10 @@ describe("useBlindtestGame", () => {
   it("submitAnswer with correct artist sets artistFound", async () => {
     const { result } = renderHook(() => useBlindtestGame());
 
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
     await act(async () => {
-      await result.current.startGame(sampleGenre);
+      await result.current.startGame(samplePlaylist);
     });
     act(() => {
       result.current.beginPlaying();
@@ -285,8 +333,10 @@ describe("useBlindtestGame", () => {
   it("submitAnswer with wrong answer clears input and triggers error", async () => {
     const { result } = renderHook(() => useBlindtestGame());
 
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
     await act(async () => {
-      await result.current.startGame(sampleGenre);
+      await result.current.startGame(samplePlaylist);
     });
     act(() => {
       result.current.beginPlaying();
@@ -308,8 +358,10 @@ describe("useBlindtestGame", () => {
   it("resetGame clears state and deletes saved storage", async () => {
     const { result } = renderHook(() => useBlindtestGame());
 
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
     await act(async () => {
-      await result.current.startGame(sampleGenre);
+      await result.current.startGame(samplePlaylist);
     });
 
     mockDeleteGameState.mockClear();
@@ -318,9 +370,10 @@ describe("useBlindtestGame", () => {
       result.current.resetGame();
     });
 
-    expect(result.current.gameState).toBe("genreSelection");
+    expect(result.current.gameState).toBe("playlistSelection");
     expect(result.current.currentTrack).toBeNull();
     expect(result.current.sessionId).toBeNull();
+    expect(result.current.selectedPlaylist).toBeNull();
     expect(result.current.completedRounds).toEqual([]);
     expect(mockDeleteGameState).toHaveBeenCalledWith("556");
     expect(mockAudioStop).toHaveBeenCalled();
@@ -333,7 +386,7 @@ describe("useBlindtestGame", () => {
     });
     mockGetGameState.mockResolvedValue({
       gameState: "playing",
-      selectedGenre: sampleGenre,
+      selectedPlaylist: samplePlaylist,
       tracks: sampleTracks,
       currentRoundIndex: 2,
       timeRemaining: 20,
@@ -371,5 +424,18 @@ describe("useBlindtestGame", () => {
 
     expect(result.current.getRoundMaxScore(regularTrack)).toBe(2);
     expect(result.current.getRoundMaxScore(featTrack)).toBe(3);
+  });
+
+  it("shows toast when curated playlists fail to load", async () => {
+    mockGetCuratedPlaylists.mockRejectedValueOnce(new Error("network"));
+
+    const { result } = renderHook(() => useBlindtestGame());
+
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
+    expect(mockShow).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "error" }),
+    );
+    expect(result.current.playlists).toEqual([]);
   });
 });

--- a/front-mobile/hooks/feature/blindtest/useBlindtestGame.ts
+++ b/front-mobile/hooks/feature/blindtest/useBlindtestGame.ts
@@ -105,7 +105,6 @@ export function useBlindtestGame() {
 
   const isSubmittingRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const isMountedRef = useRef(true);
 
   const { gameId, resume } = useLocalSearchParams<{
     gameId: string;
@@ -116,13 +115,6 @@ export function useBlindtestGame() {
   const { show } = useToast();
   const { shakeAnimation, borderOpacity, errorMessage, triggerError } =
     useErrorFeedback(errorAnimationsEnabled);
-
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -351,19 +343,23 @@ export function useBlindtestGame() {
           Math.min(TOTAL_ROUNDS, tracksWithPreview.length),
         );
 
-        // Fetch each track individually to get contributors
+        // Fetch each track individually to get contributors. On failure we drop the
+        // track rather than fall back to the curated payload, which lacks fields
+        // required by DeezerTrack (e.g. contributors, *_xl variants).
         const enriched = await Promise.all(
           picked.map(async (t) => {
             try {
               return await deezerAPI.getTrack(t.id);
-            } catch {
-              return t as unknown as DeezerTrack;
+            } catch (error) {
+              console.warn(`Failed to enrich track ${t.id}:`, error);
+              return null;
             }
           }),
         );
 
         const valid = enriched.filter(
-          (t) => t.preview && t.preview.startsWith("http"),
+          (t): t is DeezerTrack =>
+            t !== null && !!t.preview && t.preview.startsWith("http"),
         );
 
         if (valid.length < MIN_TRACKS_REQUIRED) {

--- a/front-mobile/hooks/feature/blindtest/useBlindtestGame.ts
+++ b/front-mobile/hooks/feature/blindtest/useBlindtestGame.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Alert } from "react-native";
 import { useLocalSearchParams } from "expo-router";
-import { deezerAPI, DeezerGenre, DeezerTrack } from "@/services/deezer-api";
+import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
 import { cacheManager } from "@/services/cache-manager";
 import { useAuthStore } from "@/stores/authStore";
 import { useToast } from "@/components/Toast";
@@ -17,12 +17,16 @@ import {
 } from "@/services/gameStorageService";
 import { BlindtestGameData, BlindtestRound } from "@/types/gameSession";
 import { useErrorFeedback } from "@/hooks/useErrorFeedback";
-import { useGenres } from "@/hooks/useGenres";
+import {
+  CuratedPlaylist,
+  getCuratedPlaylists,
+  getCuratedPlaylistTracks,
+} from "@/services/curatedPlaylistService";
 import { useAudioPlayer } from "@/hooks/useAudioPlayer";
 import { fuzzyMatch, nearMatch } from "@/utils/stringUtils";
 
 export type BlindtestGameState =
-  | "genreSelection"
+  | "playlistSelection"
   | "ready"
   | "playing"
   | "roundReveal"
@@ -45,7 +49,7 @@ export function getFeaturing(track: DeezerTrack): string[] {
 
 interface BlindtestSaveState {
   gameState: BlindtestGameState;
-  selectedGenre: DeezerGenre | null;
+  selectedPlaylist: CuratedPlaylist | null;
   tracks: DeezerTrack[];
   currentRoundIndex: number;
   timeRemaining: number;
@@ -59,11 +63,13 @@ interface BlindtestSaveState {
 
 export function useBlindtestGame() {
   const [gameState, setGameState] =
-    useState<BlindtestGameState>("genreSelection");
-  const { genres, loadingGenres } = useGenres();
+    useState<BlindtestGameState>("playlistSelection");
+  const [playlists, setPlaylists] = useState<CuratedPlaylist[]>([]);
+  const [loadingPlaylists, setLoadingPlaylists] = useState(true);
   const [loadingTracks, setLoadingTracks] = useState(false);
 
-  const [selectedGenre, setSelectedGenre] = useState<DeezerGenre | null>(null);
+  const [selectedPlaylist, setSelectedPlaylist] =
+    useState<CuratedPlaylist | null>(null);
   const [tracks, setTracks] = useState<DeezerTrack[]>([]);
   const [currentRoundIndex, setCurrentRoundIndex] = useState(0);
 
@@ -99,6 +105,7 @@ export function useBlindtestGame() {
 
   const isSubmittingRef = useRef(false);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const isMountedRef = useRef(true);
 
   const { gameId, resume } = useLocalSearchParams<{
     gameId: string;
@@ -109,6 +116,39 @@ export function useBlindtestGame() {
   const { show } = useToast();
   const { shakeAnimation, borderOpacity, errorMessage, triggerError } =
     useErrorFeedback(errorAnimationsEnabled);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoadingPlaylists(true);
+      try {
+        const data = await getCuratedPlaylists();
+        if (!cancelled) setPlaylists(data);
+      } catch (error) {
+        console.error("Failed to load curated playlists:", error);
+        if (!cancelled) {
+          show({
+            type: "error",
+            message: "Impossible de charger les playlists",
+          });
+        }
+      } finally {
+        if (!cancelled) setLoadingPlaylists(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [show]);
+
   const handleAudioRetry = useCallback(
     async (track: DeezerTrack): Promise<DeezerTrack | null> => {
       try {
@@ -181,7 +221,7 @@ export function useBlindtestGame() {
       const saved = await getGameState<BlindtestSaveState>(gameId);
       if (saved) {
         setGameState(saved.gameState);
-        setSelectedGenre(saved.selectedGenre);
+        setSelectedPlaylist(saved.selectedPlaylist);
         setTracks(saved.tracks);
         setCurrentRoundIndex(saved.currentRoundIndex);
         setTimeRemaining(saved.timeRemaining);
@@ -225,7 +265,7 @@ export function useBlindtestGame() {
 
     const saveState: BlindtestSaveState = {
       gameState,
-      selectedGenre,
+      selectedPlaylist,
       tracks,
       currentRoundIndex,
       timeRemaining,
@@ -241,7 +281,7 @@ export function useBlindtestGame() {
   }, [
     gameId,
     gameState,
-    selectedGenre,
+    selectedPlaylist,
     tracks,
     currentRoundIndex,
     timeRemaining,
@@ -277,39 +317,38 @@ export function useBlindtestGame() {
 
   // --- Game actions ---
   const startGame = useCallback(
-    async (genre: DeezerGenre) => {
+    async (playlist: CuratedPlaylist) => {
       setLoadingTracks(true);
-      setSelectedGenre(genre);
+      setSelectedPlaylist(playlist);
 
       try {
-        const response = await deezerAPI.getGenreTracks(genre.id, 50);
+        const sampledTracks = await getCuratedPlaylistTracks(playlist.id, 50);
 
-        if (!response.data || response.data.length === 0) {
+        if (!sampledTracks || sampledTracks.length === 0) {
           show({
             type: "error",
-            message: "Aucune musique trouvée pour ce genre",
+            message: "Aucune musique trouvée pour cette playlist",
           });
           setLoadingTracks(false);
           return;
         }
 
-        const tracksWithPreview = response.data.filter(
+        const tracksWithPreview = sampledTracks.filter(
           (t) => t.preview && t.preview.startsWith("http"),
         );
 
         if (tracksWithPreview.length < MIN_TRACKS_REQUIRED) {
           show({
             type: "error",
-            message: "Pas assez de morceaux disponibles pour ce genre",
+            message: "Pas assez de morceaux disponibles pour cette playlist",
           });
           setLoadingTracks(false);
           return;
         }
 
-        const shuffled = [...tracksWithPreview].sort(() => Math.random() - 0.5);
-        const picked = shuffled.slice(
+        const picked = tracksWithPreview.slice(
           0,
-          Math.min(TOTAL_ROUNDS, shuffled.length),
+          Math.min(TOTAL_ROUNDS, tracksWithPreview.length),
         );
 
         // Fetch each track individually to get contributors
@@ -318,7 +357,7 @@ export function useBlindtestGame() {
             try {
               return await deezerAPI.getTrack(t.id);
             } catch {
-              return t;
+              return t as unknown as DeezerTrack;
             }
           }),
         );
@@ -330,7 +369,7 @@ export function useBlindtestGame() {
         if (valid.length < MIN_TRACKS_REQUIRED) {
           show({
             type: "error",
-            message: "Pas assez de morceaux disponibles pour ce genre",
+            message: "Pas assez de morceaux disponibles pour cette playlist",
           });
           setLoadingTracks(false);
           return;
@@ -348,7 +387,11 @@ export function useBlindtestGame() {
         );
 
         const gameData: BlindtestGameData = {
-          genre: { id: genre.id, name: genre.name },
+          playlist: {
+            id: playlist.id,
+            name: playlist.name,
+            genreLabel: playlist.genreLabel,
+          },
           totalRounds: valid.length,
           rounds: [],
           totalScore: 0,
@@ -625,8 +668,8 @@ export function useBlindtestGame() {
   const resetGame = useCallback(() => {
     if (gameId) void deleteGameState(gameId);
     void audioPlayer.stop();
-    setGameState("genreSelection");
-    setSelectedGenre(null);
+    setGameState("playlistSelection");
+    setSelectedPlaylist(null);
     setWarmMessage(null);
     setTracks([]);
     setCurrentRoundIndex(0);
@@ -646,8 +689,8 @@ export function useBlindtestGame() {
 
   return {
     gameState,
-    genres,
-    loadingGenres,
+    playlists,
+    loadingPlaylists,
     loadingTracks,
     currentTrack,
     currentFeaturingNames,
@@ -670,6 +713,7 @@ export function useBlindtestGame() {
     borderOpacity,
     errorMessage,
     errorAnimationsEnabled,
+    selectedPlaylist,
     startGame,
     beginPlaying,
     submitAnswer,

--- a/front-mobile/services/__tests__/curatedPlaylistService.test.ts
+++ b/front-mobile/services/__tests__/curatedPlaylistService.test.ts
@@ -1,0 +1,72 @@
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
+
+import {
+  getCuratedPlaylists,
+  getCuratedPlaylistTracks,
+  CuratedPlaylist,
+  CuratedPlaylistTrack,
+} from "../curatedPlaylistService";
+import { get } from "../api";
+
+jest.mock("../api", () => ({
+  get: jest.fn(),
+}));
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+
+const samplePlaylist: CuratedPlaylist = {
+  id: 1,
+  deezerPlaylistId: 1996494362,
+  name: "Top France",
+  genreLabel: "Hits FR",
+  coverUrl: "https://cover.example/fr.jpg",
+  trackCount: 1500,
+  createdAt: "2026-04-29T10:00:00.000Z",
+  updatedAt: "2026-04-29T10:00:00.000Z",
+};
+
+const sampleTrack: CuratedPlaylistTrack = {
+  id: 12345,
+  title: "Track",
+  title_short: "Track",
+  preview: "https://preview/12345.mp3",
+  duration: 30,
+  artist: { id: 1, name: "Artist" },
+  album: { id: 2, title: "Album" },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("curatedPlaylistService", () => {
+  it("getCuratedPlaylists hits /api/games/blindtest/playlists and unwraps the playlists field", async () => {
+    mockGet.mockResolvedValueOnce({ playlists: [samplePlaylist] });
+
+    const result = await getCuratedPlaylists();
+
+    expect(mockGet).toHaveBeenCalledWith("/api/games/blindtest/playlists");
+    expect(result).toEqual([samplePlaylist]);
+  });
+
+  it("getCuratedPlaylistTracks hits the tracks endpoint with default count=50", async () => {
+    mockGet.mockResolvedValueOnce({ tracks: [sampleTrack] });
+
+    const result = await getCuratedPlaylistTracks(7);
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/games/blindtest/playlists/7/tracks?count=50",
+    );
+    expect(result).toEqual([sampleTrack]);
+  });
+
+  it("getCuratedPlaylistTracks forwards a custom count", async () => {
+    mockGet.mockResolvedValueOnce({ tracks: [] });
+
+    await getCuratedPlaylistTracks(42, 5);
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/games/blindtest/playlists/42/tracks?count=5",
+    );
+  });
+});

--- a/front-mobile/services/curatedPlaylistService.ts
+++ b/front-mobile/services/curatedPlaylistService.ts
@@ -1,0 +1,63 @@
+import { get } from "./api";
+
+export interface CuratedPlaylist {
+  id: number;
+  deezerPlaylistId: number;
+  name: string;
+  genreLabel: string;
+  coverUrl: string | null;
+  trackCount: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CuratedPlaylistTrack {
+  id: number;
+  title: string;
+  title_short: string;
+  preview: string;
+  duration: number;
+  artist: {
+    id: number;
+    name: string;
+    picture?: string;
+    picture_small?: string;
+    picture_medium?: string;
+    picture_big?: string;
+    picture_xl?: string;
+  };
+  album: {
+    id: number;
+    title: string;
+    cover?: string;
+    cover_small?: string;
+    cover_medium?: string;
+    cover_big?: string;
+    cover_xl?: string;
+  };
+}
+
+interface GetCuratedPlaylistsResponse {
+  playlists: CuratedPlaylist[];
+}
+
+interface GetCuratedPlaylistTracksResponse {
+  tracks: CuratedPlaylistTrack[];
+}
+
+export const getCuratedPlaylists = async (): Promise<CuratedPlaylist[]> => {
+  const data = await get<GetCuratedPlaylistsResponse>(
+    "/api/games/blindtest/playlists",
+  );
+  return data.playlists;
+};
+
+export const getCuratedPlaylistTracks = async (
+  playlistId: number,
+  count = 50,
+): Promise<CuratedPlaylistTrack[]> => {
+  const data = await get<GetCuratedPlaylistTracksResponse>(
+    `/api/games/blindtest/playlists/${playlistId}/tracks?count=${count}`,
+  );
+  return data.tracks;
+};

--- a/front-mobile/types/gameSession.ts
+++ b/front-mobile/types/gameSession.ts
@@ -178,9 +178,10 @@ export interface BlindtestRound {
 }
 
 export interface BlindtestGameData {
-  genre: {
+  playlist: {
     id: number;
     name: string;
+    genreLabel: string;
   };
   totalRounds: number;
   rounds: BlindtestRound[];


### PR DESCRIPTION
## Description

Le jeu Blind Test ne charge plus ses morceaux par genre Deezer mais via des playlists curées par l'équipe, persistées en base. Côté backend, une nouvelle table `curated_playlists` stocke les 8 playlists thématiques (Rap FR, Rap US, Pop, Variété FR, Rock, R&B, Électro, Latino) avec leur ID Deezer et leur nombre de morceaux ; deux endpoints `/api/games/blindtest/playlists` et `/api/games/blindtest/playlists/:id/tracks?count=50` exposent la liste et un échantillon aléatoire de tracks (pagination complète de la playlist Deezer côté serveur, dédup + shuffle). Côté front mobile, l'écran de sélection passe d'une grille de genres à une liste de playlists pleine largeur (image + titre + nombre de morceaux), et le hook `useBlindtestGame` consomme directement les nouveaux endpoints.

## Parcours utilisateur

1. Lancer le backend et l'app front-mobile en local (avec la migration `1777476752300_create_curated_playlists_table` appliquée et le seeder `curated_playlist_seeder` joué).
2. Se connecter dans l'app, aller dans **Jeux → Blind Test → Jouer**.
3. Vérifier l'écran de sélection :
   - Titre **« Choisis la playlist »** en haut.
   - Liste verticale pleine largeur avec 8 playlists, chacune affichant la pochette à gauche, le nom en gros et le nombre de morceaux en dessous.
   - Plus aucune sélection par genre Deezer.
4. Sélectionner une playlist (ex. **Rap FR**) :
   - Loader « Chargement des morceaux… ».
   - Transition vers l'écran « Ready » avec 5 manches à jouer.
5. Jouer une partie complète :
   - Audio joue les previews, saisie d'artiste / featuring / titre fonctionne (timer, scoring, abandon, reprise inchangés).
   - Vérifier qu'on tombe sur des artistes variés sur 2-3 parties d'affilée (l'échantillonnage doit couvrir l'ensemble de la playlist, pas seulement les morceaux populaires).
6. Tester la reprise d'une partie : démarrer une partie, fermer/rouvrir l'app via `resume=true` → la playlist sélectionnée et l'état du jeu sont restaurés.
7. Vérifier que **Tracklist** et **Blurchette** conservent leur sélection par genre (pas de régression sur ces jeux).
8. Tester les erreurs côté API :
   - `GET /api/games/blindtest/playlists` sans token → 401.
   - `GET /api/games/blindtest/playlists/999999/tracks` (id inconnu) → 404.
   - `GET /api/games/blindtest/playlists/:id/tracks?count=999` (count > 100) → 422.