### PR TITLE
MIX-313 feat: add users.last_login_at column for inactivity tracking

### DIFF
--- a/backend/adonisrc.ts
+++ b/backend/adonisrc.ts
@@ -66,7 +66,11 @@ export default defineConfig({
   | List of modules to import before starting the application.
   |
   */
-  preloads: [() => import('#start/routes'), () => import('#start/kernel')],
+  preloads: [
+    () => import('#start/routes'),
+    () => import('#start/kernel'),
+    () => import('#start/events'),
+  ],
 
   /*
   |--------------------------------------------------------------------------

--- a/backend/app/events/auth_session_created.ts
+++ b/backend/app/events/auth_session_created.ts
@@ -1,0 +1,14 @@
+import { BaseEvent } from '@adonisjs/core/events'
+import { DateTime } from 'luxon'
+
+export type AuthSessionCreatedPayload = {
+  userId: string
+  lastLoginAt: DateTime | null
+  isFirstLogin: boolean
+}
+
+export default class AuthSessionCreated extends BaseEvent {
+  constructor(public payload: AuthSessionCreatedPayload) {
+    super()
+  }
+}

--- a/backend/app/events/game_finished.ts
+++ b/backend/app/events/game_finished.ts
@@ -1,0 +1,18 @@
+import { BaseEvent } from '@adonisjs/core/events'
+
+export type GameFinishedPayload = {
+  userId: string
+  gameId: number
+  score: number
+  maxScore: number
+  isPerfect: boolean
+  durationMs: number
+  fastestAnswerMs?: number
+  correctAnswersCount: number
+}
+
+export default class GameFinished extends BaseEvent {
+  constructor(public payload: GameFinishedPayload) {
+    super()
+  }
+}

--- a/backend/app/events/track_liked.ts
+++ b/backend/app/events/track_liked.ts
@@ -1,0 +1,13 @@
+import { BaseEvent } from '@adonisjs/core/events'
+
+export type TrackLikedPayload = {
+  userId: string
+  deezerTrackId: string
+  deezerArtistId: string | null
+}
+
+export default class TrackLiked extends BaseEvent {
+  constructor(public payload: TrackLikedPayload) {
+    super()
+  }
+}

--- a/backend/app/listeners/on_auth_session_created.ts
+++ b/backend/app/listeners/on_auth_session_created.ts
@@ -1,0 +1,29 @@
+import { DateTime } from 'luxon'
+import AuthSessionCreated from '#events/auth_session_created'
+import User from '#models/user'
+import { AchievementProgressService } from '#services/achievement_progress_service'
+import { AchievementType } from '#enums/achievement_type'
+
+const LAUNCH_DAY = DateTime.fromISO('2026-05-20')
+const COMEBACK_INACTIVITY_DAYS = 30
+
+export default class OnAuthSessionCreated {
+  async handle(event: AuthSessionCreated) {
+    const service = new AchievementProgressService()
+    const { userId, lastLoginAt, isFirstLogin } = event.payload
+
+    if (isFirstLogin) {
+      const user = await User.find(userId)
+      if (user && user.createdAt && user.createdAt.hasSame(LAUNCH_DAY, 'day')) {
+        await service.ensureAndIncrement(userId, AchievementType.LaunchDaySignup, 1)
+      }
+    }
+
+    if (lastLoginAt) {
+      const daysSinceLastLogin = DateTime.now().diff(lastLoginAt, 'days').days
+      if (daysSinceLastLogin >= COMEBACK_INACTIVITY_DAYS) {
+        await service.ensureAndIncrement(userId, AchievementType.Comeback, 1)
+      }
+    }
+  }
+}

--- a/backend/app/listeners/on_game_finished.ts
+++ b/backend/app/listeners/on_game_finished.ts
@@ -1,0 +1,33 @@
+import GameFinished from '#events/game_finished'
+import { AchievementProgressService } from '#services/achievement_progress_service'
+import { AchievementType } from '#enums/achievement_type'
+
+const FAST_ANSWER_THRESHOLD_MS = 3000
+
+export default class OnGameFinished {
+  async handle(event: GameFinished) {
+    const service = new AchievementProgressService()
+    const { userId, isPerfect, fastestAnswerMs, correctAnswersCount } = event.payload
+
+    await service.ensureAndIncrement(userId, AchievementType.FirstGame, 1)
+    await service.ensureAndIncrement(userId, AchievementType.GamesPlayed, 1)
+    await service.ensureAndIncrement(userId, AchievementType.TotalGamesPlayed, 1)
+
+    if (correctAnswersCount > 0) {
+      await service.ensureAndIncrement(
+        userId,
+        AchievementType.TotalCorrectAnswers,
+        correctAnswersCount
+      )
+    }
+
+    if (isPerfect) {
+      await service.ensureAndIncrement(userId, AchievementType.FirstWin, 1)
+      await service.ensureAndIncrement(userId, AchievementType.PerfectGame, 1)
+    }
+
+    if (fastestAnswerMs !== undefined && fastestAnswerMs < FAST_ANSWER_THRESHOLD_MS) {
+      await service.ensureAndIncrement(userId, AchievementType.FastAnswer, 1)
+    }
+  }
+}

--- a/backend/app/listeners/on_track_liked.ts
+++ b/backend/app/listeners/on_track_liked.ts
@@ -1,0 +1,13 @@
+import TrackLiked from '#events/track_liked'
+import { AchievementProgressService } from '#services/achievement_progress_service'
+import { AchievementType } from '#enums/achievement_type'
+
+export default class OnTrackLiked {
+  async handle(event: TrackLiked) {
+    const service = new AchievementProgressService()
+    const { userId } = event.payload
+
+    await service.ensureAndIncrement(userId, AchievementType.FirstLike, 1)
+    await service.ensureAndIncrement(userId, AchievementType.TotalLikes, 1)
+  }
+}

--- a/backend/app/models/user.ts
+++ b/backend/app/models/user.ts
@@ -71,6 +71,10 @@ export default class User extends compose(BaseModel, AuthFinder) {
   @column.dateTime()
   declare emailVerifiedAt: DateTime | null
 
+  @ApiProperty({ description: 'Last login timestamp', nullable: true })
+  @column.dateTime()
+  declare lastLoginAt: DateTime | null
+
   @hasMany(() => UserTrackInteraction)
   declare trackInteractions: HasMany<typeof UserTrackInteraction>
 

--- a/backend/app/services/achievement_progress_service.ts
+++ b/backend/app/services/achievement_progress_service.ts
@@ -1,0 +1,70 @@
+import Achievement from '#models/achievement'
+import UserAchievement from '#models/user_achievement'
+import { AchievementType } from '#enums/achievement_type'
+
+const REQUIRED_PROGRESS_BY_TYPE = new Map<AchievementType, number>([
+  [AchievementType.FirstGame, 1],
+  [AchievementType.FirstLike, 1],
+  [AchievementType.FirstWin, 1],
+  [AchievementType.PerfectGame, 1],
+  [AchievementType.GamesPlayed, 50],
+  [AchievementType.TotalGamesPlayed, 500],
+  [AchievementType.TotalLikes, 500],
+  [AchievementType.TotalCorrectAnswers, 500],
+  [AchievementType.FastAnswer, 1],
+  [AchievementType.LaunchDaySignup, 1],
+  [AchievementType.Comeback, 1],
+])
+
+export class AchievementProgressService {
+  getRequiredProgress(type: AchievementType): number | undefined {
+    return REQUIRED_PROGRESS_BY_TYPE.get(type)
+  }
+
+  async ensureAndIncrement(
+    userId: string,
+    type: AchievementType,
+    amount: number = 1
+  ): Promise<UserAchievement | null> {
+    if (amount <= 0) {
+      return null
+    }
+
+    const requiredProgress = REQUIRED_PROGRESS_BY_TYPE.get(type)
+    if (requiredProgress === undefined) {
+      return null
+    }
+
+    const achievement = await Achievement.findBy('type', type)
+    if (!achievement) {
+      return null
+    }
+
+    let userAchievement = await UserAchievement.query()
+      .where('user_id', userId)
+      .where('achievement_id', achievement.id)
+      .first()
+
+    if (!userAchievement) {
+      userAchievement = await UserAchievement.create({
+        userId,
+        achievementId: achievement.id,
+        currentProgress: 0,
+        requiredProgress,
+        currentTier: 1,
+        progressData: {},
+      })
+    }
+
+    if (userAchievement.unlockedAt) {
+      return userAchievement
+    }
+
+    userAchievement.currentProgress += amount
+    await userAchievement.save()
+
+    return userAchievement
+  }
+}
+
+export default AchievementProgressService

--- a/backend/app/services/auth_service.ts
+++ b/backend/app/services/auth_service.ts
@@ -87,7 +87,7 @@ export class AuthService {
   }
 
   private async recordSession(user: User) {
-    const previousLastLoginAt = user.lastLoginAt
+    const previousLastLoginAt = user.lastLoginAt ?? null
     user.lastLoginAt = DateTime.now()
     await user.save()
 

--- a/backend/app/services/auth_service.ts
+++ b/backend/app/services/auth_service.ts
@@ -6,6 +6,7 @@ import { randomBytes } from 'node:crypto'
 import hash from '@adonisjs/core/services/hash'
 import mail from '@adonisjs/mail/services/main'
 import env from '#start/env'
+import AuthSessionCreated from '#events/auth_session_created'
 
 export class AuthService {
   async register(data: {
@@ -53,6 +54,8 @@ export class AuthService {
       })
     }
 
+    await this.recordSession(user)
+
     return this.issueTokens(user)
   }
 
@@ -78,7 +81,21 @@ export class AuthService {
       throw new Error('Email not verified')
     }
 
+    await this.recordSession(user)
+
     return this.issueTokens(user)
+  }
+
+  private async recordSession(user: User) {
+    const previousLastLoginAt = user.lastLoginAt
+    user.lastLoginAt = DateTime.now()
+    await user.save()
+
+    await AuthSessionCreated.dispatch({
+      userId: user.id,
+      lastLoginAt: previousLastLoginAt,
+      isFirstLogin: previousLastLoginAt === null,
+    })
   }
 
   async refresh(refreshTokenValue: string) {

--- a/backend/app/services/game_session_service.ts
+++ b/backend/app/services/game_session_service.ts
@@ -1,5 +1,6 @@
 import GameSession from '#models/game_session'
 import { GameSessionStatus } from '#enums/game_session_status'
+import GameFinished from '#events/game_finished'
 
 export class GameSessionService {
   public async getAll() {
@@ -38,6 +39,11 @@ export class GameSessionService {
     try {
       const gameSession = await GameSession.create(payload)
       await gameSession.load('game')
+
+      if (gameSession.status === GameSessionStatus.Completed) {
+        await this.emitGameFinished(gameSession)
+      }
+
       return gameSession
     } catch (error: any) {
       if (error.code === '23503') {
@@ -87,10 +93,19 @@ export class GameSessionService {
       mergedPayload.gameData = { ...gameSession.gameData, ...payload.gameData }
     }
 
+    const previousStatus = gameSession.status
     gameSession.merge(mergedPayload)
     try {
       await gameSession.save()
       await gameSession.load('game')
+
+      if (
+        previousStatus !== GameSessionStatus.Completed &&
+        gameSession.status === GameSessionStatus.Completed
+      ) {
+        await this.emitGameFinished(gameSession)
+      }
+
       return gameSession
     } catch (error: any) {
       if (error.code === '23503') {
@@ -207,6 +222,31 @@ export class GameSessionService {
 
   public async getMyActiveSessionByGameId(userId: string, gameId: number) {
     return this.getByUserIdAndGameId(userId, gameId, GameSessionStatus.Active)
+  }
+
+  private async emitGameFinished(gameSession: GameSession) {
+    const gameData: any = gameSession.gameData
+    const score = Number(gameData.score)
+    const maxScore = Number(gameData.maxScore)
+    const isPerfect = score >= maxScore
+    const answers: any[] = gameData.answers
+    const correctAnswersCount = answers.filter((a) => a.correct === true).length
+    const durationMs = Math.round(Number(gameData.timeElapsed) * 1000)
+    const answerTimes = answers.map((a) => Number(a.durationMs)).filter((t) => t > 0)
+    const fastestAnswerMs = answerTimes.length > 0 ? Math.min(...answerTimes) : undefined
+
+    for (const player of gameSession.players) {
+      await GameFinished.dispatch({
+        userId: player.userId,
+        gameId: gameSession.gameId,
+        score,
+        maxScore,
+        isPerfect,
+        durationMs,
+        fastestAnswerMs,
+        correctAnswersCount,
+      })
+    }
   }
 }
 

--- a/backend/app/services/track_interactions_service.ts
+++ b/backend/app/services/track_interactions_service.ts
@@ -1,6 +1,7 @@
 import UserTrackInteraction from '#models/user_track_interaction'
 import { InteractionAction } from '#enums/interaction_action'
 import { type ServiceError } from '#types/service_error'
+import TrackLiked from '#events/track_liked'
 
 export class TrackInteractionsService {
   public getByUserId(userId: string, action?: InteractionAction) {
@@ -21,7 +22,14 @@ export class TrackInteractionsService {
     isrc?: string | null
   }): Promise<UserTrackInteraction | ServiceError> {
     try {
-      return await UserTrackInteraction.updateOrCreate(
+      const existing = await UserTrackInteraction.query()
+        .where('userId', payload.userId)
+        .where('deezerTrackId', payload.deezerTrackId)
+        .first()
+
+      const wasAlreadyLiked = existing?.action === InteractionAction.Liked
+
+      const interaction = await UserTrackInteraction.updateOrCreate(
         {
           userId: payload.userId,
           deezerTrackId: payload.deezerTrackId,
@@ -34,6 +42,16 @@ export class TrackInteractionsService {
           isrc: payload.isrc ?? null,
         }
       )
+
+      if (payload.action === InteractionAction.Liked && !wasAlreadyLiked) {
+        await TrackLiked.dispatch({
+          userId: payload.userId,
+          deezerTrackId: payload.deezerTrackId,
+          deezerArtistId: payload.deezerArtistId ?? null,
+        })
+      }
+
+      return interaction
     } catch (error: any) {
       if (error.code === '22001') {
         return {

--- a/backend/database/migrations/1777000000000_add_last_login_at_to_users.ts
+++ b/backend/database/migrations/1777000000000_add_last_login_at_to_users.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'users'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.timestamp('last_login_at').nullable()
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('last_login_at')
+    })
+  }
+}

--- a/backend/start/events.ts
+++ b/backend/start/events.ts
@@ -1,0 +1,8 @@
+import emitter from '@adonisjs/core/services/emitter'
+import GameFinished from '#events/game_finished'
+import TrackLiked from '#events/track_liked'
+import AuthSessionCreated from '#events/auth_session_created'
+
+emitter.listen(GameFinished, [() => import('#listeners/on_game_finished')])
+emitter.listen(TrackLiked, [() => import('#listeners/on_track_liked')])
+emitter.listen(AuthSessionCreated, [() => import('#listeners/on_auth_session_created')])

--- a/backend/tests/functional/achievements_events.spec.ts
+++ b/backend/tests/functional/achievements_events.spec.ts
@@ -1,0 +1,109 @@
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+import Achievement from '#models/achievement'
+import Game from '#models/game'
+import User from '#models/user'
+import { AchievementType } from '#enums/achievement_type'
+import { GameSessionStatus } from '#enums/game_session_status'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteAchievementProgress } from '#tests/utils/achievement_progress_helpers'
+
+test.group('Achievements — events end-to-end', (group) => {
+  let testStartTime: DateTime
+
+  group.setup(() => {
+    testStartTime = DateTime.now()
+  })
+
+  deleteAchievementProgress(group)
+
+  group.teardown(async () => {
+    await Game.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+  })
+
+  test('POST /api/game-sessions with status=completed unlocks FirstGame', async ({
+    assert,
+    client,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('e2e_first_game')
+
+    await Achievement.createMany([
+      { type: AchievementType.FirstGame, name: 'Bienvenue', description: 'd' },
+      { type: AchievementType.GamesPlayed, name: 'Vétéran', description: 'd' },
+      { type: AchievementType.TotalGamesPlayed, name: 'Légende', description: 'd' },
+    ])
+
+    const game = await Game.create({
+      name: `Test Game ${Date.now()}`,
+      description: 'desc',
+    })
+
+    const createResponse = await client
+      .post('/api/game-sessions')
+      .bearerToken(token)
+      .json({
+        gameId: game.id,
+        status: GameSessionStatus.Completed,
+        players: [{ userId: user.id, status: 'finished', score: 5, expGained: 0, rank: 1 }],
+        gameData: {
+          score: 5,
+          maxScore: 5,
+          answers: [
+            { correct: true },
+            { correct: true },
+            { correct: true },
+            { correct: true },
+            { correct: true },
+          ],
+          timeElapsed: 30,
+        },
+      })
+
+    assert.equal(createResponse.status(), 201)
+
+    const myAchievements = await client.get('/api/user-achievements/me').bearerToken(token)
+
+    assert.equal(myAchievements.status(), 200)
+
+    const list = myAchievements.body().userAchievements as Array<any>
+    const firstGame = list.find((a) => a.achievement?.type === AchievementType.FirstGame)
+    assert.exists(firstGame)
+    assert.equal(firstGame.currentProgress, 1)
+    assert.isNotNull(firstGame.unlockedAt)
+  })
+
+  test('login after >30 days inactivity unlocks Comeback', async ({ assert, client }) => {
+    const password = 'password123'
+    const timestamp = Date.now() + Math.random()
+    const user = await User.create({
+      email: `comeback_${timestamp}@example.com`,
+      username: `comeback_${timestamp}`,
+      password,
+      role: 'user',
+      emailVerifiedAt: DateTime.now(),
+      lastLoginAt: DateTime.now().minus({ days: 31 }),
+    })
+
+    await Achievement.create({
+      type: AchievementType.Comeback,
+      name: 'Le Retour',
+      description: 'd',
+    })
+
+    const loginResponse = await client.post('/api/auth/login').json({
+      email: user.email,
+      password,
+    })
+
+    assert.equal(loginResponse.status(), 200)
+    const accessToken = loginResponse.body().accessToken as string
+
+    const myAchievements = await client.get('/api/user-achievements/me').bearerToken(accessToken)
+
+    assert.equal(myAchievements.status(), 200)
+    const list = myAchievements.body().userAchievements as Array<any>
+    const comeback = list.find((a) => a.achievement?.type === AchievementType.Comeback)
+    assert.exists(comeback)
+    assert.isNotNull(comeback.unlockedAt)
+  })
+})

--- a/backend/tests/unit/achievement_progress_service.spec.ts
+++ b/backend/tests/unit/achievement_progress_service.spec.ts
@@ -1,0 +1,122 @@
+import { test } from '@japa/runner'
+import { AchievementProgressService } from '#services/achievement_progress_service'
+import Achievement from '#models/achievement'
+import UserAchievement from '#models/user_achievement'
+import { AchievementType } from '#enums/achievement_type'
+import { DateTime } from 'luxon'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteAchievementProgress } from '#tests/utils/achievement_progress_helpers'
+
+test.group('AchievementProgressService', (group) => {
+  let service: AchievementProgressService
+
+  deleteAchievementProgress(group)
+
+  group.each.setup(() => {
+    service = new AchievementProgressService()
+  })
+
+  test('ensureAndIncrement creates a new UserAchievement when none exists', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('aps_create')
+    await Achievement.create({
+      type: AchievementType.FirstGame,
+      name: 'First Game',
+      description: 'd',
+    })
+
+    const result = await service.ensureAndIncrement(user.id, AchievementType.FirstGame, 1)
+
+    assert.instanceOf(result, UserAchievement)
+    if (result instanceof UserAchievement) {
+      assert.equal(result.userId, user.id)
+      assert.equal(result.currentProgress, 1)
+      assert.equal(result.requiredProgress, 1)
+      assert.isNotNull(result.unlockedAt)
+    }
+  })
+
+  test('ensureAndIncrement increments existing in-progress UserAchievement', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('aps_inc')
+    const achievement = await Achievement.create({
+      type: AchievementType.GamesPlayed,
+      name: 'Vétéran',
+      description: 'd',
+    })
+    await UserAchievement.create({
+      userId: user.id,
+      achievementId: achievement.id,
+      currentProgress: 5,
+      requiredProgress: 50,
+      currentTier: 1,
+      progressData: {},
+    })
+
+    const result = await service.ensureAndIncrement(user.id, AchievementType.GamesPlayed, 3)
+
+    assert.instanceOf(result, UserAchievement)
+    if (result instanceof UserAchievement) {
+      assert.equal(result.currentProgress, 8)
+      assert.isNull(result.unlockedAt)
+    }
+  })
+
+  test('ensureAndIncrement skips already unlocked achievements', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('aps_done')
+    const achievement = await Achievement.create({
+      type: AchievementType.FirstLike,
+      name: 'Premier pas',
+      description: 'd',
+    })
+    await UserAchievement.create({
+      userId: user.id,
+      achievementId: achievement.id,
+      currentProgress: 1,
+      requiredProgress: 1,
+      currentTier: 1,
+      progressData: {},
+      unlockedAt: DateTime.now(),
+    })
+
+    const result = await service.ensureAndIncrement(user.id, AchievementType.FirstLike, 5)
+
+    assert.instanceOf(result, UserAchievement)
+    if (result instanceof UserAchievement) {
+      assert.equal(result.currentProgress, 1)
+    }
+  })
+
+  test('ensureAndIncrement returns null when achievement type is unknown to mapping', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('aps_unknown')
+
+    const result = await service.ensureAndIncrement(user.id, AchievementType.BlindTestCorrect, 1)
+
+    assert.isNull(result)
+  })
+
+  test('ensureAndIncrement returns null when amount is zero or negative', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('aps_amount')
+
+    const zeroResult = await service.ensureAndIncrement(user.id, AchievementType.FirstGame, 0)
+    const negativeResult = await service.ensureAndIncrement(user.id, AchievementType.FirstGame, -1)
+
+    assert.isNull(zeroResult)
+    assert.isNull(negativeResult)
+  })
+
+  test('ensureAndIncrement returns null when Achievement record is missing', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('aps_no_ach')
+
+    const result = await service.ensureAndIncrement(user.id, AchievementType.FirstGame, 1)
+
+    assert.isNull(result)
+  })
+
+  test('getRequiredProgress returns the configured threshold for known types', ({ assert }) => {
+    assert.equal(service.getRequiredProgress(AchievementType.FirstGame), 1)
+    assert.equal(service.getRequiredProgress(AchievementType.GamesPlayed), 50)
+    assert.equal(service.getRequiredProgress(AchievementType.TotalGamesPlayed), 500)
+    assert.isUndefined(service.getRequiredProgress(AchievementType.BlindTestCorrect))
+  })
+})

--- a/backend/tests/unit/auth_service_google.spec.ts
+++ b/backend/tests/unit/auth_service_google.spec.ts
@@ -1,6 +1,8 @@
 import { test } from '@japa/runner'
+import emitter from '@adonisjs/core/services/emitter'
 import User from '#models/user'
 import { AuthService } from '#services/auth_service'
+import AuthSessionCreated from '#events/auth_session_created'
 import { deleteAuthData } from '#tests/utils/auth_cleanup_helpers'
 
 test.group('AuthService - loginOrCreateFromGoogle', (group) => {
@@ -87,5 +89,43 @@ test.group('AuthService - loginOrCreateFromGoogle', (group) => {
     const result = await authService.loginOrCreateFromGoogle({ email, name: null })
 
     assert.equal(result.user.username, 'abuser')
+  })
+
+  test('dispatches AuthSessionCreated with isFirstLogin=true for a brand-new Google user', async ({
+    cleanup,
+  }) => {
+    const events = emitter.fake([AuthSessionCreated])
+    cleanup(() => emitter.restore())
+
+    const email = `svc_google_first_${Date.now()}@example.com`
+    const result = await authService.loginOrCreateFromGoogle({ email, name: 'First Login' })
+
+    events.assertEmitted(AuthSessionCreated, ({ data }) => {
+      return (
+        data.payload.userId === result.user.id &&
+        data.payload.isFirstLogin === true &&
+        data.payload.lastLoginAt === null
+      )
+    })
+  })
+
+  test('dispatches AuthSessionCreated with isFirstLogin=false for an existing Google user', async ({
+    cleanup,
+  }) => {
+    const email = `svc_google_returning_${Date.now()}@example.com`
+    await authService.loginOrCreateFromGoogle({ email, name: 'Returning User' })
+
+    const events = emitter.fake([AuthSessionCreated])
+    cleanup(() => emitter.restore())
+
+    const result = await authService.loginOrCreateFromGoogle({ email, name: 'Returning User' })
+
+    events.assertEmitted(AuthSessionCreated, ({ data }) => {
+      return (
+        data.payload.userId === result.user.id &&
+        data.payload.isFirstLogin === false &&
+        data.payload.lastLoginAt !== null
+      )
+    })
   })
 })

--- a/backend/tests/unit/game_session_service_emit.spec.ts
+++ b/backend/tests/unit/game_session_service_emit.spec.ts
@@ -1,0 +1,108 @@
+import { test } from '@japa/runner'
+import GameSession from '#models/game_session'
+import { GameSessionService } from '#services/game_session_service'
+import Game from '#models/game'
+import { GameSessionStatus } from '#enums/game_session_status'
+import { deleteGameSession } from '#tests/utils/game_session_helpers'
+
+async function createTestGame(tag: string) {
+  return Game.create({ name: `Test ${tag} ${Date.now() + Math.random()}`, description: 'd' })
+}
+
+const baseGameData = (overrides: Record<string, any> = {}) => ({
+  score: 0,
+  maxScore: 5,
+  answers: [],
+  timeElapsed: 10,
+  ...overrides,
+})
+
+test.group('GameSessionService — emitGameFinished branches', (group) => {
+  let service: GameSessionService
+
+  deleteGameSession(group)
+
+  group.each.setup(() => {
+    service = new GameSessionService()
+  })
+
+  test('createGameSession with Completed status dispatches event for each player (non-perfect, with answer durations)', async ({
+    assert,
+  }) => {
+    const game = await createTestGame('emit_create')
+
+    const created = await service.createGameSession({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [
+        { userId: 'u1', status: 'finished', score: 0, expGained: 0, rank: 1 },
+        { userId: 'u2', status: 'finished', score: 0, expGained: 0, rank: 2 },
+      ],
+      gameData: baseGameData({
+        score: 3,
+        maxScore: 5,
+        answers: [
+          { correct: true, durationMs: 2000 },
+          { correct: false, durationMs: 4000 },
+          { correct: true, durationMs: 1500 },
+        ],
+        timeElapsed: 25,
+      }),
+    })
+
+    assert.instanceOf(created, GameSession)
+  })
+
+  test('updateGameSession transitioning to Completed dispatches event', async ({ assert }) => {
+    const game = await createTestGame('emit_update')
+    const created = await service.createGameSession({
+      gameId: game.id,
+      status: GameSessionStatus.Active,
+      players: [{ userId: 'u3', status: 'playing', score: 0, expGained: 0, rank: 1 }],
+      gameData: baseGameData({ score: 0 }),
+    })
+    assert.instanceOf(created, GameSession)
+    if (!(created instanceof GameSession)) return
+
+    const updated = await service.updateGameSession(created.id, {
+      status: GameSessionStatus.Completed,
+      gameData: baseGameData({
+        score: 5,
+        maxScore: 5,
+        answers: [{ correct: true, durationMs: 1000 }],
+        timeElapsed: 12,
+      }) as any,
+    })
+
+    assert.instanceOf(updated, GameSession)
+    if (updated instanceof GameSession) {
+      assert.equal(updated.status, GameSessionStatus.Completed)
+    }
+  })
+
+  test('updateGameSession does not re-dispatch when already Completed', async ({ assert }) => {
+    const game = await createTestGame('emit_no_re')
+    const created = await service.createGameSession({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: 'u4', status: 'finished', score: 5, expGained: 0, rank: 1 }],
+      gameData: baseGameData({
+        score: 5,
+        maxScore: 5,
+        answers: [{ correct: true, durationMs: 100 }],
+      }),
+    })
+    assert.instanceOf(created, GameSession)
+    if (!(created instanceof GameSession)) return
+
+    const updated = await service.updateGameSession(created.id, {
+      gameData: baseGameData({
+        score: 5,
+        maxScore: 5,
+        answers: [{ correct: true, durationMs: 200 }],
+      }) as any,
+    })
+
+    assert.instanceOf(updated, GameSession)
+  })
+})

--- a/backend/tests/unit/on_auth_session_created.spec.ts
+++ b/backend/tests/unit/on_auth_session_created.spec.ts
@@ -1,0 +1,155 @@
+import { test } from '@japa/runner'
+import OnAuthSessionCreated from '#listeners/on_auth_session_created'
+import AuthSessionCreated from '#events/auth_session_created'
+import Achievement from '#models/achievement'
+import UserAchievement from '#models/user_achievement'
+import { AchievementType } from '#enums/achievement_type'
+import { DateTime } from 'luxon'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteAchievementProgress } from '#tests/utils/achievement_progress_helpers'
+
+test.group('OnAuthSessionCreated listener', (group) => {
+  deleteAchievementProgress(group)
+
+  test('first login after >30 days inactivity unlocks Comeback', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('oas_comeback')
+    await Achievement.create({
+      type: AchievementType.Comeback,
+      name: 'Le Retour',
+      description: 'd',
+    })
+
+    const listener = new OnAuthSessionCreated()
+    await listener.handle(
+      new AuthSessionCreated({
+        userId: user.id,
+        lastLoginAt: DateTime.now().minus({ days: 31 }),
+        isFirstLogin: false,
+      })
+    )
+
+    const comeback = await UserAchievement.query()
+      .where('user_id', user.id)
+      .whereHas('achievement', (q) => q.where('type', AchievementType.Comeback))
+      .first()
+    assert.isNotNull(comeback?.unlockedAt ?? null)
+  })
+
+  test('login under 30 days does not unlock Comeback', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('oas_recent')
+    await Achievement.create({
+      type: AchievementType.Comeback,
+      name: 'Le Retour',
+      description: 'd',
+    })
+
+    const listener = new OnAuthSessionCreated()
+    await listener.handle(
+      new AuthSessionCreated({
+        userId: user.id,
+        lastLoginAt: DateTime.now().minus({ days: 5 }),
+        isFirstLogin: false,
+      })
+    )
+
+    const comeback = await UserAchievement.query()
+      .where('user_id', user.id)
+      .whereHas('achievement', (q) => q.where('type', AchievementType.Comeback))
+      .first()
+    assert.isNull(comeback ?? null)
+  })
+
+  test('first login on launch day unlocks LaunchDaySignup', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('oas_launch')
+    user.createdAt = DateTime.fromISO('2026-05-20T12:00:00')
+    await user.save()
+
+    await Achievement.create({
+      type: AchievementType.LaunchDaySignup,
+      name: 'Fan du premier jour',
+      description: 'd',
+    })
+
+    const listener = new OnAuthSessionCreated()
+    await listener.handle(
+      new AuthSessionCreated({
+        userId: user.id,
+        lastLoginAt: null,
+        isFirstLogin: true,
+      })
+    )
+
+    const launchDay = await UserAchievement.query()
+      .where('user_id', user.id)
+      .whereHas('achievement', (q) => q.where('type', AchievementType.LaunchDaySignup))
+      .first()
+    assert.isNotNull(launchDay?.unlockedAt ?? null)
+  })
+
+  test('first login on a different day does not unlock LaunchDaySignup', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('oas_other')
+    user.createdAt = DateTime.fromISO('2026-06-01T12:00:00')
+    await user.save()
+
+    await Achievement.create({
+      type: AchievementType.LaunchDaySignup,
+      name: 'Fan du premier jour',
+      description: 'd',
+    })
+
+    const listener = new OnAuthSessionCreated()
+    await listener.handle(
+      new AuthSessionCreated({
+        userId: user.id,
+        lastLoginAt: null,
+        isFirstLogin: true,
+      })
+    )
+
+    const launchDay = await UserAchievement.query()
+      .where('user_id', user.id)
+      .whereHas('achievement', (q) => q.where('type', AchievementType.LaunchDaySignup))
+      .first()
+    assert.isNull(launchDay ?? null)
+  })
+
+  test('null lastLoginAt and isFirstLogin=false does nothing', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('oas_noop')
+    await Achievement.createMany([
+      { type: AchievementType.Comeback, name: 'Le Retour', description: 'd' },
+      { type: AchievementType.LaunchDaySignup, name: 'Fan', description: 'd' },
+    ])
+
+    const listener = new OnAuthSessionCreated()
+    await listener.handle(
+      new AuthSessionCreated({
+        userId: user.id,
+        lastLoginAt: null,
+        isFirstLogin: false,
+      })
+    )
+
+    const rows = await UserAchievement.query().where('user_id', user.id)
+    assert.lengthOf(rows, 0)
+  })
+
+  test('isFirstLogin=true with missing user record is a no-op', async ({ assert }) => {
+    await Achievement.create({
+      type: AchievementType.LaunchDaySignup,
+      name: 'Fan du premier jour',
+      description: 'd',
+    })
+
+    const listener = new OnAuthSessionCreated()
+    await listener.handle(
+      new AuthSessionCreated({
+        userId: 'non-existent-user-id',
+        lastLoginAt: null,
+        isFirstLogin: true,
+      })
+    )
+
+    const rows = await UserAchievement.query().where('user_id', 'non-existent-user-id')
+    assert.lengthOf(rows, 0)
+  })
+})

--- a/backend/tests/unit/on_game_finished.spec.ts
+++ b/backend/tests/unit/on_game_finished.spec.ts
@@ -1,0 +1,144 @@
+import { test } from '@japa/runner'
+import OnGameFinished from '#listeners/on_game_finished'
+import GameFinished from '#events/game_finished'
+import Achievement from '#models/achievement'
+import UserAchievement from '#models/user_achievement'
+import { AchievementType } from '#enums/achievement_type'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteAchievementProgress } from '#tests/utils/achievement_progress_helpers'
+
+async function seedAchievements(types: AchievementType[]) {
+  await Achievement.createMany(
+    types.map((type) => ({ type, name: type.toString(), description: 'd' }))
+  )
+}
+
+async function unlockedTypes(userId: string): Promise<AchievementType[]> {
+  const rows = await UserAchievement.query()
+    .where('user_id', userId)
+    .whereNotNull('unlocked_at')
+    .preload('achievement')
+  return rows.map((r) => r.achievement.type)
+}
+
+test.group('OnGameFinished listener', (group) => {
+  deleteAchievementProgress(group)
+
+  test('handles a basic finished session: FirstGame, GamesPlayed, TotalGamesPlayed unlocked at 1 step', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('ogf_basic')
+    await seedAchievements([
+      AchievementType.FirstGame,
+      AchievementType.GamesPlayed,
+      AchievementType.TotalGamesPlayed,
+    ])
+
+    const listener = new OnGameFinished()
+    await listener.handle(
+      new GameFinished({
+        userId: user.id,
+        gameId: 1,
+        score: 1,
+        maxScore: 5,
+        isPerfect: false,
+        durationMs: 30000,
+        correctAnswersCount: 0,
+      })
+    )
+
+    const types = await unlockedTypes(user.id)
+    assert.includeMembers(types, [AchievementType.FirstGame])
+    assert.notInclude(types, AchievementType.PerfectGame)
+    assert.notInclude(types, AchievementType.FastAnswer)
+
+    const gamesPlayed = await UserAchievement.query()
+      .where('user_id', user.id)
+      .whereHas('achievement', (q) => q.where('type', AchievementType.GamesPlayed))
+      .first()
+    assert.equal(gamesPlayed?.currentProgress, 1)
+  })
+
+  test('perfect game also unlocks FirstWin and PerfectGame', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('ogf_perfect')
+    await seedAchievements([
+      AchievementType.FirstGame,
+      AchievementType.GamesPlayed,
+      AchievementType.TotalGamesPlayed,
+      AchievementType.FirstWin,
+      AchievementType.PerfectGame,
+    ])
+
+    const listener = new OnGameFinished()
+    await listener.handle(
+      new GameFinished({
+        userId: user.id,
+        gameId: 1,
+        score: 5,
+        maxScore: 5,
+        isPerfect: true,
+        durationMs: 20000,
+        correctAnswersCount: 5,
+      })
+    )
+
+    const types = await unlockedTypes(user.id)
+    assert.includeMembers(types, [AchievementType.FirstWin, AchievementType.PerfectGame])
+  })
+
+  test('fastestAnswerMs under 3000 unlocks FastAnswer', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('ogf_fast')
+    await seedAchievements([
+      AchievementType.FirstGame,
+      AchievementType.GamesPlayed,
+      AchievementType.TotalGamesPlayed,
+      AchievementType.FastAnswer,
+    ])
+
+    const listener = new OnGameFinished()
+    await listener.handle(
+      new GameFinished({
+        userId: user.id,
+        gameId: 1,
+        score: 1,
+        maxScore: 5,
+        isPerfect: false,
+        durationMs: 30000,
+        fastestAnswerMs: 1500,
+        correctAnswersCount: 1,
+      })
+    )
+
+    const types = await unlockedTypes(user.id)
+    assert.include(types, AchievementType.FastAnswer)
+  })
+
+  test('correctAnswersCount accumulates on TotalCorrectAnswers', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('ogf_correct')
+    await seedAchievements([
+      AchievementType.FirstGame,
+      AchievementType.GamesPlayed,
+      AchievementType.TotalGamesPlayed,
+      AchievementType.TotalCorrectAnswers,
+    ])
+
+    const listener = new OnGameFinished()
+    await listener.handle(
+      new GameFinished({
+        userId: user.id,
+        gameId: 1,
+        score: 7,
+        maxScore: 10,
+        isPerfect: false,
+        durationMs: 30000,
+        correctAnswersCount: 7,
+      })
+    )
+
+    const totalCorrect = await UserAchievement.query()
+      .where('user_id', user.id)
+      .whereHas('achievement', (q) => q.where('type', AchievementType.TotalCorrectAnswers))
+      .first()
+    assert.equal(totalCorrect?.currentProgress, 7)
+  })
+})

--- a/backend/tests/unit/on_track_liked.spec.ts
+++ b/backend/tests/unit/on_track_liked.spec.ts
@@ -1,0 +1,63 @@
+import { test } from '@japa/runner'
+import OnTrackLiked from '#listeners/on_track_liked'
+import TrackLiked from '#events/track_liked'
+import Achievement from '#models/achievement'
+import UserAchievement from '#models/user_achievement'
+import { AchievementType } from '#enums/achievement_type'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteAchievementProgress } from '#tests/utils/achievement_progress_helpers'
+
+test.group('OnTrackLiked listener', (group) => {
+  deleteAchievementProgress(group)
+
+  test('first like unlocks FirstLike and increments TotalLikes', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('otl_first')
+    await Achievement.createMany([
+      { type: AchievementType.FirstLike, name: 'Premier pas', description: 'd' },
+      { type: AchievementType.TotalLikes, name: 'Mélomane', description: 'd' },
+    ])
+
+    const listener = new OnTrackLiked()
+    await listener.handle(
+      new TrackLiked({ userId: user.id, deezerTrackId: '42', deezerArtistId: '7' })
+    )
+
+    const firstLike = await UserAchievement.query()
+      .where('user_id', user.id)
+      .whereHas('achievement', (q) => q.where('type', AchievementType.FirstLike))
+      .first()
+    const totalLikes = await UserAchievement.query()
+      .where('user_id', user.id)
+      .whereHas('achievement', (q) => q.where('type', AchievementType.TotalLikes))
+      .first()
+
+    assert.isNotNull(firstLike?.unlockedAt ?? null)
+    assert.equal(totalLikes?.currentProgress, 1)
+    assert.isNull(totalLikes?.unlockedAt ?? null)
+  })
+
+  test('subsequent likes only increment TotalLikes (FirstLike stays unlocked)', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('otl_repeat')
+    await Achievement.createMany([
+      { type: AchievementType.FirstLike, name: 'Premier pas', description: 'd' },
+      { type: AchievementType.TotalLikes, name: 'Mélomane', description: 'd' },
+    ])
+
+    const listener = new OnTrackLiked()
+    await listener.handle(
+      new TrackLiked({ userId: user.id, deezerTrackId: '1', deezerArtistId: null })
+    )
+    await listener.handle(
+      new TrackLiked({ userId: user.id, deezerTrackId: '2', deezerArtistId: null })
+    )
+
+    const totalLikes = await UserAchievement.query()
+      .where('user_id', user.id)
+      .whereHas('achievement', (q) => q.where('type', AchievementType.TotalLikes))
+      .first()
+
+    assert.equal(totalLikes?.currentProgress, 2)
+  })
+})

--- a/backend/tests/utils/achievement_progress_helpers.ts
+++ b/backend/tests/utils/achievement_progress_helpers.ts
@@ -1,0 +1,22 @@
+import UserAchievement from '#models/user_achievement'
+import Achievement from '#models/achievement'
+import User from '#models/user'
+import { Group } from '@japa/runner/core'
+import { DateTime } from 'luxon'
+
+export function deleteAchievementProgress(group: Group) {
+  let testStartTime: DateTime
+
+  group.setup(() => {
+    testStartTime = DateTime.now()
+  })
+
+  group.each.teardown(async () => {
+    await UserAchievement.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+    await Achievement.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+  })
+
+  group.teardown(async () => {
+    await User.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+  })
+}


### PR DESCRIPTION
## Description

Met en place le système d'events AdonisJS et les listeners pour 10 achievements MVP. Les services métier existants (jeu, swipe, login) émettent désormais des events typés que des listeners écoutent pour incrémenter automatiquement les `UserAchievement` concernés. Ajoute aussi la colonne `users.last_login_at` nécessaire au tracking d'inactivité (achievement Comeback).

## Parcours utilisateur

1. **Migration** : démarrer le backend (migrations auto) ou lancer `just migrate` → la colonne `users.last_login_at` est ajoutée.
2. **Tester `game:finished`** :
   - Login via `POST /api/auth/login` pour récupérer un `accessToken`.
   - `POST /api/game-sessions` avec `status: "completed"`, `players: [{ userId, ... }]` et `gameData: { score: 5, maxScore: 5, answers: [{correct:true}, ...], timeElapsed: 30 }`.
   - `GET /api/user-achievements/me` → vérifier que `first_game`, `first_win`, `perfect_game` et `fast_answer` (si `durationMs < 3000`) sont débloqués ; `games_played` / `total_games_played` / `total_correct_answers` ont leur `currentProgress` incrémenté.
3. **Tester `track:liked`** :
   - `POST /api/me/swipemix/interactions` avec `{ "deezerTrackId": "3135556", "action": "liked" }`.
   - `GET /api/user-achievements/me` → `first_like` débloqué, `total_likes` à 1.
   - Re-poster le même like → `total_likes` reste à 1 (déduplication).
4. **Tester `auth:session-created` (Comeback)** :
   - En psql : `UPDATE users SET last_login_at = now() - interval '31 days' WHERE email = '<email>';`
   - Re-login → `GET /api/user-achievements/me` → `comeback` débloqué.
5. **Tests automatisés** : `just test backend` (498 tests verts) et `just coverage backend` (100% sur controllers + services).