### PR TITLE
HOTFIX: make game and achievement seeders idempotent

### DIFF
--- a/backend/database/seeders/achievement_seeder.ts
+++ b/backend/database/seeders/achievement_seeder.ts
@@ -4,7 +4,7 @@ import { AchievementType } from '#enums/achievement_type'
 
 export default class extends BaseSeeder {
   async run() {
-    await Achievement.createMany([
+    const achievements = [
       {
         name: "Bienvenue dans l'arène",
         description: 'Jouer sa toute première partie.',
@@ -131,6 +131,10 @@ export default class extends BaseSeeder {
         type: AchievementType.Comeback,
         icon: '🔄',
       },
-    ])
+    ]
+
+    for (const achievement of achievements) {
+      await Achievement.updateOrCreate({ type: achievement.type }, achievement)
+    }
   }
 }

--- a/backend/database/seeders/game_seeder.ts
+++ b/backend/database/seeders/game_seeder.ts
@@ -3,7 +3,7 @@ import Game from '#models/game'
 
 export default class extends BaseSeeder {
   async run() {
-    await Game.createMany([
+    const games = [
       {
         name: 'Blind Test',
         description: 'Devinez les morceaux le plus rapidement possible en temps réel.',
@@ -52,6 +52,10 @@ export default class extends BaseSeeder {
         isMultiplayer: false,
         isEnabled: false,
       },
-    ])
+    ]
+
+    for (const game of games) {
+      await Game.updateOrCreate({ name: game.name }, game)
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `game_seeder` et `achievement_seeder` utilisaient `createMany` → re-seed = doublons (×2 sur staging)
- Switch en `updateOrCreate` (clé : `name` pour games, `type` pour achievements), aligné sur `curated_playlist_seeder`

## Contexte
Doublons constatés sur staging après replay du seeder. Tables purgées (`TRUNCATE ... CASCADE`) et re-seedées proprement (8 games / 21 achievements / 8 playlists).

## Test plan
- [x] Run seeder 2× en local → 0 doublon (`SELECT name, count(*) FROM games GROUP BY name HAVING count(*) > 1` vide)
- [x] Run seeder 2× en local sur achievements → 0 doublon
- [x] Lint + Prettier OK