### PR TITLE
MIX-321 fix: prevent test runner from wiping dev db and return single active session

### DIFF
--- a/backend/app/controllers/parkeur_controller.ts
+++ b/backend/app/controllers/parkeur_controller.ts
@@ -1,0 +1,56 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import logger from '@adonisjs/core/services/logger'
+import { ParkeurService, type ParkeurStartOptions } from '#services/parkeur_service'
+import { parkeurStartValidator } from '#validators/parkeur_validator'
+import { ApiBody, ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
+
+@inject()
+export default class ParkeurController {
+  constructor(private readonly parkeurService: ParkeurService) {}
+
+  @ApiOperation({
+    summary: 'Start a Parkeur game session',
+    description:
+      'Pre-loads 10 lyric rounds from a curated playlist or a Deezer artist top tracks (caching lyrics fetched from multiple sources) and creates the GameSession.',
+  })
+  @ApiSecurity('bearerAuth')
+  @ApiBody({
+    description: 'Parkeur start payload — exactly one of playlistId or artistId must be set',
+    required: true,
+    schema: {
+      type: 'object',
+      properties: {
+        playlistId: { type: 'integer', example: 1 },
+        artistId: { type: 'integer', example: 27 },
+      },
+    },
+  })
+  @ApiResponse({ status: 201, description: 'Parkeur session created with rounds' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Game, playlist or artist not found' })
+  @ApiResponse({ status: 409, description: 'An active Parkeur session already exists' })
+  @ApiResponse({ status: 422, description: 'Not enough playable lyrics for this selection' })
+  @ApiResponse({ status: 502, description: 'Failed to fetch source tracks' })
+  public async start({ auth, request, response }: HttpContext) {
+    const { playlistId, artistId } = await request.validateUsing(parkeurStartValidator)
+    if ((playlistId && artistId) || (!playlistId && !artistId)) {
+      return response.status(422).json({ message: 'Provide exactly one of playlistId or artistId' })
+    }
+    const userId = auth.user!.id
+    const options: ParkeurStartOptions = playlistId
+      ? { mode: 'playlist', playlistId }
+      : { mode: 'artist', artistId: artistId! }
+
+    try {
+      const result = await this.parkeurService.startSession(userId, options)
+      if ('error' in result) {
+        return response.status(result.status).json({ message: result.error })
+      }
+      return response.status(201).json(result)
+    } catch (error) {
+      logger.error({ err: error }, 'Failed to start Parkeur session')
+      return response.status(500).json({ message: 'Failed to start Parkeur session' })
+    }
+  }
+}

--- a/backend/app/services/curated_playlist_service.ts
+++ b/backend/app/services/curated_playlist_service.ts
@@ -165,7 +165,7 @@ export class CuratedPlaylistService {
     return (await response.json()) as DeezerPlaylistTracksResponse
   }
 
-  protected shuffle<T>(items: T[]): T[] {
+  public shuffle<T>(items: T[]): T[] {
     const copy = [...items]
     for (let i = copy.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1))

--- a/backend/app/services/game_session_service.ts
+++ b/backend/app/services/game_session_service.ts
@@ -221,7 +221,8 @@ export class GameSessionService {
   }
 
   public async getMyActiveSessionByGameId(userId: string, gameId: number) {
-    return this.getByUserIdAndGameId(userId, gameId, GameSessionStatus.Active)
+    const sessions = await this.getByUserIdAndGameId(userId, gameId, GameSessionStatus.Active)
+    return sessions[0] ?? null
   }
 
   private async emitGameFinished(gameSession: GameSession) {

--- a/backend/app/services/lyrics_service.ts
+++ b/backend/app/services/lyrics_service.ts
@@ -1,0 +1,368 @@
+import * as cheerio from 'cheerio'
+
+/**
+ * Lyrics aggregator inspired by https://github.com/NTag/lyrics.ovh.
+ * Queries multiple sources in parallel and returns the first valid result.
+ * No database cache — only an in-memory LRU so a fresh process pays the cold
+ * cost once per (artist, title) pair.
+ */
+
+const USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
+
+const FETCH_TIMEOUT_MS = 5000
+
+export interface LyricsFetchInput {
+  artist: string
+  title: string
+}
+
+export interface LyricsResult {
+  lines: string[]
+  source: string
+}
+
+type SourceFn = (title: string, artist: string) => Promise<string>
+
+const REJECT_PATTERNS = [
+  /no lyrics found/i,
+  /lyrics not available/i,
+  /we do not have the lyrics/i,
+  /submit lyrics/i,
+  /paroles introuvables/i,
+  /n[ãa]o possui letra/i,
+]
+
+export class LyricsService {
+  static cacheMax = 10_000
+  private static cache = new Map<string, LyricsResult>()
+
+  static clearCache() {
+    LyricsService.cache.clear()
+  }
+
+  /**
+   * Returns parsed lyric lines for a track, or null when no source has them.
+   * Public surface kept track-shaped (id is unused but tolerated) for callers
+   * that already pass Deezer track records.
+   */
+  async getLyricsForTrack(track: LyricsFetchInput & { id?: number }): Promise<LyricsResult | null> {
+    return this.findLyrics(track.title, track.artist)
+  }
+
+  protected sources(): Record<string, SourceFn> {
+    return {
+      genius: (t, a) => this.fromGenius(t, a),
+      azlyrics: (t, a) => this.fromAZLyrics(t, a),
+      paroles_net: (t, a) => this.fromParolesNet(t, a),
+      lyrics_mania: (t, a) => this.fromLyricsMania(t, a),
+      letras: (t, a) => this.fromLetras(t, a),
+      lyrics_com: (t, a) => this.fromLyricsCom(t, a),
+    }
+  }
+
+  protected async findLyrics(title: string, artist: string): Promise<LyricsResult | null> {
+    const key = `${artist.toLowerCase()}\n${title.toLowerCase()}`
+    const cached = LyricsService.cacheGet(key)
+    if (cached) return cached
+
+    const sources = this.sources()
+    const attempts: Promise<LyricsResult>[] = Object.entries(sources).map(([name, fn]) =>
+      fn(title, artist).then((raw) => ({ lines: this.parseLyrics(raw), source: name }))
+    )
+
+    if (/[(\[].*[)\]]/.test(title)) {
+      const cleanTitle = title
+        .replace(/\([^)]*\)/g, '')
+        .replace(/\[[^\]]*\]/g, '')
+        .trim()
+      if (cleanTitle && cleanTitle !== title) {
+        attempts.push(this.findLyrics(cleanTitle, artist).then((r) => r ?? Promise.reject()))
+      }
+    }
+
+    const primaryArtist = artist.split(/\s*(?:feat\.?|ft\.?|featuring|&|\/|,|;)\s*/i)[0].trim()
+    if (primaryArtist && primaryArtist.length > 1 && primaryArtist !== artist) {
+      attempts.push(this.findLyrics(title, primaryArtist).then((r) => r ?? Promise.reject()))
+    }
+
+    try {
+      const result = await Promise.any(attempts)
+      LyricsService.cacheSet(key, result)
+      return result
+    } catch {
+      return null
+    }
+  }
+
+  protected parseLyrics(raw: string): string[] {
+    return raw
+      .normalize('NFC')
+      .replace(/[\u0080-\u009F]/g, '')
+      .split(/\r?\n/)
+      .map((line) =>
+        line
+          .replace(/^\s*\d+\s*Contributors?.*?Lyrics/i, '')
+          .replace(/\[[^\]]*\]/g, '')
+          .trim()
+      )
+      .filter((line) => line.length > 0)
+  }
+
+  // ── HTTP plumbing ──────────────────────────────────────────────────────
+
+  protected async fetchHtml(
+    url: string,
+    options: { rejectRedirects?: boolean } = {}
+  ): Promise<cheerio.CheerioAPI> {
+    const res = await fetch(url, {
+      headers: { 'User-Agent': USER_AGENT },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    if (options.rejectRedirects && res.redirected) {
+      throw new Error('Redirected (likely no match)')
+    }
+    return cheerio.load(await res.text())
+  }
+
+  protected cleanLyrics(text: string): string {
+    text = text
+      .trim()
+      .replace(/\n{3,}/g, '\n\n')
+      .replace(/ +\n/g, '\n')
+    if (text.length < 20) throw new Error('No lyrics found')
+    if (text.length < 80 && REJECT_PATTERNS.some((re) => re.test(text))) {
+      throw new Error('Scraped error message, not lyrics')
+    }
+    return text
+  }
+
+  protected textln(el: cheerio.Cheerio<any>): string {
+    el.find('script').remove()
+    let html = el.html() as string
+    html = html.replace(/\s*<br\s*\/?>\s*/gi, '\n')
+    html = html.replace(/<[^>]+>/g, '')
+    html = html
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>')
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;/g, "'")
+      .replace(/&nbsp;/g, ' ')
+    html = html.replace(/\r\n/g, '\n').replace(/\t/g, '').replace(/ +/g, ' ')
+    html = html.replace(/\n /g, '\n').replace(/ \n/g, '\n')
+    return html.trim()
+  }
+
+  // ── Sources ────────────────────────────────────────────────────────────
+
+  protected async fromGenius(title: string, artist: string): Promise<string> {
+    const searchUrl =
+      'https://genius.com/api/search/multi?q=' + encodeURIComponent(`${artist} ${title}`)
+    const searchRes = await fetch(searchUrl, {
+      headers: { 'User-Agent': USER_AGENT },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    })
+    if (!searchRes.ok) throw new Error(`HTTP ${searchRes.status}`)
+    const data = (await searchRes.json()) as any
+    const songSection = (data?.response?.sections || []).find((s: any) => s.type === 'song')
+    const hits = songSection?.hits || []
+    const matching = hits.filter((h: any) => titleMatches(title, h.result?.title || ''))
+    if (matching.length === 0) throw new Error('No matching title')
+
+    let best = matching[0]
+    let bestScore = Number.POSITIVE_INFINITY
+    for (const hit of matching) {
+      const score = levenshtein(
+        artist.toLowerCase(),
+        (hit.result?.primary_artist?.name || '').toLowerCase()
+      )
+      if (score < bestScore) {
+        bestScore = score
+        best = hit
+      }
+    }
+
+    const $ = await this.fetchHtml(best.result.url)
+    const containers = $('[data-lyrics-container="true"]')
+    if (containers.length === 0) throw new Error('No lyrics container')
+    let lyrics = ''
+    containers.each((_, el) => {
+      const $el = $(el)
+      $el.find('br').replaceWith('\n')
+      lyrics += $el.text() + '\n'
+    })
+    return this.cleanLyrics(lyrics.trim())
+  }
+
+  protected async fromAZLyrics(title: string, artist: string): Promise<string> {
+    const a = stripToAlphaNum(deburr(artist)).replace(/^the/, '')
+    const s = stripToAlphaNum(deburr(title))
+    const $ = await this.fetchHtml(`https://www.azlyrics.com/lyrics/${a}/${s}.html`)
+    const divs = $('.col-xs-12.col-lg-8.text-center div')
+    let lyrics = ''
+    divs.each((_, el) => {
+      const $el = $(el)
+      if (!$el.attr('class') && !$el.attr('id') && $el.text().trim().length > 100) {
+        $el.find('br').replaceWith('\n')
+        lyrics = $el.text().trim()
+        return false
+      }
+    })
+    return this.cleanLyrics(lyrics)
+  }
+
+  protected async fromLetras(title: string, artist: string): Promise<string> {
+    const a = kebabCase(deburr(artist.trim()))
+    const s = kebabCase(deburr(title.trim()))
+    const $ = await this.fetchHtml(`https://www.letras.mus.br/${a}/${s}/`, {
+      rejectRedirects: true,
+    })
+    const els = $('.lyric-original p, .lyric-tra p')
+    if (els.length === 0) throw new Error('Not found')
+    let lyrics = ''
+    els.each((_, p) => {
+      const $p = $(p)
+      $p.find('br').replaceWith('\n')
+      lyrics += $p.text().trim() + '\n\n'
+    })
+    return this.cleanLyrics(lyrics.trim())
+  }
+
+  protected async fromLyricsCom(title: string, artist: string): Promise<string> {
+    const $search = await this.fetchHtml(
+      'https://www.lyrics.com/serp.php?st=' + encodeURIComponent(`${title} ${artist}`) + '&stype=1'
+    )
+    const results = $search('.sec-lyric.clearfix')
+    if (results.length === 0) throw new Error('No results')
+
+    let bestLink: string | null = null
+    let bestScore = Number.POSITIVE_INFINITY
+    results.each((_, el) => {
+      const $el = $search(el)
+      const resultArtist = $el.find('.lyric-meta-album-artist a').first().text()
+      const resultTitle = $el.find('a.lyric-meta-title').text()
+      const link = $el.find('a.lyric-meta-title').attr('href')
+      if (link && titleMatches(title, resultTitle)) {
+        const score = levenshtein(artist.toLowerCase(), resultArtist.toLowerCase())
+        if (score < bestScore) {
+          bestScore = score
+          bestLink = link
+        }
+      }
+    })
+    if (!bestLink) throw new Error('No matching result')
+    const url = (bestLink as string).startsWith('http')
+      ? (bestLink as string)
+      : 'https://www.lyrics.com' + (bestLink as string)
+    const $ = await this.fetchHtml(url)
+    const el = $('#lyric-body-text')
+    if (el.length === 0) throw new Error('Not found')
+    el.find('br').replaceWith('\n')
+    return this.cleanLyrics(el.text().trim())
+  }
+
+  protected async fromParolesNet(title: string, artist: string): Promise<string> {
+    const slug = (s: string) => kebabCase(deburr(s.trim().toLowerCase()))
+    const $ = await this.fetchHtml(
+      `https://www.paroles.net/${slug(artist)}/paroles-${slug(title)}`,
+      { rejectRedirects: true }
+    )
+    const el = $('.song-text')
+    if (el.length === 0) throw new Error('Not found')
+    el.find('h2').remove()
+    el.find('div[id], div[class]').remove()
+    return this.cleanLyrics(this.textln(el))
+  }
+
+  protected async fromLyricsMania(title: string, artist: string): Promise<string> {
+    const slug = (s: string) => snakeCase(deburr(s.trim().toLowerCase()))
+    const urls = [
+      `https://www.lyricsmania.com/${slug(title)}_lyrics_${slug(artist)}.html`,
+      `https://www.lyricsmania.com/${slug(title)}_${slug(artist)}.html`,
+    ]
+    return Promise.any(
+      urls.map(async (url) => {
+        const $ = await this.fetchHtml(url, { rejectRedirects: true })
+        if ($('.lyrics-body').length === 0) throw new Error('Not found')
+        return this.cleanLyrics(this.textln($('.lyrics-body')))
+      })
+    )
+  }
+
+  // ── LRU helpers ────────────────────────────────────────────────────────
+
+  private static cacheGet(key: string): LyricsResult | undefined {
+    const val = LyricsService.cache.get(key)
+    if (val === undefined) return undefined
+    LyricsService.cache.delete(key)
+    LyricsService.cache.set(key, val)
+    return val
+  }
+
+  private static cacheSet(key: string, val: LyricsResult): void {
+    LyricsService.cache.set(key, val)
+    while (LyricsService.cache.size > LyricsService.cacheMax) {
+      LyricsService.cache.delete(LyricsService.cache.keys().next().value!)
+    }
+  }
+}
+
+// ── String helpers (module-private) ──────────────────────────────────────
+
+function deburr(s: string): string {
+  return s.normalize('NFD').replace(/[̀-ͯ]/g, '')
+}
+
+function kebabCase(s: string): string {
+  return s
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .toLowerCase()
+}
+
+function snakeCase(s: string): string {
+  return s
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_|_$/g, '')
+    .toLowerCase()
+}
+
+function stripToAlphaNum(s: string): string {
+  return s.replace(/[^a-zA-Z0-9]/g, '').toLowerCase()
+}
+
+function levenshtein(a: string, b: string): number {
+  const m = a.length
+  const n = b.length
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0))
+  for (let i = 0; i <= m; i++) dp[i][0] = i
+  for (let j = 0; j <= n; j++) dp[0][j] = j
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1])
+    }
+  }
+  return dp[m][n]
+}
+
+function titleMatches(requested: string, found: string): boolean {
+  const normalize = (s: string) =>
+    deburr(s)
+      .toLowerCase()
+      .replace(/\(.*?\)/g, '')
+      .replace(/\[.*?\]/g, '')
+      .replace(/[^a-z0-9]/g, '')
+  const a = normalize(requested)
+  const b = normalize(found)
+  if (!a || !b) return false
+  if (a === b) return true
+  if (a.includes(b) || b.includes(a)) return true
+  const dist = levenshtein(a, b)
+  return dist / Math.max(a.length, b.length) <= 0.3
+}

--- a/backend/app/services/lyrics_service.ts
+++ b/backend/app/services/lyrics_service.ts
@@ -61,7 +61,11 @@ export class LyricsService {
     }
   }
 
-  protected async findLyrics(title: string, artist: string): Promise<LyricsResult | null> {
+  protected async findLyrics(
+    title: string,
+    artist: string,
+    allowFallbacks = true
+  ): Promise<LyricsResult | null> {
     const key = `${artist.toLowerCase()}\n${title.toLowerCase()}`
     const cached = LyricsService.cacheGet(key)
     if (cached) return cached
@@ -71,19 +75,28 @@ export class LyricsService {
       fn(title, artist).then((raw) => ({ lines: this.parseLyrics(raw), source: name }))
     )
 
-    if (/[(\[].*[)\]]/.test(title)) {
-      const cleanTitle = title
-        .replace(/\([^)]*\)/g, '')
-        .replace(/\[[^\]]*\]/g, '')
-        .trim()
-      if (cleanTitle && cleanTitle !== title) {
-        attempts.push(this.findLyrics(cleanTitle, artist).then((r) => r ?? Promise.reject()))
+    // Fallbacks (cleaned title / primary artist) recurse once at most: each
+    // variant calls findLyrics with allowFallbacks=false so we cap outbound
+    // calls at 3× the base 6-source fanout instead of multiplying combinatorially.
+    if (allowFallbacks) {
+      if (/[(\[].*[)\]]/.test(title)) {
+        const cleanTitle = title
+          .replace(/\([^)]*\)/g, '')
+          .replace(/\[[^\]]*\]/g, '')
+          .trim()
+        if (cleanTitle && cleanTitle !== title) {
+          attempts.push(
+            this.findLyrics(cleanTitle, artist, false).then((r) => r ?? Promise.reject())
+          )
+        }
       }
-    }
 
-    const primaryArtist = artist.split(/\s*(?:feat\.?|ft\.?|featuring|&|\/|,|;)\s*/i)[0].trim()
-    if (primaryArtist && primaryArtist.length > 1 && primaryArtist !== artist) {
-      attempts.push(this.findLyrics(title, primaryArtist).then((r) => r ?? Promise.reject()))
+      const primaryArtist = artist.split(/\s*(?:feat\.?|ft\.?|featuring|&|\/|,|;)\s*/i)[0].trim()
+      if (primaryArtist && primaryArtist.length > 1 && primaryArtist !== artist) {
+        attempts.push(
+          this.findLyrics(title, primaryArtist, false).then((r) => r ?? Promise.reject())
+        )
+      }
     }
 
     try {
@@ -141,7 +154,7 @@ export class LyricsService {
 
   protected textln(el: cheerio.Cheerio<any>): string {
     el.find('script').remove()
-    let html = el.html() as string
+    let html = el.html() ?? ''
     html = html.replace(/\s*<br\s*\/?>\s*/gi, '\n')
     html = html.replace(/<[^>]+>/g, '')
     html = html

--- a/backend/app/services/parkeur_service.ts
+++ b/backend/app/services/parkeur_service.ts
@@ -1,0 +1,212 @@
+import { DateTime } from 'luxon'
+import { inject } from '@adonisjs/core'
+import {
+  CuratedPlaylistService,
+  DeezerPlaylistFetchError,
+  DeezerPlaylistTrack,
+  PlaylistNotFoundError,
+} from '#services/curated_playlist_service'
+import { LyricsService } from '#services/lyrics_service'
+import { GameSessionService } from '#services/game_session_service'
+import GameSession from '#models/game_session'
+import Game from '#models/game'
+import { GameSessionStatus } from '#enums/game_session_status'
+
+export const PARKEUR_GAME_NAME = 'Parkeur'
+export const PARKEUR_TARGET_ROUNDS = 10
+export const PARKEUR_OVERSHOOT_FACTOR = 3
+const DEEZER_API_BASE = 'https://api.deezer.com'
+const DEEZER_ARTIST_TOP_LIMIT = 50
+
+export interface ParkeurRound {
+  trackId: number
+  artist: string
+  title: string
+  coverUrl: string | null
+  lines: [string, string]
+  answerLine: string
+}
+
+export interface ParkeurStartResult {
+  session: GameSession
+  rounds: ParkeurRound[]
+}
+
+export type ServiceError = { error: string; status: number }
+
+export type ParkeurStartOptions =
+  | { mode: 'playlist'; playlistId: number }
+  | { mode: 'artist'; artistId: number }
+
+interface SourceMeta {
+  playlistId?: number
+  playlistName?: string
+  artistId?: number
+  artistName?: string
+}
+
+interface ResolvedSource {
+  tracks: DeezerPlaylistTrack[]
+  meta: SourceMeta
+}
+
+@inject()
+export class ParkeurService {
+  constructor(
+    private readonly curatedPlaylistService: CuratedPlaylistService,
+    private readonly lyricsService: LyricsService,
+    private readonly gameSessionService: GameSessionService
+  ) {}
+
+  /**
+   * Pre-loads up to {@link PARKEUR_TARGET_ROUNDS} lyric rounds from either a curated
+   * playlist or a Deezer artist's top tracks (overshooting the track sample to absorb
+   * tracks without lyrics) and creates the GameSession. Returns 422 when too few
+   * playable rounds can be assembled.
+   */
+  async startSession(
+    userId: string,
+    options: ParkeurStartOptions
+  ): Promise<ParkeurStartResult | ServiceError> {
+    const game = await Game.findBy('name', PARKEUR_GAME_NAME)
+    if (!game || !game.isEnabled) {
+      return { error: 'Parkeur game is not available', status: 404 }
+    }
+
+    const sourceOrError = await this.resolveSource(options)
+    if ('error' in sourceOrError) return sourceOrError
+
+    const rounds = await this.buildRounds(sourceOrError.tracks)
+    if (rounds.length < PARKEUR_TARGET_ROUNDS) {
+      return {
+        error: 'Not enough playable lyrics for this selection. Try another one.',
+        status: 422,
+      }
+    }
+
+    const sessionResult = await this.gameSessionService.createGameSession({
+      gameId: game.id,
+      status: GameSessionStatus.Active,
+      players: [{ userId, status: 'active', score: 0, rank: 1 }],
+      gameData: {
+        ...sourceOrError.meta,
+        rounds,
+        currentRound: 0,
+        score: 0,
+        maxScore: rounds.length,
+        answers: [],
+        startedAt: DateTime.now().toISO(),
+        completedAt: null,
+        timeElapsed: 0,
+      },
+    })
+
+    if (!(sessionResult instanceof GameSession)) {
+      return sessionResult
+    }
+
+    return { session: sessionResult, rounds }
+  }
+
+  protected async resolveSource(
+    options: ParkeurStartOptions
+  ): Promise<ResolvedSource | ServiceError> {
+    if (options.mode === 'playlist') {
+      try {
+        const tracks = await this.curatedPlaylistService.getRandomTracks(
+          options.playlistId,
+          PARKEUR_TARGET_ROUNDS * PARKEUR_OVERSHOOT_FACTOR
+        )
+        const playlist = await this.curatedPlaylistService.findById(options.playlistId)
+        return {
+          tracks,
+          meta: { playlistId: options.playlistId, playlistName: playlist!.name },
+        }
+      } catch (error) {
+        if (error instanceof PlaylistNotFoundError) {
+          return { error: 'Curated playlist not found', status: 404 }
+        }
+        if (error instanceof DeezerPlaylistFetchError) {
+          return { error: 'Failed to load playlist tracks', status: 502 }
+        }
+        throw error
+      }
+    }
+    return this.resolveArtistSource(options.artistId)
+  }
+
+  protected async resolveArtistSource(artistId: number): Promise<ResolvedSource | ServiceError> {
+    let response: Response
+    try {
+      response = await fetch(
+        `${DEEZER_API_BASE}/artist/${artistId}/top?limit=${DEEZER_ARTIST_TOP_LIMIT}`
+      )
+    } catch {
+      return { error: 'Failed to load artist top tracks', status: 502 }
+    }
+    if (!response.ok) {
+      return { error: 'Failed to load artist top tracks', status: 502 }
+    }
+    const payload = (await response.json()) as {
+      data?: DeezerPlaylistTrack[]
+      error?: { code?: number; message?: string }
+    }
+    if (payload.error || !payload.data || payload.data.length === 0) {
+      return { error: 'Artist not found or has no top tracks', status: 404 }
+    }
+    return {
+      tracks: this.curatedPlaylistService.shuffle(payload.data),
+      meta: { artistId, artistName: payload.data[0].artist.name },
+    }
+  }
+
+  protected async buildRounds(tracks: DeezerPlaylistTrack[]): Promise<ParkeurRound[]> {
+    const rounds: ParkeurRound[] = []
+
+    // Process tracks in parallel batches and stop as soon as we have enough rounds.
+    // Best case (all tracks have lyrics): one batch ≈ 1-2s instead of 30 sequential
+    // calls. Worst case still bounded by tracks.length / PARKEUR_TARGET_ROUNDS batches.
+    for (
+      let i = 0;
+      i < tracks.length && rounds.length < PARKEUR_TARGET_ROUNDS;
+      i += PARKEUR_TARGET_ROUNDS
+    ) {
+      const batch = tracks.slice(i, i + PARKEUR_TARGET_ROUNDS)
+      const results = await Promise.allSettled(
+        batch.map(async (track) => ({
+          track,
+          lyrics: await this.lyricsService.getLyricsForTrack({
+            id: track.id,
+            artist: track.artist.name,
+            title: track.title,
+          }),
+        }))
+      )
+
+      for (const result of results) {
+        if (rounds.length >= PARKEUR_TARGET_ROUNDS) break
+        if (result.status === 'rejected') continue
+        const { track, lyrics } = result.value
+        if (!lyrics || lyrics.lines.length < 3) continue
+        rounds.push(this.pickRound(track, lyrics.lines))
+      }
+    }
+
+    return rounds
+  }
+
+  protected pickRound(track: DeezerPlaylistTrack, lines: string[]): ParkeurRound {
+    // Caller guarantees lines.length >= 3 — see buildRounds filter above.
+    const startIndex = Math.floor(Math.random() * (lines.length - 2))
+    return {
+      trackId: track.id,
+      artist: track.artist.name,
+      title: track.title,
+      coverUrl: track.album.cover_xl ?? track.album.cover_big ?? null,
+      lines: [lines[startIndex], lines[startIndex + 1]],
+      answerLine: lines[startIndex + 2],
+    }
+  }
+}
+
+export default ParkeurService

--- a/backend/app/services/parkeur_service.ts
+++ b/backend/app/services/parkeur_service.ts
@@ -17,6 +17,7 @@ export const PARKEUR_TARGET_ROUNDS = 10
 export const PARKEUR_OVERSHOOT_FACTOR = 3
 const DEEZER_API_BASE = 'https://api.deezer.com'
 const DEEZER_ARTIST_TOP_LIMIT = 50
+const DEEZER_FETCH_TIMEOUT_MS = 5000
 
 export interface ParkeurRound {
   trackId: number
@@ -139,7 +140,8 @@ export class ParkeurService {
     let response: Response
     try {
       response = await fetch(
-        `${DEEZER_API_BASE}/artist/${artistId}/top?limit=${DEEZER_ARTIST_TOP_LIMIT}`
+        `${DEEZER_API_BASE}/artist/${artistId}/top?limit=${DEEZER_ARTIST_TOP_LIMIT}`,
+        { signal: AbortSignal.timeout(DEEZER_FETCH_TIMEOUT_MS) }
       )
     } catch {
       return { error: 'Failed to load artist top tracks', status: 502 }

--- a/backend/app/validators/parkeur_validator.ts
+++ b/backend/app/validators/parkeur_validator.ts
@@ -1,0 +1,8 @@
+import vine from '@vinejs/vine'
+
+export const parkeurStartValidator = vine.compile(
+  vine.object({
+    playlistId: vine.number().min(1).optional(),
+    artistId: vine.number().min(1).optional(),
+  })
+)

--- a/backend/bin/test.ts
+++ b/backend/bin/test.ts
@@ -12,6 +12,36 @@
 
 process.env.NODE_ENV = 'test'
 
+/**
+ * Force the test database name before AdonisJS' env loader runs.
+ *
+ * docker-compose.override.yml mounts backend/.env as env_file, which pre-populates
+ * the container's process.env with DB_DATABASE=rythmix. AdonisJS uses dotenv to
+ * read .env.test and dotenv NEVER overrides existing process.env values — so the
+ * test runner would otherwise connect to (and wipe) the dev database.
+ *
+ * We only override DB_DATABASE: DB_HOST/PORT/USER/PASSWORD must keep whatever the
+ * environment already set (Docker uses host=database, GitHub Actions uses localhost).
+ */
+import { readFileSync, existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+const envTestPath = fileURLToPath(new URL('../.env.test', import.meta.url))
+if (existsSync(envTestPath)) {
+  for (const line of readFileSync(envTestPath, 'utf-8').split(/\r?\n/)) {
+    const match = line.match(/^\s*DB_DATABASE\s*=\s*(.*)$/)
+    if (!match) continue
+    let value = match[1].trim()
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1)
+    }
+    process.env.DB_DATABASE = value
+    break
+  }
+}
+
 import 'reflect-metadata'
 import { Ignitor, prettyPrintError } from '@adonisjs/core'
 import { configure, processCLIArgs, run } from '@japa/runner'

--- a/backend/database/seeders/game_seeder.ts
+++ b/backend/database/seeders/game_seeder.ts
@@ -50,7 +50,7 @@ export default class extends BaseSeeder {
         name: 'Parkeur',
         description: 'Complétez les paroles manquantes des chansons.',
         isMultiplayer: false,
-        isEnabled: false,
+        isEnabled: true,
       },
     ]
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -18,6 +18,7 @@
         "@adonisjs/mail": "^9.2.2",
         "@foadonis/openapi": "^0.4.1",
         "@vinejs/vine": "^3.0.1",
+        "cheerio": "^1.2.0",
         "edge.js": "^6.3.0",
         "luxon": "^3.7.1",
         "pg": "^8.16.3",
@@ -3911,6 +3912,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/bowser": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
@@ -4233,6 +4240,48 @@
       "license": "MIT",
       "engines": {
         "node": ">= 16"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/chevrotain": {
@@ -4673,6 +4722,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
@@ -4834,6 +4911,61 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -4977,6 +5109,31 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -4998,6 +5155,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -6178,6 +6347,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
@@ -7343,6 +7543,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -7609,6 +7821,55 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/path-browserify": {
@@ -9487,6 +9748,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -9622,6 +9892,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -69,6 +69,7 @@
     "@adonisjs/mail": "^9.2.2",
     "@foadonis/openapi": "^0.4.1",
     "@vinejs/vine": "^3.0.1",
+    "cheerio": "^1.2.0",
     "edge.js": "^6.3.0",
     "luxon": "^3.7.1",
     "pg": "^8.16.3",

--- a/backend/start/env.ts
+++ b/backend/start/env.ts
@@ -73,4 +73,11 @@ export default await Env.create(new URL('../', import.meta.url), {
   GOOGLE_CLIENT_ID: Env.schema.string(),
   GOOGLE_CLIENT_SECRET: Env.schema.string(),
   GOOGLE_CALLBACK_URL: Env.schema.string(),
+
+  /*
+  |----------------------------------------------------------
+  | Lyrics provider for the Parkeur game
+  |----------------------------------------------------------
+  */
+  LYRICS_OVH_BASE_URL: Env.schema.string.optional(),
 })

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -18,6 +18,7 @@ const GoogleAuthController = () => import('#controllers/google_auth_controller')
 const MeIntegrationsController = () => import('#controllers/me_integrations_controller')
 const OnboardingController = () => import('#controllers/onboarding_controller')
 const CuratedPlaylistsController = () => import('#controllers/curated_playlists_controller')
+const ParkeurController = () => import('#controllers/parkeur_controller')
 
 // Register OpenAPI/Swagger routes: /docs, /docs.json, /docs.yaml
 openapi.registerRoutes('/docs')
@@ -138,6 +139,7 @@ router
         router
           .get('/blindtest/playlists/:id/tracks', [CuratedPlaylistsController, 'tracks'])
           .use(middleware.auth())
+        router.post('/parkeur/start', [ParkeurController, 'start']).use(middleware.auth())
         router.get('/:id', [GamesController, 'show']).use(middleware.silentAuth())
         router.patch('/:id', [GamesController, 'update']).use(middleware.role({ roles: ['admin'] }))
         router

--- a/backend/tests/functional/parkeur_controller.spec.ts
+++ b/backend/tests/functional/parkeur_controller.spec.ts
@@ -1,0 +1,242 @@
+import { test } from '@japa/runner'
+import Game from '#models/game'
+import CuratedPlaylist from '#models/curated_playlist'
+import { createAuthenticatedUser } from '../utils/auth_helpers.js'
+import { CuratedPlaylistService } from '#services/curated_playlist_service'
+import { LyricsService } from '#services/lyrics_service'
+import { PARKEUR_GAME_NAME, PARKEUR_TARGET_ROUNDS } from '#services/parkeur_service'
+import { deleteCuratedPlaylists } from '#tests/utils/curated_playlist_helpers'
+import { deleteGameSession } from '#tests/utils/game_session_helpers'
+
+const SAMPLE_LYRICS = Array.from({ length: 25 }, (_, i) => `Ligne ${i + 1}`).join('\n')
+
+const AZ_HTML = `
+  <html><body>
+    <div class="col-xs-12 col-lg-8 text-center">
+      <div class="ringtone"></div>
+      <div>${SAMPLE_LYRICS.replace(/\n/g, '<br>') + '<br>line line line line line line line line'}</div>
+    </div>
+  </body></html>
+`
+
+const buildDeezerTrack = (id: number) => ({
+  id,
+  title: `Track ${id}`,
+  title_short: `Track ${id}`,
+  preview: `https://preview/${id}.mp3`,
+  duration: 30,
+  artist: { id: id * 10, name: `Artist ${id}` },
+  album: { id: id * 100, title: `Album ${id}` },
+})
+
+function fetchMock(handlers: { deezer?: () => Response; azSucceeds?: boolean }) {
+  return async (input: any) => {
+    const url = typeof input === 'string' ? input : (input as URL).toString()
+    if (url.includes('api.deezer.com') && handlers.deezer) return handlers.deezer()
+    if (url.includes('azlyrics.com')) {
+      return handlers.azSucceeds
+        ? new Response(AZ_HTML, { status: 200, headers: { 'Content-Type': 'text/html' } })
+        : new Response('not found', { status: 404 })
+    }
+    // Every other lyrics source returns 500 so Promise.any falls through.
+    return new Response('boom', { status: 500 })
+  }
+}
+
+test.group('ParkeurController - Functional', (group) => {
+  deleteCuratedPlaylists(group)
+  deleteGameSession(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(async () => {
+    originalFetch = globalThis.fetch
+    CuratedPlaylistService.clearCache()
+    LyricsService.clearCache()
+    await Game.updateOrCreate(
+      { name: PARKEUR_GAME_NAME },
+      {
+        name: PARKEUR_GAME_NAME,
+        description: 'Devine la suite des paroles',
+        isMultiplayer: false,
+        isEnabled: true,
+      }
+    )
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+    CuratedPlaylistService.clearCache()
+  })
+
+  test('POST /api/games/parkeur/start returns 401 when unauthenticated', async ({ client }) => {
+    const res = await client.post('/api/games/parkeur/start').json({ playlistId: 1 })
+    res.assertStatus(401)
+  })
+
+  test('POST /api/games/parkeur/start returns 422 when payload is invalid', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('parkeur_inv')
+    const res = await client
+      .post('/api/games/parkeur/start')
+      .bearerToken(token)
+      .json({ playlistId: 'not-a-number' })
+    res.assertStatus(422)
+  })
+
+  test('POST /api/games/parkeur/start creates session with 10 rounds on happy path', async ({
+    client,
+    assert,
+  }) => {
+    const { token } = await createAuthenticatedUser('parkeur_ok')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 8001,
+      name: 'Rap FR',
+      genreLabel: 'Rap FR',
+      coverUrl: null,
+    })
+
+    const tracks = Array.from({ length: 30 }, (_, i) => buildDeezerTrack(7000 + i))
+    globalThis.fetch = fetchMock({
+      deezer: () =>
+        new Response(JSON.stringify({ data: tracks, total: tracks.length }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      azSucceeds: true,
+    })
+
+    const res = await client
+      .post('/api/games/parkeur/start')
+      .bearerToken(token)
+      .json({ playlistId: playlist.id })
+
+    res.assertStatus(201)
+    const body = res.body()
+    assert.equal(body.rounds.length, PARKEUR_TARGET_ROUNDS)
+    assert.equal(body.session.gameData.maxScore, PARKEUR_TARGET_ROUNDS)
+    assert.equal(body.session.gameData.playlistId, playlist.id)
+  })
+
+  test('POST /api/games/parkeur/start returns 422 when lyrics are missing', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('parkeur_miss')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 8002,
+      name: 'Mostly instrumental',
+      genreLabel: 'Lounge',
+      coverUrl: null,
+    })
+
+    const tracks = Array.from({ length: 30 }, (_, i) => buildDeezerTrack(8000 + i))
+    globalThis.fetch = fetchMock({
+      deezer: () =>
+        new Response(JSON.stringify({ data: tracks, total: tracks.length }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      azSucceeds: false,
+    })
+
+    const res = await client
+      .post('/api/games/parkeur/start')
+      .bearerToken(token)
+      .json({ playlistId: playlist.id })
+
+    res.assertStatus(422)
+  })
+
+  test('POST /api/games/parkeur/start returns 404 when playlist does not exist', async ({
+    client,
+  }) => {
+    const { token } = await createAuthenticatedUser('parkeur_nopl')
+    const res = await client
+      .post('/api/games/parkeur/start')
+      .bearerToken(token)
+      .json({ playlistId: 999999 })
+    res.assertStatus(404)
+  })
+
+  test('POST /api/games/parkeur/start returns 500 when an unexpected error occurs', async ({
+    client,
+  }) => {
+    const { token } = await createAuthenticatedUser('parkeur_500')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 8003,
+      name: 'Crashing',
+      genreLabel: 'Rock',
+      coverUrl: null,
+    })
+
+    // Returning a 200 with invalid JSON triggers a SyntaxError in response.json(),
+    // which is not caught by curated_playlist_service and propagates up — exactly the
+    // unexpected-error path that parkeur_service rethrows and the controller renders as 500.
+    globalThis.fetch = async (input: any) => {
+      const url = typeof input === 'string' ? input : (input as URL).toString()
+      if (url.includes('api.deezer.com'))
+        return new Response('not-json', {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      throw new Error(`Unexpected URL ${url}`)
+    }
+
+    const res = await client
+      .post('/api/games/parkeur/start')
+      .bearerToken(token)
+      .json({ playlistId: playlist.id })
+
+    res.assertStatus(500)
+  })
+
+  test('POST /api/games/parkeur/start returns 422 when neither playlistId nor artistId is set', async ({
+    client,
+  }) => {
+    const { token } = await createAuthenticatedUser('parkeur_neither')
+    const res = await client.post('/api/games/parkeur/start').bearerToken(token).json({})
+    res.assertStatus(422)
+  })
+
+  test('POST /api/games/parkeur/start returns 422 when both playlistId and artistId are set', async ({
+    client,
+  }) => {
+    const { token } = await createAuthenticatedUser('parkeur_both')
+    const res = await client
+      .post('/api/games/parkeur/start')
+      .bearerToken(token)
+      .json({ playlistId: 1, artistId: 27 })
+    res.assertStatus(422)
+  })
+
+  test('POST /api/games/parkeur/start with artistId creates a session from Deezer top tracks', async ({
+    client,
+    assert,
+  }) => {
+    const { token } = await createAuthenticatedUser('parkeur_artist_func')
+    const tracks = Array.from({ length: 30 }, (_, i) => ({
+      id: 6000 + i,
+      title: `Track ${i}`,
+      title_short: `Track ${i}`,
+      preview: `https://preview/${i}.mp3`,
+      duration: 30,
+      artist: { id: 27, name: 'Stromae' },
+      album: { id: i + 1, title: `Album ${i}` },
+    }))
+    globalThis.fetch = fetchMock({
+      deezer: () =>
+        new Response(JSON.stringify({ data: tracks }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      azSucceeds: true,
+    })
+
+    const res = await client
+      .post('/api/games/parkeur/start')
+      .bearerToken(token)
+      .json({ artistId: 27 })
+
+    res.assertStatus(201)
+    const body = res.body() as any
+    assert.equal(body.session.gameData.artistId, 27)
+    assert.equal(body.session.gameData.artistName, 'Stromae')
+  })
+})

--- a/backend/tests/unit/game_session_service.spec.ts
+++ b/backend/tests/unit/game_session_service.spec.ts
@@ -674,9 +674,18 @@ test.group('GameSessionService - Unit CRUD', (group) => {
       gameData: {},
     })
 
-    const sessions = await service.getMyActiveSessionByGameId(userId, game.id)
-    assert.equal(sessions.length, 1)
-    assert.equal(sessions[0].id, activeSession.id)
+    const session = await service.getMyActiveSessionByGameId(userId, game.id)
+    assert.isNotNull(session)
+    assert.equal(session!.id, activeSession.id)
+  })
+
+  test('getMyActiveSessionByGameId returns null when no active session exists', async ({
+    assert,
+  }) => {
+    const game = await createTestGame('no_active')
+    const userId = `user-no-active-${Date.now()}`
+    const session = await service.getMyActiveSessionByGameId(userId, game.id)
+    assert.isNull(session)
   })
 
   test('JSON fields are properly serialized and deserialized', async ({ assert }) => {

--- a/backend/tests/unit/lyrics_service.spec.ts
+++ b/backend/tests/unit/lyrics_service.spec.ts
@@ -1,4 +1,5 @@
 import { test } from '@japa/runner'
+import type * as cheerio from 'cheerio'
 import { LyricsService } from '#services/lyrics_service'
 
 const FAKE_LYRICS = [
@@ -645,13 +646,13 @@ test.group('LyricsService — multi-source aggregator', (group) => {
   test('textln returns an empty string when the selection has no matched elements', async ({
     assert,
   }) => {
-    const cheerio = await import('cheerio')
+    const cheerioMod = await import('cheerio')
     class ExposedLyricsService extends LyricsService {
       public textlnPublic(el: cheerio.Cheerio<any>) {
         return this.textln(el)
       }
     }
-    const $ = cheerio.load('<html><body></body></html>')
+    const $ = cheerioMod.load('<html><body></body></html>')
     const exposed = new ExposedLyricsService()
     assert.equal(exposed.textlnPublic($('does-not-exist')), '')
   })

--- a/backend/tests/unit/lyrics_service.spec.ts
+++ b/backend/tests/unit/lyrics_service.spec.ts
@@ -1,0 +1,663 @@
+import { test } from '@japa/runner'
+import { LyricsService } from '#services/lyrics_service'
+
+const FAKE_LYRICS = [
+  'Première ligne du couplet',
+  'Deuxième ligne du couplet',
+  '',
+  'Troisième ligne, plus longue, pour valider la longueur minimum',
+].join('\n')
+
+const GENIUS_PAGE_HTML = `
+  <html><body>
+    <div data-lyrics-container="true">${FAKE_LYRICS.replace(/\n/g, '<br>')}</div>
+  </body></html>
+`
+
+const AZ_HTML = `
+  <html><body>
+    <div class="col-xs-12 col-lg-8 text-center">
+      <div class="ringtone"></div>
+      <div>${FAKE_LYRICS.replace(/\n/g, '<br>') + '<br>extra padding to pass length filter'.repeat(5)}</div>
+    </div>
+  </body></html>
+`
+
+const PAROLES_HTML = `
+  <html><body>
+    <div class="song-text">
+      <h2>Title</h2>
+      <div id="ad"></div>
+      ${FAKE_LYRICS.replace(/\n/g, '<br>')}
+    </div>
+  </body></html>
+`
+
+const LETRAS_HTML = `
+  <html><body>
+    <div class="lyric-original">
+      <p>${FAKE_LYRICS.split('\n').slice(0, 2).join('<br>')}</p>
+      <p>${FAKE_LYRICS.split('\n').slice(2).join('<br>')}</p>
+    </div>
+  </body></html>
+`
+
+const LYRICSCOM_SEARCH_HTML = `
+  <html><body>
+    <div class="sec-lyric clearfix">
+      <a class="lyric-meta-title" href="/lyric/123/Some+Track">Some Track</a>
+      <div class="lyric-meta-album-artist"><a>Some Artist</a></div>
+    </div>
+  </body></html>
+`
+
+const LYRICSCOM_SONG_HTML = `
+  <html><body>
+    <pre id="lyric-body-text">${FAKE_LYRICS.replace(/\n/g, '<br>')}</pre>
+  </body></html>
+`
+
+const MANIA_HTML = `
+  <html><body>
+    <div class="lyrics-body">${FAKE_LYRICS.replace(/\n/g, '<br>')}</div>
+  </body></html>
+`
+
+const GENIUS_SEARCH_JSON = {
+  response: {
+    sections: [
+      {
+        type: 'song',
+        hits: [
+          {
+            result: {
+              title: 'Some Track',
+              primary_artist: { name: 'Some Artist' },
+              url: 'https://genius.com/some-track-lyrics',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+
+function htmlResponse(body: string, init: ResponseInit = {}): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'Content-Type': 'text/html' },
+    ...init,
+  })
+}
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+type Routes = Array<{ match: RegExp; respond: () => Response | Promise<Response> }>
+
+function fetchRouter(routes: Routes) {
+  return async (input: any) => {
+    const url = typeof input === 'string' ? input : (input as URL | Request).toString()
+    for (const r of routes) {
+      if (r.match.test(url)) return r.respond()
+    }
+    throw new Error(`Unrouted URL: ${url}`)
+  }
+}
+
+test.group('LyricsService — multi-source aggregator', (group) => {
+  let service: LyricsService
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    service = new LyricsService()
+    LyricsService.clearCache()
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('returns lines from Genius when it responds first', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /genius\.com\/api\/search/, respond: () => jsonResponse(GENIUS_SEARCH_JSON) },
+      { match: /genius\.com\/some-track/, respond: () => htmlResponse(GENIUS_PAGE_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'genius')
+    assert.isAtLeast(result!.lines.length, 3)
+  })
+
+  test('falls through to AZLyrics when Genius fails', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /genius\.com/, respond: () => new Response('boom', { status: 500 }) },
+      { match: /azlyrics\.com/, respond: () => htmlResponse(AZ_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'azlyrics')
+  })
+
+  test('parses Paroles.net successfully', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /paroles\.net/, respond: () => htmlResponse(PAROLES_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'Artiste', title: 'Titre' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'paroles_net')
+  })
+
+  test('parses Letras.mus.br successfully', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /letras\.mus\.br/, respond: () => htmlResponse(LETRAS_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'Artista', title: 'Cancao' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'letras')
+  })
+
+  test('parses Lyrics.com via search + song page', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /lyrics\.com\/serp\.php/, respond: () => htmlResponse(LYRICSCOM_SEARCH_HTML) },
+      { match: /lyrics\.com\/lyric/, respond: () => htmlResponse(LYRICSCOM_SONG_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'lyrics_com')
+  })
+
+  test('parses LyricsMania successfully', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /lyricsmania\.com/, respond: () => htmlResponse(MANIA_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'lyrics_mania')
+  })
+
+  test('returns null when every source fails', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'Nope', title: 'Never' })
+    assert.isNull(result)
+  })
+
+  test('uses in-memory LRU cache on subsequent calls', async ({ assert }) => {
+    let calls = 0
+    globalThis.fetch = fetchRouter([
+      {
+        match: /azlyrics\.com/,
+        respond: () => {
+          calls += 1
+          return htmlResponse(AZ_HTML)
+        },
+      },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    await service.getLyricsForTrack({ artist: 'Cached', title: 'Track' })
+    const after1 = calls
+    const second = await service.getLyricsForTrack({ artist: 'Cached', title: 'Track' })
+    assert.equal(calls, after1)
+    assert.isNotNull(second)
+  })
+
+  test('falls back to a cleaned title when the original has parentheses', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      // Original title (with parens) → all sources 404; cleaned title → Paroles works.
+      {
+        match: /paroles\.net\/some-artist\/paroles-some-track-radio-edit/,
+        respond: () => new Response('not found', { status: 404 }),
+      },
+      {
+        match: /paroles\.net\/some-artist\/paroles-some-track/,
+        respond: () => htmlResponse(PAROLES_HTML),
+      },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({
+      artist: 'Some Artist',
+      title: 'Some Track (Radio Edit)',
+    })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'paroles_net')
+  })
+
+  test('falls back to the primary artist when the artist contains a feat.', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      // Full artist string fails on every source...
+      {
+        match: /paroles\.net\/some-artist-feat-other\/paroles-track/,
+        respond: () => new Response('not found', { status: 404 }),
+      },
+      // ...but the primary artist alone works on Paroles.
+      {
+        match: /paroles\.net\/some-artist\/paroles-track/,
+        respond: () => htmlResponse(PAROLES_HTML),
+      },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({
+      artist: 'Some Artist feat. Other',
+      title: 'Track',
+    })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'paroles_net')
+  })
+
+  test('handles absolute href URLs returned by Lyrics.com search', async ({ assert }) => {
+    const searchHtmlAbsoluteHref = `
+      <html><body>
+        <div class="sec-lyric clearfix">
+          <a class="lyric-meta-title" href="https://www.lyrics.com/lyric/999/Track">Some Track</a>
+          <div class="lyric-meta-album-artist"><a>Some Artist</a></div>
+        </div>
+      </body></html>
+    `
+    globalThis.fetch = fetchRouter([
+      { match: /lyrics\.com\/serp\.php/, respond: () => htmlResponse(searchHtmlAbsoluteHref) },
+      { match: /lyrics\.com\/lyric\/999/, respond: () => htmlResponse(LYRICSCOM_SONG_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'lyrics_com')
+  })
+
+  test('matches titles via Levenshtein when neither is a substring of the other', async ({
+    assert,
+  }) => {
+    // Genius response titled "Some Trakk" (1-letter typo) — Levenshtein covers it.
+    const fuzzyGeniusJson = {
+      response: {
+        sections: [
+          {
+            type: 'song',
+            hits: [
+              {
+                result: {
+                  title: 'Some Trakk',
+                  primary_artist: { name: 'Some Artist' },
+                  url: 'https://genius.com/some-track-lyrics',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }
+    globalThis.fetch = fetchRouter([
+      { match: /genius\.com\/api\/search/, respond: () => jsonResponse(fuzzyGeniusJson) },
+      { match: /genius\.com\/some-track/, respond: () => htmlResponse(GENIUS_PAGE_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'genius')
+  })
+
+  test('evicts oldest cache entry when cacheMax is exceeded', async ({ assert }) => {
+    const previousMax = LyricsService.cacheMax
+    LyricsService.cacheMax = 2
+    try {
+      globalThis.fetch = fetchRouter([
+        { match: /azlyrics\.com/, respond: () => htmlResponse(AZ_HTML) },
+        { match: /./, respond: () => new Response('boom', { status: 500 }) },
+      ])
+      await service.getLyricsForTrack({ artist: 'A', title: 'T1' })
+      await service.getLyricsForTrack({ artist: 'A', title: 'T2' })
+      await service.getLyricsForTrack({ artist: 'A', title: 'T3' })
+
+      // T1 should have been evicted (oldest), so it'll be re-fetched. Mock now refuses
+      // to serve AZLyrics: the call should still re-trigger sources (and fail).
+      globalThis.fetch = fetchRouter([
+        { match: /./, respond: () => new Response('boom', { status: 500 }) },
+      ])
+      const result = await service.getLyricsForTrack({ artist: 'A', title: 'T1' })
+      assert.isNull(result)
+    } finally {
+      LyricsService.cacheMax = previousMax
+    }
+  })
+
+  test('rejects scraped pages whose body is too short to be lyrics', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      {
+        match: /paroles\.net/,
+        respond: () =>
+          htmlResponse('<html><body><div class="song-text">no lyrics found</div></body></html>'),
+      },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+
+    const result = await service.getLyricsForTrack({ artist: 'X', title: 'Y' })
+    assert.isNull(result)
+  })
+
+  test('rejects medium-length placeholder messages matching REJECT_PATTERNS', async ({
+    assert,
+  }) => {
+    // Body is long enough to skip the < 20 guard but still short and obviously a placeholder.
+    globalThis.fetch = fetchRouter([
+      {
+        match: /paroles\.net/,
+        respond: () =>
+          htmlResponse(
+            '<html><body><div class="song-text">no lyrics found in our database for this song</div></body></html>'
+          ),
+      },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'X', title: 'Y' })
+    assert.isNull(result)
+  })
+
+  test('returns null when Genius search returns malformed JSON without a song section', async ({
+    assert,
+  }) => {
+    globalThis.fetch = fetchRouter([
+      // Empty response object → data?.response?.sections is undefined → || [] kicks in.
+      { match: /genius\.com\/api\/search/, respond: () => jsonResponse({}) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'Nope', title: 'Never' })
+    assert.isNull(result)
+  })
+
+  test('skips LyricsMania pages without a .lyrics-body container', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      // Both URLs return valid HTML but no .lyrics-body — should fall through.
+      { match: /lyricsmania\.com/, respond: () => htmlResponse('<html><body></body></html>') },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'A', title: 'B' })
+    assert.isNull(result)
+  })
+
+  test('treats one-string-contains-the-other as a title match', async ({ assert }) => {
+    // Found title "Some Track Remix" includes "Some Track" → covers the substring branch.
+    const containsJson = {
+      response: {
+        sections: [
+          {
+            type: 'song',
+            hits: [
+              {
+                result: {
+                  title: 'Some Track Remix',
+                  primary_artist: { name: 'Some Artist' },
+                  url: 'https://genius.com/some-track-lyrics',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }
+    globalThis.fetch = fetchRouter([
+      { match: /genius\.com\/api\/search/, respond: () => jsonResponse(containsJson) },
+      { match: /genius\.com\/some-track/, respond: () => htmlResponse(GENIUS_PAGE_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'genius')
+  })
+
+  test('rejects matches when the requested title normalises to an empty string', async ({
+    assert,
+  }) => {
+    // "(...)" has only parenthetical content → normalize() returns "" → titleMatches false.
+    const punctOnlyJson = {
+      response: {
+        sections: [
+          {
+            type: 'song',
+            hits: [
+              {
+                result: {
+                  title: 'Real Title',
+                  primary_artist: { name: 'Some Artist' },
+                  url: 'https://genius.com/real-title',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }
+    globalThis.fetch = fetchRouter([
+      { match: /genius\.com\/api\/search/, respond: () => jsonResponse(punctOnlyJson) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: '(...)' })
+    assert.isNull(result)
+  })
+
+  test('skips Letras pages without lyric paragraphs', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /letras\.mus\.br/, respond: () => htmlResponse('<html><body></body></html>') },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'X', title: 'Y' })
+    assert.isNull(result)
+  })
+
+  test('skips Lyrics.com when the search has no results', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      {
+        match: /lyrics\.com\/serp\.php/,
+        respond: () => htmlResponse('<html><body></body></html>'),
+      },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'X', title: 'Y' })
+    assert.isNull(result)
+  })
+
+  test('skips Lyrics.com when search results all have non-matching titles', async ({ assert }) => {
+    const noMatchHtml = `
+      <html><body>
+        <div class="sec-lyric clearfix">
+          <a class="lyric-meta-title" href="/lyric/1/Other">Totally Different Title</a>
+          <div class="lyric-meta-album-artist"><a>Some Artist</a></div>
+        </div>
+      </body></html>
+    `
+    globalThis.fetch = fetchRouter([
+      { match: /lyrics\.com\/serp\.php/, respond: () => htmlResponse(noMatchHtml) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNull(result)
+  })
+
+  test('skips Lyrics.com when the song page has no #lyric-body-text', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /lyrics\.com\/serp\.php/, respond: () => htmlResponse(LYRICSCOM_SEARCH_HTML) },
+      { match: /lyrics\.com\/lyric/, respond: () => htmlResponse('<html><body></body></html>') },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNull(result)
+  })
+
+  test('skips Paroles.net when the .song-text container is missing', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /paroles\.net/, respond: () => htmlResponse('<html><body></body></html>') },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'X', title: 'Y' })
+    assert.isNull(result)
+  })
+
+  test('falls back recursively even when both fallbacks return null', async ({ assert }) => {
+    // Title with parens + feat artist forces both fallback branches; every source fails so
+    // each recursive findLyrics call also resolves to null (covering the `r ?? Promise.reject()`
+    // null branch on both fallbacks).
+    globalThis.fetch = fetchRouter([
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({
+      artist: 'Main Artist feat. Other',
+      title: 'Track (Edit)',
+    })
+    assert.isNull(result)
+  })
+
+  test('falls back to empty primary_artist name when missing on Genius hit', async ({ assert }) => {
+    // Hit has matching title but no primary_artist — covers `(... || '').toLowerCase()`.
+    const noArtistJson = {
+      response: {
+        sections: [
+          {
+            type: 'song',
+            hits: [{ result: { title: 'Track', url: 'https://genius.com/track' } }],
+          },
+        ],
+      },
+    }
+    globalThis.fetch = fetchRouter([
+      { match: /genius\.com\/api\/search/, respond: () => jsonResponse(noArtistJson) },
+      { match: /genius\.com\/track/, respond: () => htmlResponse(GENIUS_PAGE_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'A', title: 'Track' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'genius')
+  })
+
+  test('rejects Genius pages with no lyrics container', async ({ assert }) => {
+    globalThis.fetch = fetchRouter([
+      { match: /genius\.com\/api\/search/, respond: () => jsonResponse(GENIUS_SEARCH_JSON) },
+      {
+        match: /genius\.com\/some-track/,
+        respond: () => htmlResponse('<html><body></body></html>'),
+      },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNull(result)
+  })
+
+  test('drops Genius hits whose result has no title field', async ({ assert }) => {
+    // Hit with an empty result object → titleMatches gets '' → filtered out → no matches.
+    const noTitleJson = {
+      response: {
+        sections: [{ type: 'song', hits: [{ result: { primary_artist: { name: 'A' } } }] }],
+      },
+    }
+    globalThis.fetch = fetchRouter([
+      { match: /genius\.com\/api\/search/, respond: () => jsonResponse(noTitleJson) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'A', title: 'B' })
+    assert.isNull(result)
+  })
+
+  test('picks the closest artist among multiple matching Genius hits', async ({ assert }) => {
+    // Two hits with matching titles but different artist closeness — we should land on the
+    // closer one (covers both branches of the score-comparison loop).
+    const multiHitJson = {
+      response: {
+        sections: [
+          {
+            type: 'song',
+            hits: [
+              {
+                result: {
+                  title: 'Some Track',
+                  primary_artist: { name: 'Wrong Person Entirely' },
+                  url: 'https://genius.com/wrong',
+                },
+              },
+              {
+                result: {
+                  title: 'Some Track',
+                  primary_artist: { name: 'Some Artist' },
+                  url: 'https://genius.com/right',
+                },
+              },
+            ],
+          },
+        ],
+      },
+    }
+    globalThis.fetch = fetchRouter([
+      { match: /genius\.com\/api\/search/, respond: () => jsonResponse(multiHitJson) },
+      { match: /genius\.com\/right/, respond: () => htmlResponse(GENIUS_PAGE_HTML) },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'Some Artist', title: 'Some Track' })
+    assert.isNotNull(result)
+    assert.equal(result!.source, 'genius')
+  })
+
+  test('parseLyrics strips section markers, Genius header, and C1 control chars', ({ assert }) => {
+    class ExposedLyricsService extends LyricsService {
+      public parseLyricsPublic(raw: string) {
+        return this.parseLyrics(raw)
+      }
+    }
+    const exposed = new ExposedLyricsService()
+    const raw = [
+      '21 ContributorsTranslationsEnglishMiroirs Lyrics[Paroles de "Miroirs"]',
+      '[Couplet 1]',
+      'Première ligne avec un caractère de contrôle',
+      '[Refrain]',
+      'Deuxième ligne valide',
+      'Yeah [hook] suite',
+      '   ',
+    ].join('\n')
+
+    const lines = exposed.parseLyricsPublic(raw)
+    assert.deepEqual(lines, [
+      'Première ligne avec un caractère de contrôle',
+      'Deuxième ligne valide',
+      'Yeah  suite',
+    ])
+  })
+
+  test('rejects redirected responses when rejectRedirects is set', async ({ assert }) => {
+    // Letras passes rejectRedirects: true. We craft a Response with redirected=true
+    // (Response constructor doesn't expose that flag, so we override it).
+    const redirectedRes = () => {
+      const r = new Response('<html></html>', {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      })
+      Object.defineProperty(r, 'redirected', { value: true, configurable: true })
+      return r
+    }
+    globalThis.fetch = fetchRouter([
+      { match: /letras\.mus\.br/, respond: () => redirectedRes() },
+      { match: /./, respond: () => new Response('boom', { status: 500 }) },
+    ])
+    const result = await service.getLyricsForTrack({ artist: 'X', title: 'Y' })
+    assert.isNull(result)
+  })
+})

--- a/backend/tests/unit/lyrics_service.spec.ts
+++ b/backend/tests/unit/lyrics_service.spec.ts
@@ -642,6 +642,20 @@ test.group('LyricsService — multi-source aggregator', (group) => {
     ])
   })
 
+  test('textln returns an empty string when the selection has no matched elements', async ({
+    assert,
+  }) => {
+    const cheerio = await import('cheerio')
+    class ExposedLyricsService extends LyricsService {
+      public textlnPublic(el: cheerio.Cheerio<any>) {
+        return this.textln(el)
+      }
+    }
+    const $ = cheerio.load('<html><body></body></html>')
+    const exposed = new ExposedLyricsService()
+    assert.equal(exposed.textlnPublic($('does-not-exist')), '')
+  })
+
   test('rejects redirected responses when rejectRedirects is set', async ({ assert }) => {
     // Letras passes rejectRedirects: true. We craft a Response with redirected=true
     // (Response constructor doesn't expose that flag, so we override it).

--- a/backend/tests/unit/parkeur_service.spec.ts
+++ b/backend/tests/unit/parkeur_service.spec.ts
@@ -1,0 +1,385 @@
+import { test } from '@japa/runner'
+import Game from '#models/game'
+import GameSession from '#models/game_session'
+import CuratedPlaylist from '#models/curated_playlist'
+import { GameSessionService } from '#services/game_session_service'
+import { LyricsService, type LyricsResult } from '#services/lyrics_service'
+import { CuratedPlaylistService } from '#services/curated_playlist_service'
+import { PARKEUR_GAME_NAME, PARKEUR_TARGET_ROUNDS, ParkeurService } from '#services/parkeur_service'
+import { GameSessionStatus } from '#enums/game_session_status'
+import { createAuthenticatedUser } from '../utils/auth_helpers.js'
+import { deleteCuratedPlaylists } from '#tests/utils/curated_playlist_helpers'
+import { deleteGameSession } from '#tests/utils/game_session_helpers'
+
+const SAMPLE_LINES = Array.from({ length: 25 }, (_, i) => `Ligne ${i + 1}`)
+
+class FakeLyricsService extends LyricsService {
+  private calls = 0
+  constructor(
+    private behavior: 'success' | 'fail' | 'mixed' | 'throw' | 'first-half-fail' = 'success'
+  ) {
+    super()
+  }
+
+  async getLyricsForTrack(_track: {
+    id?: number
+    artist: string
+    title: string
+  }): Promise<LyricsResult | null> {
+    this.calls += 1
+    if (this.behavior === 'fail') return null
+    if (this.behavior === 'throw') throw new Error('boom')
+    if (this.behavior === 'mixed') {
+      // Deterministic: every 4th call throws, every 3rd returns null, rest succeed.
+      // With batches of 10 we still average ~5 successes per batch.
+      if (this.calls % 4 === 0) throw new Error('boom')
+      if (this.calls % 3 === 0) return null
+    }
+    if (this.behavior === 'first-half-fail') {
+      // Calls 1-5 return null, calls 6+ all succeed. Batch 1 yields 5 (rounds=5),
+      // batch 2 would yield 10 — exercises the inner break that caps rounds at target.
+      if (this.calls <= 5) return null
+    }
+    return { lines: [...SAMPLE_LINES], source: 'fake' }
+  }
+}
+
+const buildDeezerTrack = (id: number) => ({
+  id,
+  title: `Track ${id}`,
+  title_short: `Track ${id}`,
+  preview: `https://preview/${id}.mp3`,
+  duration: 30,
+  artist: { id: id * 10, name: `Artist ${id}` },
+  album: { id: id * 100, title: `Album ${id}` },
+})
+
+function deezerFetchMock(response: () => Response) {
+  return async (input: any) => {
+    const url = typeof input === 'string' ? input : (input as URL).toString()
+    if (url.includes('api.deezer.com')) return response()
+    throw new Error(`Unexpected URL ${url}`)
+  }
+}
+
+function makeService(lyrics: LyricsService = new FakeLyricsService('success')) {
+  return new ParkeurService(new CuratedPlaylistService(), lyrics, new GameSessionService())
+}
+
+test.group('ParkeurService', (group) => {
+  deleteCuratedPlaylists(group)
+  deleteGameSession(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(async () => {
+    originalFetch = globalThis.fetch
+    CuratedPlaylistService.clearCache()
+    LyricsService.clearCache()
+    await Game.updateOrCreate(
+      { name: PARKEUR_GAME_NAME },
+      {
+        name: PARKEUR_GAME_NAME,
+        description: 'Devine la suite des paroles',
+        isMultiplayer: false,
+        isEnabled: true,
+      }
+    )
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+    CuratedPlaylistService.clearCache()
+  })
+
+  test('startSession builds 10 rounds and creates a Parkeur GameSession', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('parkeur_happy')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 9001,
+      name: 'Rap FR',
+      genreLabel: 'Rap FR',
+      coverUrl: null,
+    })
+
+    const tracks = Array.from({ length: 30 }, (_, i) => buildDeezerTrack(i + 1))
+    globalThis.fetch = deezerFetchMock(
+      () =>
+        new Response(JSON.stringify({ data: tracks, total: tracks.length }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+
+    const result = await makeService().startSession(user.id, {
+      mode: 'playlist',
+      playlistId: playlist.id,
+    })
+    assert.notProperty(result, 'error')
+    if ('error' in result) throw new Error('expected success')
+    assert.lengthOf(result.rounds, PARKEUR_TARGET_ROUNDS)
+    for (const round of result.rounds) {
+      assert.lengthOf(round.lines, 2)
+      assert.isString(round.answerLine)
+      assert.notInclude([...round.lines, round.answerLine], '')
+    }
+    assert.equal(result.session.status, GameSessionStatus.Active)
+    assert.equal((result.session.gameData as any).playlistName, 'Rap FR')
+    assert.equal((result.session.gameData as any).maxScore, PARKEUR_TARGET_ROUNDS)
+  })
+
+  test('startSession returns 422 when not enough lyrics are available', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('parkeur_few')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 9002,
+      name: 'Mostly instrumental',
+      genreLabel: 'Lounge',
+      coverUrl: null,
+    })
+
+    const tracks = Array.from({ length: 30 }, (_, i) => buildDeezerTrack(2000 + i))
+    globalThis.fetch = deezerFetchMock(
+      () =>
+        new Response(JSON.stringify({ data: tracks, total: tracks.length }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+
+    const result = await makeService(new FakeLyricsService('fail')).startSession(user.id, {
+      mode: 'playlist',
+      playlistId: playlist.id,
+    })
+    assert.equal((result as any).status, 422)
+    assert.match((result as any).error, /Not enough playable lyrics/)
+  })
+
+  test('startSession returns 404 when the playlist does not exist', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('parkeur_nopl')
+    const result = await makeService().startSession(user.id, {
+      mode: 'playlist',
+      playlistId: 999999,
+    })
+    assert.equal((result as any).status, 404)
+    assert.match((result as any).error, /Curated playlist not found/)
+  })
+
+  test('startSession returns 502 when the Deezer fetch fails', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('parkeur_502')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 9003,
+      name: 'Failing',
+      genreLabel: 'Pop',
+      coverUrl: null,
+    })
+
+    globalThis.fetch = deezerFetchMock(() => new Response('boom', { status: 500 }))
+
+    const result = await makeService().startSession(user.id, {
+      mode: 'playlist',
+      playlistId: playlist.id,
+    })
+    assert.equal((result as any).status, 502)
+  })
+
+  test('startSession returns 404 when the Parkeur game is disabled', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('parkeur_disabled')
+    await Game.updateOrCreate(
+      { name: PARKEUR_GAME_NAME },
+      { name: PARKEUR_GAME_NAME, isEnabled: false, isMultiplayer: false, description: 'x' }
+    )
+
+    const result = await makeService().startSession(user.id, { mode: 'playlist', playlistId: 1 })
+    assert.equal((result as any).status, 404)
+    assert.match((result as any).error, /not available/)
+  })
+
+  test('startSession propagates 409 when an active session already exists', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('parkeur_active')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 9004,
+      name: 'Pop',
+      genreLabel: 'Pop',
+      coverUrl: null,
+    })
+    const game = await Game.findBy('name', PARKEUR_GAME_NAME)
+    await GameSession.create({
+      gameId: game!.id,
+      status: GameSessionStatus.Active,
+      players: [{ userId: user.id, status: 'active', score: 0, rank: 1 }],
+      gameData: {},
+    })
+
+    globalThis.fetch = deezerFetchMock(
+      () =>
+        new Response(
+          JSON.stringify({
+            data: Array.from({ length: 30 }, (_, i) => buildDeezerTrack(3000 + i)),
+            total: 30,
+          }),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        )
+    )
+
+    const result = await makeService().startSession(user.id, {
+      mode: 'playlist',
+      playlistId: playlist.id,
+    })
+    assert.equal((result as any).status, 409)
+  })
+
+  test('startSession rethrows unexpected errors from the playlist service', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('parkeur_throw')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 9006,
+      name: 'Boom',
+      genreLabel: 'Pop',
+      coverUrl: null,
+    })
+
+    const customSvc = new (class extends CuratedPlaylistService {
+      async getRandomTracks(): Promise<any> {
+        throw new Error('unexpected boom')
+      }
+    })()
+    const customService = new ParkeurService(
+      customSvc,
+      new FakeLyricsService('success'),
+      new GameSessionService()
+    )
+
+    await assert.rejects(async () => {
+      await customService.startSession(user.id, { mode: 'playlist', playlistId: playlist.id })
+    }, /unexpected boom/)
+  })
+
+  test('startSession caps rounds at the target even when a later batch would overshoot', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('parkeur_cap')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 9008,
+      name: 'Cap',
+      genreLabel: 'Pop',
+      coverUrl: null,
+    })
+
+    const tracks = Array.from({ length: 30 }, (_, i) => buildDeezerTrack(7000 + i))
+    globalThis.fetch = deezerFetchMock(
+      () =>
+        new Response(JSON.stringify({ data: tracks, total: tracks.length }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+
+    const result = await makeService(new FakeLyricsService('first-half-fail')).startSession(
+      user.id,
+      { mode: 'playlist', playlistId: playlist.id }
+    )
+    if ('error' in result) throw new Error('expected success')
+    assert.lengthOf(result.rounds, PARKEUR_TARGET_ROUNDS)
+  })
+
+  test('buildRounds skips tracks whose lyrics service throws and still completes 10 rounds', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('parkeur_throwlyrics')
+    const playlist = await CuratedPlaylist.create({
+      deezerPlaylistId: 9007,
+      name: 'Mixed throws',
+      genreLabel: 'Rap',
+      coverUrl: null,
+    })
+
+    const tracks = Array.from({ length: 60 }, (_, i) => buildDeezerTrack(5000 + i))
+    globalThis.fetch = deezerFetchMock(
+      () =>
+        new Response(JSON.stringify({ data: tracks, total: tracks.length }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+
+    const result = await makeService(new FakeLyricsService('mixed')).startSession(user.id, {
+      mode: 'playlist',
+      playlistId: playlist.id,
+    })
+    if ('error' in result) throw new Error('expected success')
+    assert.lengthOf(result.rounds, PARKEUR_TARGET_ROUNDS)
+  })
+
+  test('startSession with artist mode builds 10 rounds from Deezer top tracks', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('parkeur_artist_ok')
+    const tracks = Array.from({ length: 30 }, (_, i) => buildDeezerTrack(8000 + i))
+    globalThis.fetch = deezerFetchMock(
+      () =>
+        new Response(JSON.stringify({ data: tracks }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+
+    const result = await makeService().startSession(user.id, { mode: 'artist', artistId: 27 })
+    if ('error' in result) throw new Error('expected success')
+    assert.lengthOf(result.rounds, PARKEUR_TARGET_ROUNDS)
+    assert.equal((result.session.gameData as any).artistId, 27)
+    assert.equal((result.session.gameData as any).artistName, 'Artist 8000')
+  })
+
+  test('startSession with artist mode returns 404 when Deezer responds with an error payload', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('parkeur_artist_404')
+    globalThis.fetch = deezerFetchMock(
+      () =>
+        new Response(JSON.stringify({ error: { code: 800, message: 'no data' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+
+    const result = await makeService().startSession(user.id, { mode: 'artist', artistId: 99 })
+    assert.equal((result as any).status, 404)
+    assert.match((result as any).error, /Artist not found/)
+  })
+
+  test('startSession with artist mode returns 404 when Deezer returns an empty data array', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('parkeur_artist_empty')
+    globalThis.fetch = deezerFetchMock(
+      () =>
+        new Response(JSON.stringify({ data: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+    )
+
+    const result = await makeService().startSession(user.id, { mode: 'artist', artistId: 99 })
+    assert.equal((result as any).status, 404)
+  })
+
+  test('startSession with artist mode returns 502 when Deezer fetch errors out', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('parkeur_artist_502')
+    globalThis.fetch = deezerFetchMock(() => new Response('boom', { status: 500 }))
+
+    const result = await makeService().startSession(user.id, { mode: 'artist', artistId: 99 })
+    assert.equal((result as any).status, 502)
+  })
+
+  test('startSession with artist mode returns 502 when fetch throws (network error)', async ({
+    assert,
+  }) => {
+    const { user } = await createAuthenticatedUser('parkeur_artist_net')
+    globalThis.fetch = (async () => {
+      throw new Error('network down')
+    }) as any
+
+    const result = await makeService().startSession(user.id, { mode: 'artist', artistId: 99 })
+    assert.equal((result as any).status, 502)
+  })
+})

--- a/front-mobile/app/(tabs)/games/_layout.tsx
+++ b/front-mobile/app/(tabs)/games/_layout.tsx
@@ -34,6 +34,12 @@ export default function GamesLayout() {
         }}
       />
       <Stack.Screen
+        name="parkeur"
+        options={{
+          presentation: "card",
+        }}
+      />
+      <Stack.Screen
         name="history/[gameId]"
         options={{
           headerShown: false,

--- a/front-mobile/app/(tabs)/games/parkeur/_layout.tsx
+++ b/front-mobile/app/(tabs)/games/parkeur/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from "expo-router";
+
+export default function ParkeurLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="index" />
+      <Stack.Screen name="game" />
+    </Stack>
+  );
+}

--- a/front-mobile/app/(tabs)/games/parkeur/game.tsx
+++ b/front-mobile/app/(tabs)/games/parkeur/game.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { router } from "expo-router";
+import Header from "@/components/Header";
+import { ThemedText } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import { useParkeurGame } from "@/hooks/feature/parkeur/useParkeurGame";
+import ParkeurModeSelection from "@/components/feature/parkeur/ParkeurModeSelection";
+import ParkeurPlaylistSelection from "@/components/feature/parkeur/ParkeurPlaylistSelection";
+import ParkeurArtistSelection from "@/components/feature/parkeur/ParkeurArtistSelection";
+import ParkeurPlayingScreen from "@/components/feature/parkeur/ParkeurPlayingScreen";
+import ParkeurResultScreen from "@/components/feature/parkeur/ParkeurResultScreen";
+import ConfirmationModal from "@/components/ConfirmationModal";
+
+export default function ParkeurGameScreen() {
+  const {
+    gameState,
+    mode,
+    setMode,
+    playlists,
+    loadingPlaylists,
+    sessionId,
+    rounds,
+    currentRound,
+    currentRoundIndex,
+    score,
+    answers,
+    lastAnswer,
+    startWithPlaylist,
+    startWithArtist,
+    submitAnswer,
+    skipRound,
+    goToNextRound,
+    resetGame,
+    abandonGame,
+    saveCurrentState,
+    errorMessage,
+  } = useParkeurGame();
+  const [isQuitModalVisible, setIsQuitModalVisible] = useState(false);
+
+  const handleBackPress = () => {
+    if (sessionId) {
+      setIsQuitModalVisible(true);
+    } else if (router.canGoBack()) {
+      router.back();
+    }
+  };
+
+  const handleSaveAndQuit = () => {
+    saveCurrentState();
+    setIsQuitModalVisible(false);
+    if (router.canGoBack()) router.back();
+  };
+
+  const handleAbandon = () => {
+    setIsQuitModalVisible(false);
+    abandonGame();
+  };
+
+  if (gameState === "selection") {
+    if (mode === "pick") {
+      return (
+        <>
+          <Header title="Parkeur" variant="withBack" />
+          <ParkeurModeSelection onSelect={setMode} />
+        </>
+      );
+    }
+    if (mode === "playlist") {
+      return (
+        <>
+          <Header
+            title="Parkeur"
+            variant="withBack"
+            onBack={() => setMode("pick")}
+          />
+          <ParkeurPlaylistSelection
+            playlists={playlists}
+            loading={loadingPlaylists}
+            errorMessage={errorMessage}
+            onSelect={startWithPlaylist}
+          />
+        </>
+      );
+    }
+    return (
+      <>
+        <Header
+          title="Parkeur"
+          variant="withBack"
+          onBack={() => setMode("pick")}
+        />
+        <ParkeurArtistSelection
+          errorMessage={errorMessage}
+          onSelect={startWithArtist}
+        />
+      </>
+    );
+  }
+
+  if (gameState === "loading") {
+    return (
+      <>
+        <Header title="Parkeur" variant="withBack" />
+        <View style={styles.loading}>
+          <ActivityIndicator size="large" color={Colors.primary.survol} />
+          <ThemedText style={styles.loadingText}>
+            Préparation de la partie…
+          </ThemedText>
+        </View>
+      </>
+    );
+  }
+
+  if (gameState === "result") {
+    return (
+      <ParkeurResultScreen
+        rounds={rounds}
+        answers={answers}
+        score={score}
+        maxScore={rounds.length}
+        onReplay={resetGame}
+      />
+    );
+  }
+
+  if (!currentRound) {
+    return (
+      <>
+        <Header title="Parkeur" variant="withBack" />
+        <View style={styles.loading}>
+          <ActivityIndicator size="large" color={Colors.primary.survol} />
+        </View>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header title="Parkeur" variant="withBack" onBack={handleBackPress} />
+      <ConfirmationModal
+        visible={isQuitModalVisible}
+        title="Quitter la partie ?"
+        message="Tu peux sauvegarder pour reprendre plus tard, ou abandonner et voir ton score actuel."
+        confirmLabel="Sauvegarder et quitter"
+        secondaryLabel="Abandonner la partie"
+        cancelLabel="Annuler"
+        variant="danger"
+        onConfirm={handleSaveAndQuit}
+        onSecondary={handleAbandon}
+        onCancel={() => setIsQuitModalVisible(false)}
+      />
+      <ParkeurPlayingScreen
+        round={currentRound}
+        roundIndex={currentRoundIndex}
+        totalRounds={rounds.length}
+        score={score}
+        lastAnswer={lastAnswer}
+        isReveal={gameState === "reveal"}
+        onSubmit={submitAnswer}
+        onSkip={skipRound}
+        onNext={goToNextRound}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  loading: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+    justifyContent: "center",
+    alignItems: "center",
+    gap: 12,
+  },
+  loadingText: { color: "white" },
+});

--- a/front-mobile/app/(tabs)/games/parkeur/index.tsx
+++ b/front-mobile/app/(tabs)/games/parkeur/index.tsx
@@ -1,0 +1,339 @@
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { router } from "expo-router";
+import { MaterialIcons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/ThemedText";
+import Button from "@/components/Button";
+import Header from "@/components/Header";
+import ConfirmationModal from "@/components/ConfirmationModal";
+import RulesModal from "@/components/games/RulesModal";
+import GameHistory from "@/components/games/GameHistory";
+import { Colors } from "@/constants/Colors";
+import { useGameIndex } from "@/hooks/useGameIndex";
+
+export default function ParkeurIndexScreen() {
+  const {
+    gameId,
+    loading,
+    error,
+    hasPlayedBefore,
+    activeSession,
+    isRulesModalVisible,
+    setIsRulesModalVisible,
+    handleStartGame,
+    handleStartNewGame,
+  } = useGameIndex({
+    gameName: "parkeur",
+    gamePath: "/games/parkeur/game",
+    // Rounds (lyrics + answer lines) are stored server-side in gameData, so we can
+    // resume a Parkeur session even after a reinstall or on a different device.
+    canResumeFromServer: true,
+  });
+  const [isConfirmNewGameVisible, setIsConfirmNewGameVisible] = useState(false);
+
+  if (loading && !gameId) {
+    return (
+      <>
+        <Header title="Parkeur" variant="withBack" />
+        <View style={styles.loadingContainer}>
+          <ActivityIndicator size="large" color={Colors.primary.survol} />
+          <ThemedText style={styles.loadingText}>Chargement...</ThemedText>
+        </View>
+      </>
+    );
+  }
+
+  if (error) {
+    return (
+      <>
+        <Header title="Parkeur" variant="withBack" />
+        <View style={styles.errorContainer}>
+          <MaterialIcons name="error-outline" size={80} color="#ff6b6b" />
+          <ThemedText type="title" style={styles.errorTitle}>
+            Jeu indisponible
+          </ThemedText>
+          <ThemedText style={styles.errorText}>
+            Impossible de charger le jeu. Veuillez réessayer plus tard.
+          </ThemedText>
+          <Button
+            title="Retour"
+            onPress={() => router.back()}
+            style={styles.errorButton}
+          />
+        </View>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header title="Parkeur" variant="withBack" />
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.content}
+      >
+        <View style={styles.headerSection}>
+          <MaterialIcons
+            name="lyrics"
+            size={80}
+            color={Colors.primary.survol}
+          />
+          <ThemedText type="title" style={styles.title}>
+            Parkeur
+          </ThemedText>
+          <ThemedText style={styles.subtitle}>
+            Complète les paroles à la manière de N&apos;oubliez pas les paroles
+          </ThemedText>
+        </View>
+
+        {hasPlayedBefore === false && (
+          <>
+            <View style={styles.section}>
+              <View style={styles.sectionHeader}>
+                <MaterialIcons
+                  name="info"
+                  size={24}
+                  color={Colors.primary.survol}
+                />
+                <ThemedText type="subtitle" style={styles.sectionTitle}>
+                  Objectif
+                </ThemedText>
+              </View>
+              <ThemedText style={styles.text}>
+                Devinez le 3ᵉ vers d&apos;une chanson en vous basant sur les
+                deux vers précédents. Score max : 10/10.
+              </ThemedText>
+            </View>
+
+            <View style={styles.section}>
+              <View style={styles.sectionHeader}>
+                <MaterialIcons
+                  name="sports-esports"
+                  size={24}
+                  color={Colors.primary.survol}
+                />
+                <ThemedText type="subtitle" style={styles.sectionTitle}>
+                  Comment jouer
+                </ThemedText>
+              </View>
+              <View style={styles.list}>
+                <View style={styles.listItem}>
+                  <ThemedText style={styles.listNumber}>1.</ThemedText>
+                  <ThemedText style={styles.listText}>
+                    Choisissez une playlist
+                  </ThemedText>
+                </View>
+                <View style={styles.listItem}>
+                  <ThemedText style={styles.listNumber}>2.</ThemedText>
+                  <ThemedText style={styles.listText}>
+                    Lisez les deux vers affichés et l&apos;indice (un trait par
+                    mot manquant)
+                  </ThemedText>
+                </View>
+                <View style={styles.listItem}>
+                  <ThemedText style={styles.listNumber}>3.</ThemedText>
+                  <ThemedText style={styles.listText}>
+                    Tapez le vers suivant. Casse, accents et ponctuation sont
+                    ignorés.
+                  </ThemedText>
+                </View>
+              </View>
+            </View>
+          </>
+        )}
+
+        <View style={styles.buttonContainer}>
+          {activeSession ? (
+            <>
+              <Button
+                title="Reprendre la partie"
+                onPress={() => handleStartGame(true)}
+                style={styles.playButton}
+              />
+              <Button
+                title="Nouvelle partie"
+                variant="outline"
+                onPress={() => setIsConfirmNewGameVisible(true)}
+                style={styles.playButton}
+              />
+            </>
+          ) : (
+            <Button
+              title="Commencer à jouer"
+              onPress={() => handleStartGame(false)}
+              style={styles.playButton}
+            />
+          )}
+        </View>
+
+        {hasPlayedBefore && (
+          <TouchableOpacity
+            style={styles.rulesButton}
+            onPress={() => setIsRulesModalVisible(true)}
+            activeOpacity={0.7}
+          >
+            <MaterialIcons name="help-outline" size={18} color="#999" />
+            <ThemedText style={styles.rulesButtonText}>
+              Voir les règles
+            </ThemedText>
+          </TouchableOpacity>
+        )}
+
+        <GameHistory gameId={gameId} gameTitle="Parkeur" />
+      </ScrollView>
+
+      <RulesModal
+        visible={isRulesModalVisible}
+        onClose={() => setIsRulesModalVisible(false)}
+        title="Règles — Parkeur"
+        objective="Devinez le 3ᵉ vers de la chanson à partir des deux vers précédents"
+        steps={[
+          { text: "Choisissez une playlist parmi celles proposées" },
+          {
+            text: "Lisez les deux vers affichés et l'indice de longueur (un trait par mot)",
+          },
+          { text: "Tapez le vers manquant et validez" },
+          { text: "Casse, accents et ponctuation ne comptent pas" },
+          {
+            text: "10 rounds par partie ; le score s'enregistre à la fin",
+          },
+        ]}
+      />
+
+      <ConfirmationModal
+        visible={isConfirmNewGameVisible}
+        title="Démarrer une nouvelle partie ?"
+        message="Tu as une partie en cours. La lancer va l'abandonner — tu ne pourras plus la reprendre."
+        confirmLabel="Oui, nouvelle partie"
+        cancelLabel="Annuler"
+        variant="danger"
+        onConfirm={() => {
+          setIsConfirmNewGameVisible(false);
+          handleStartNewGame();
+        }}
+        onCancel={() => setIsConfirmNewGameVisible(false)}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+  },
+  content: {
+    padding: 20,
+    paddingBottom: 40,
+  },
+  headerSection: {
+    alignItems: "center",
+    marginBottom: 40,
+    marginTop: 20,
+  },
+  title: {
+    marginTop: 20,
+    marginBottom: 10,
+    textAlign: "center",
+  },
+  subtitle: {
+    color: "#999",
+    textAlign: "center",
+    fontSize: 16,
+  },
+  section: {
+    marginBottom: 30,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    marginBottom: 15,
+  },
+  sectionTitle: {
+    color: "white",
+    fontSize: 20,
+  },
+  text: {
+    color: "#CCC",
+    fontSize: 16,
+    lineHeight: 24,
+  },
+  list: {
+    gap: 12,
+  },
+  listItem: {
+    flexDirection: "row",
+    gap: 12,
+  },
+  listNumber: {
+    color: Colors.primary.survol,
+    fontSize: 16,
+    fontWeight: "bold",
+    minWidth: 20,
+  },
+  listText: {
+    color: "#CCC",
+    fontSize: 16,
+    flex: 1,
+    lineHeight: 22,
+  },
+  buttonContainer: {
+    marginTop: 20,
+    gap: 12,
+  },
+  playButton: {
+    paddingVertical: 16,
+  },
+  loadingContainer: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  loadingText: {
+    color: "white",
+    marginTop: 15,
+    fontSize: 16,
+  },
+  errorContainer: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 40,
+  },
+  errorTitle: {
+    marginTop: 20,
+    marginBottom: 10,
+    textAlign: "center",
+    color: "#ff6b6b",
+  },
+  errorText: {
+    color: "#999",
+    textAlign: "center",
+    fontSize: 16,
+    marginBottom: 30,
+  },
+  errorButton: {
+    paddingHorizontal: 40,
+  },
+  rulesButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 6,
+    marginTop: 16,
+    paddingVertical: 8,
+  },
+  rulesButtonText: {
+    color: "#999",
+    fontSize: 14,
+  },
+});

--- a/front-mobile/components/feature/parkeur/ParkeurArtistSelection.tsx
+++ b/front-mobile/components/feature/parkeur/ParkeurArtistSelection.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Image,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import {
+  searchDeezerArtists,
+  type DeezerArtistSearchResult,
+} from "@/services/parkeurService";
+import type { ParkeurArtist } from "@/hooks/feature/parkeur/useParkeurGame";
+
+interface Props {
+  errorMessage: string | null;
+  onSelect: (artist: ParkeurArtist) => void;
+}
+
+const SEARCH_DEBOUNCE_MS = 350;
+
+export default function ParkeurArtistSelection({
+  errorMessage,
+  onSelect,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<DeezerArtistSearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      setResults([]);
+      setSearching(false);
+      setSearchError(null);
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setSearching(true);
+    const timer = setTimeout(async () => {
+      try {
+        const data = await searchDeezerArtists(trimmed);
+        if (requestIdRef.current !== requestId) return;
+        setResults(data);
+        setSearchError(null);
+      } catch (err) {
+        console.error("[Parkeur] Artist search failed:", err);
+        if (requestIdRef.current !== requestId) return;
+        setSearchError("Recherche impossible. Réessaie plus tard.");
+        setResults([]);
+      } finally {
+        if (requestIdRef.current === requestId) setSearching(false);
+      }
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(timer);
+  }, [query]);
+
+  return (
+    <View style={styles.container}>
+      <ThemedText type="title" style={styles.title}>
+        Cherche un artiste
+      </ThemedText>
+      {errorMessage && (
+        <View style={styles.errorBanner}>
+          <ThemedText style={styles.errorText}>{errorMessage}</ThemedText>
+        </View>
+      )}
+      <View style={styles.searchRow}>
+        <MaterialIcons
+          name="search"
+          size={20}
+          color="#999"
+          style={styles.searchIcon}
+        />
+        <TextInput
+          value={query}
+          onChangeText={setQuery}
+          style={styles.searchInput}
+          placeholder="Tape un nom d'artiste…"
+          placeholderTextColor="#666"
+          autoCapitalize="words"
+          autoCorrect={false}
+          returnKeyType="search"
+          accessibilityLabel="Recherche d'artiste"
+        />
+      </View>
+
+      {searching && (
+        <View style={styles.statusRow}>
+          <ActivityIndicator size="small" color={Colors.primary.survol} />
+          <ThemedText style={styles.statusText}>Recherche…</ThemedText>
+        </View>
+      )}
+
+      {!searching && searchError && (
+        <ThemedText style={styles.errorText}>{searchError}</ThemedText>
+      )}
+
+      {!searching &&
+        !searchError &&
+        query.trim().length >= 2 &&
+        results.length === 0 && (
+          <ThemedText style={styles.emptyText}>
+            Aucun artiste trouvé pour « {query.trim()} ».
+          </ThemedText>
+        )}
+
+      <FlatList
+        data={results}
+        keyExtractor={(item) => String(item.id)}
+        contentContainerStyle={styles.listContent}
+        keyboardShouldPersistTaps="handled"
+        renderItem={({ item }) => (
+          <TouchableOpacity
+            style={styles.artistRow}
+            activeOpacity={0.7}
+            onPress={() =>
+              onSelect({
+                id: item.id,
+                name: item.name,
+                pictureUrl: item.picture_medium ?? item.picture,
+              })
+            }
+            accessibilityRole="button"
+            accessibilityLabel={`Démarrer une partie sur ${item.name}`}
+          >
+            {item.picture_medium ? (
+              <Image
+                source={{ uri: item.picture_medium }}
+                style={styles.avatar}
+              />
+            ) : (
+              <View style={[styles.avatar, styles.avatarPlaceholder]}>
+                <MaterialIcons name="person" size={26} color="#666" />
+              </View>
+            )}
+            <View style={styles.info}>
+              <ThemedText style={styles.name}>{item.name}</ThemedText>
+              {typeof item.nb_fan === "number" && (
+                <ThemedText style={styles.meta}>
+                  {item.nb_fan.toLocaleString("fr-FR")} fans
+                </ThemedText>
+              )}
+            </View>
+            <MaterialIcons name="chevron-right" size={22} color="#666" />
+          </TouchableOpacity>
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+    padding: 20,
+  },
+  title: { color: "white", marginBottom: 12 },
+  errorBanner: {
+    backgroundColor: "rgba(255, 107, 107, 0.15)",
+    borderColor: "#ff6b6b",
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 12,
+  },
+  errorText: { color: "#ff6b6b" },
+  searchRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "rgba(255, 255, 255, 0.06)",
+    borderRadius: 10,
+    paddingHorizontal: 12,
+    height: 44,
+    marginBottom: 12,
+  },
+  searchIcon: { marginRight: 8 },
+  searchInput: { flex: 1, color: "white", fontSize: 15 },
+  statusRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    paddingVertical: 8,
+  },
+  statusText: { color: "#999", fontSize: 13 },
+  emptyText: { color: "#999", textAlign: "center", marginTop: 24 },
+  listContent: { paddingBottom: 40, gap: 10 },
+  artistRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.08)",
+  },
+  avatar: { width: 52, height: 52, borderRadius: 26, backgroundColor: "#222" },
+  avatarPlaceholder: {
+    backgroundColor: "#333",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  info: { flex: 1 },
+  name: { color: "white", fontSize: 16, fontWeight: "600" },
+  meta: { color: "#999", fontSize: 12, marginTop: 2 },
+});

--- a/front-mobile/components/feature/parkeur/ParkeurArtistSelection.tsx
+++ b/front-mobile/components/feature/parkeur/ParkeurArtistSelection.tsx
@@ -37,6 +37,7 @@ export default function ParkeurArtistSelection({
   useEffect(() => {
     const trimmed = query.trim();
     if (trimmed.length < 2) {
+      ++requestIdRef.current;
       setResults([]);
       setSearching(false);
       setSearchError(null);

--- a/front-mobile/components/feature/parkeur/ParkeurModeSelection.tsx
+++ b/front-mobile/components/feature/parkeur/ParkeurModeSelection.tsx
@@ -1,0 +1,91 @@
+import { ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import type { ParkeurMode } from "@/hooks/feature/parkeur/useParkeurGame";
+
+interface Props {
+  onSelect: (mode: Exclude<ParkeurMode, "pick">) => void;
+}
+
+export default function ParkeurModeSelection({ onSelect }: Props) {
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <ThemedText type="title" style={styles.title}>
+        Choisis ta source
+      </ThemedText>
+      <ThemedText style={styles.subtitle}>
+        Joue sur une playlist toute prête, ou sur les morceaux les plus connus
+        d&apos;un artiste de ton choix.
+      </ThemedText>
+
+      <TouchableOpacity
+        style={styles.card}
+        activeOpacity={0.7}
+        onPress={() => onSelect("playlist")}
+        accessibilityRole="button"
+        accessibilityLabel="Mode playlist"
+      >
+        <MaterialIcons
+          name="queue-music"
+          size={42}
+          color={Colors.primary.survol}
+        />
+        <View style={styles.cardText}>
+          <ThemedText style={styles.cardTitle}>Playlist</ThemedText>
+          <ThemedText style={styles.cardDescription}>
+            Choisis parmi les playlists Rythmix.
+          </ThemedText>
+        </View>
+        <MaterialIcons name="chevron-right" size={24} color="#666" />
+      </TouchableOpacity>
+
+      <TouchableOpacity
+        style={styles.card}
+        activeOpacity={0.7}
+        onPress={() => onSelect("artist")}
+        accessibilityRole="button"
+        accessibilityLabel="Mode artiste"
+      >
+        <MaterialIcons
+          name="person-search"
+          size={42}
+          color={Colors.primary.survol}
+        />
+        <View style={styles.cardText}>
+          <ThemedText style={styles.cardTitle}>Artiste</ThemedText>
+          <ThemedText style={styles.cardDescription}>
+            Cherche un artiste, on tire au sort dans ses tubes.
+          </ThemedText>
+        </View>
+        <MaterialIcons name="chevron-right" size={24} color="#666" />
+      </TouchableOpacity>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.primary.fondPremier },
+  content: { padding: 20, paddingBottom: 40, gap: 16 },
+  title: { color: "white", textAlign: "center", marginBottom: 4 },
+  subtitle: {
+    color: "#999",
+    textAlign: "center",
+    fontSize: 14,
+    marginBottom: 16,
+    lineHeight: 20,
+  },
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 16,
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 12,
+    padding: 18,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.08)",
+  },
+  cardText: { flex: 1 },
+  cardTitle: { color: "white", fontSize: 18, fontWeight: "600" },
+  cardDescription: { color: "#999", fontSize: 13, marginTop: 4 },
+});

--- a/front-mobile/components/feature/parkeur/ParkeurPlayingScreen.tsx
+++ b/front-mobile/components/feature/parkeur/ParkeurPlayingScreen.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Image,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  View,
+} from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { ThemedText } from "@/components/ThemedText";
+import { GameAnswerInput } from "@/components/games/GameAnswerInput";
+import Button from "@/components/Button";
+import { Colors } from "@/constants/Colors";
+import { answerHintTokens } from "@/utils/parkeur";
+import type { ParkeurAnswer, ParkeurRound } from "@/types/gameSession";
+
+interface Props {
+  round: ParkeurRound;
+  roundIndex: number;
+  totalRounds: number;
+  score: number;
+  lastAnswer: ParkeurAnswer | null;
+  isReveal: boolean;
+  onSubmit: (input: string) => void;
+  onSkip: () => void;
+  onNext: () => void;
+}
+
+export default function ParkeurPlayingScreen({
+  round,
+  roundIndex,
+  totalRounds,
+  score,
+  lastAnswer,
+  isReveal,
+  onSubmit,
+  onSkip,
+  onNext,
+}: Props) {
+  const [input, setInput] = useState("");
+  const inputRef = useRef<TextInput>(null);
+  const hintTokens = useMemo(
+    () => answerHintTokens(round.answerLine),
+    [round.answerLine],
+  );
+
+  // Reset input when moving to a new round.
+  useEffect(() => {
+    if (!isReveal) setInput("");
+  }, [round.trackId, isReveal]);
+
+  const handleSubmit = () => {
+    if (!input.trim() || isReveal) return;
+    onSubmit(input);
+  };
+
+  const isLast = roundIndex + 1 >= totalRounds;
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.flex}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+      keyboardVerticalOffset={80}
+    >
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.content}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={styles.scoreRow}>
+          <ThemedText style={styles.scoreText}>
+            Round {roundIndex + 1}/{totalRounds}
+          </ThemedText>
+          <ThemedText style={styles.scoreText}>Score : {score}</ThemedText>
+        </View>
+
+        <View style={styles.trackInfo}>
+          {round.coverUrl ? (
+            <Image source={{ uri: round.coverUrl }} style={styles.cover} />
+          ) : (
+            <View style={[styles.cover, styles.coverPlaceholder]}>
+              <MaterialIcons name="music-note" size={36} color="#555" />
+            </View>
+          )}
+          <ThemedText style={styles.artist}>{round.artist}</ThemedText>
+          <ThemedText style={styles.title}>{round.title}</ThemedText>
+        </View>
+
+        <View style={styles.lyricsBlock}>
+          {round.lines.map((line, idx) => (
+            <ThemedText key={idx} style={styles.lyricLine}>
+              {line}
+            </ThemedText>
+          ))}
+          <View style={styles.hintRow}>
+            {hintTokens.length > 0 ? (
+              hintTokens.map((token, idx) => (
+                <View key={idx} style={styles.hintWord}>
+                  <ThemedText style={styles.hintText}>{token}</ThemedText>
+                </View>
+              ))
+            ) : (
+              <ThemedText style={styles.hintText}>___</ThemedText>
+            )}
+          </View>
+        </View>
+
+        {isReveal && lastAnswer && (
+          <View
+            style={[
+              styles.revealBlock,
+              lastAnswer.correct ? styles.revealOk : styles.revealKo,
+            ]}
+          >
+            <MaterialIcons
+              name={lastAnswer.correct ? "check-circle" : "cancel"}
+              size={28}
+              color={lastAnswer.correct ? "#4ade80" : "#ff6b6b"}
+            />
+            <View style={styles.revealTextBlock}>
+              <ThemedText style={styles.revealLabel}>
+                {lastAnswer.correct ? "Bonne réponse !" : "Mauvaise réponse"}
+              </ThemedText>
+              <ThemedText style={styles.revealExpected}>
+                {lastAnswer.expected}
+              </ThemedText>
+              {!lastAnswer.correct && lastAnswer.userInput && (
+                <ThemedText style={styles.revealUserInput}>
+                  Ta réponse : {lastAnswer.userInput}
+                </ThemedText>
+              )}
+            </View>
+          </View>
+        )}
+
+        {isReveal ? (
+          <Button
+            title={isLast ? "Voir le score" : "Suivant"}
+            onPress={onNext}
+            style={styles.nextButton}
+          />
+        ) : (
+          <View style={styles.inputBlock}>
+            <GameAnswerInput
+              ref={inputRef}
+              value={input}
+              onChangeText={setInput}
+              onSubmit={handleSubmit}
+              placeholder="Tape la suite des paroles…"
+              disabled={!input.trim()}
+              accessibilityLabel="Champ de réponse Parkeur"
+              accessibilityHint="Saisis le vers manquant"
+            />
+            <Pressable
+              onPress={onSkip}
+              style={styles.skipButton}
+              accessibilityRole="button"
+              accessibilityLabel="Passer ce round"
+            >
+              <ThemedText style={styles.skipText}>Je ne sais pas</ThemedText>
+            </Pressable>
+          </View>
+        )}
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1, backgroundColor: Colors.primary.fondPremier },
+  container: { flex: 1 },
+  content: { padding: 20, paddingBottom: 40, gap: 18 },
+  scoreRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    paddingVertical: 8,
+  },
+  scoreText: { color: "#bbb", fontSize: 14, fontWeight: "600" },
+  trackInfo: { alignItems: "center", marginVertical: 6, gap: 8 },
+  cover: {
+    width: 96,
+    height: 96,
+    borderRadius: 12,
+    backgroundColor: "#222",
+  },
+  coverPlaceholder: {
+    backgroundColor: "#222",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  artist: {
+    color: Colors.primary.survol,
+    fontSize: 14,
+    textTransform: "uppercase",
+    letterSpacing: 1.5,
+  },
+  title: { color: "white", fontSize: 18, fontWeight: "700" },
+  lyricsBlock: {
+    backgroundColor: "rgba(255, 255, 255, 0.04)",
+    borderRadius: 16,
+    padding: 22,
+    gap: 14,
+  },
+  lyricLine: {
+    color: "white",
+    fontSize: 20,
+    lineHeight: 28,
+    textAlign: "center",
+  },
+  hintRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: 10,
+    marginTop: 4,
+  },
+  hintWord: { paddingHorizontal: 4 },
+  hintText: {
+    color: Colors.primary.survol,
+    fontSize: 22,
+    letterSpacing: 2,
+    fontWeight: "700",
+  },
+  revealBlock: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    borderRadius: 12,
+    padding: 14,
+  },
+  revealOk: { backgroundColor: "rgba(74, 222, 128, 0.12)" },
+  revealKo: { backgroundColor: "rgba(255, 107, 107, 0.12)" },
+  revealTextBlock: { flex: 1, gap: 4 },
+  revealLabel: { color: "white", fontWeight: "700", fontSize: 15 },
+  revealExpected: { color: "#ddd" },
+  revealUserInput: { color: "#888", fontSize: 13, fontStyle: "italic" },
+  inputBlock: { marginTop: 8, gap: 10 },
+  skipButton: {
+    alignSelf: "center",
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+  },
+  skipText: { color: "#999", fontSize: 14, textDecorationLine: "underline" },
+  nextButton: { marginTop: 8 },
+});

--- a/front-mobile/components/feature/parkeur/ParkeurPlaylistSelection.tsx
+++ b/front-mobile/components/feature/parkeur/ParkeurPlaylistSelection.tsx
@@ -1,0 +1,111 @@
+import {
+  ActivityIndicator,
+  Image,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { Colors } from "@/constants/Colors";
+import type { CuratedPlaylist } from "@/services/curatedPlaylistService";
+
+interface Props {
+  playlists: CuratedPlaylist[];
+  loading: boolean;
+  errorMessage: string | null;
+  onSelect: (playlist: CuratedPlaylist) => void;
+}
+
+export default function ParkeurPlaylistSelection({
+  playlists,
+  loading,
+  errorMessage,
+  onSelect,
+}: Props) {
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator size="large" color={Colors.primary.survol} />
+        <ThemedText style={styles.loadingText}>
+          Chargement des playlists...
+        </ThemedText>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <ThemedText type="title" style={styles.title}>
+        Choisis une playlist
+      </ThemedText>
+      {errorMessage && (
+        <View style={styles.errorBanner}>
+          <ThemedText style={styles.errorText}>{errorMessage}</ThemedText>
+        </View>
+      )}
+      {playlists.map((playlist) => (
+        <TouchableOpacity
+          key={playlist.id}
+          style={styles.playlistRow}
+          onPress={() => onSelect(playlist)}
+          activeOpacity={0.7}
+          accessibilityRole="button"
+          accessibilityLabel={`Démarrer une partie sur ${playlist.name}`}
+        >
+          {playlist.coverUrl ? (
+            <Image source={{ uri: playlist.coverUrl }} style={styles.cover} />
+          ) : (
+            <View style={[styles.cover, styles.coverPlaceholder]} />
+          )}
+          <View style={styles.info}>
+            <ThemedText style={styles.name}>{playlist.name}</ThemedText>
+            <ThemedText style={styles.genre}>{playlist.genreLabel}</ThemedText>
+          </View>
+        </TouchableOpacity>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.primary.fondPremier },
+  content: { padding: 20, paddingBottom: 40, gap: 12 },
+  title: { marginBottom: 16, color: "white" },
+  center: {
+    flex: 1,
+    backgroundColor: Colors.primary.fondPremier,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  loadingText: { color: "white", marginTop: 12 },
+  errorBanner: {
+    backgroundColor: "rgba(255, 107, 107, 0.15)",
+    borderColor: "#ff6b6b",
+    borderWidth: 1,
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 12,
+  },
+  errorText: { color: "#ff6b6b" },
+  playlistRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderRadius: 12,
+    padding: 12,
+    borderWidth: 1,
+    borderColor: "rgba(255, 255, 255, 0.08)",
+  },
+  cover: {
+    width: 56,
+    height: 56,
+    borderRadius: 8,
+    backgroundColor: "#222",
+  },
+  coverPlaceholder: { backgroundColor: "#333" },
+  info: { flex: 1 },
+  name: { color: "white", fontSize: 16, fontWeight: "600" },
+  genre: { color: "#999", fontSize: 13, marginTop: 2 },
+});

--- a/front-mobile/components/feature/parkeur/ParkeurResultScreen.tsx
+++ b/front-mobile/components/feature/parkeur/ParkeurResultScreen.tsx
@@ -1,0 +1,124 @@
+import { ScrollView, StyleSheet, View } from "react-native";
+import { MaterialIcons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import { ThemedText } from "@/components/ThemedText";
+import Button from "@/components/Button";
+import Header from "@/components/Header";
+import { Colors } from "@/constants/Colors";
+import type { ParkeurAnswer, ParkeurRound } from "@/types/gameSession";
+
+interface Props {
+  rounds: ParkeurRound[];
+  answers: ParkeurAnswer[];
+  score: number;
+  maxScore: number;
+  onReplay: () => void;
+}
+
+function ratingFor(percentage: number): string {
+  if (percentage >= 80) return "Excellent !";
+  if (percentage >= 60) return "Très bien !";
+  if (percentage >= 40) return "Pas mal !";
+  return "Continue à t'entraîner !";
+}
+
+export default function ParkeurResultScreen({
+  rounds,
+  answers,
+  score,
+  maxScore,
+  onReplay,
+}: Props) {
+  const percentage = maxScore > 0 ? Math.round((score / maxScore) * 100) : 0;
+  return (
+    <>
+      <Header title="Parkeur" variant="withBack" />
+      <ScrollView
+        style={styles.container}
+        contentContainerStyle={styles.content}
+      >
+        <View style={styles.scoreSection}>
+          <MaterialIcons
+            name="emoji-events"
+            size={64}
+            color={Colors.primary.survol}
+          />
+          <ThemedText type="title" style={styles.scoreValue}>
+            {score}/{maxScore}
+          </ThemedText>
+          <ThemedText style={styles.percentage}>{percentage}%</ThemedText>
+          <ThemedText style={styles.rating}>{ratingFor(percentage)}</ThemedText>
+        </View>
+
+        <View style={styles.recapSection}>
+          <ThemedText type="subtitle" style={styles.recapTitle}>
+            Récapitulatif
+          </ThemedText>
+          {rounds.map((round, idx) => {
+            const answer = answers[idx];
+            const correct = answer?.correct ?? false;
+            return (
+              <View key={`${round.trackId}-${idx}`} style={styles.recapRow}>
+                <MaterialIcons
+                  name={correct ? "check-circle" : "cancel"}
+                  size={20}
+                  color={correct ? "#4ade80" : "#ff6b6b"}
+                />
+                <View style={styles.recapInfo}>
+                  <ThemedText style={styles.recapArtist}>
+                    {round.artist}
+                  </ThemedText>
+                  <ThemedText style={styles.recapTitleText}>
+                    {round.title}
+                  </ThemedText>
+                  <ThemedText style={styles.recapExpected}>
+                    « {round.answerLine} »
+                  </ThemedText>
+                </View>
+              </View>
+            );
+          })}
+        </View>
+
+        <View style={styles.actions}>
+          <Button title="Rejouer" onPress={onReplay} style={styles.cta} />
+          <Button
+            title="Retour aux jeux"
+            variant="outline"
+            onPress={() => router.replace("/games")}
+            style={styles.cta}
+          />
+        </View>
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: Colors.primary.fondPremier },
+  content: { padding: 20, paddingBottom: 40, gap: 24 },
+  scoreSection: { alignItems: "center", paddingVertical: 30 },
+  scoreValue: { marginTop: 14, color: "white" },
+  percentage: { color: Colors.primary.survol, fontSize: 22, marginTop: 4 },
+  rating: { color: "#bbb", marginTop: 6 },
+  recapSection: { gap: 12 },
+  recapTitle: { color: "white", marginBottom: 6 },
+  recapRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 12,
+    backgroundColor: "rgba(255, 255, 255, 0.04)",
+    padding: 12,
+    borderRadius: 10,
+  },
+  recapInfo: { flex: 1 },
+  recapArtist: {
+    color: Colors.primary.survol,
+    fontSize: 12,
+    textTransform: "uppercase",
+  },
+  recapTitleText: { color: "white", fontSize: 14, fontWeight: "600" },
+  recapExpected: { color: "#ccc", marginTop: 4, fontStyle: "italic" },
+  actions: { gap: 12, marginTop: 20 },
+  cta: { paddingVertical: 16 },
+});

--- a/front-mobile/components/games/GameHistory.tsx
+++ b/front-mobile/components/games/GameHistory.tsx
@@ -155,10 +155,12 @@ export function HistoryRow({ session, currentUserId }: HistoryRowProps) {
     : undefined;
   // gameData.score is the authoritative final score for solo games (mobile updates
   // it on completion). players[].score stays at 0 in the DB, so prefer gameData.
-  const gameDataScore = (session.gameData as { score?: unknown } | undefined)
-    ?.score;
-  const score =
-    typeof gameDataScore === "number" ? gameDataScore : playerEntry?.score;
+  const rawScore = (session.gameData as { score?: unknown } | undefined)?.score;
+  const numericScore =
+    typeof rawScore === "number" ? rawScore : Number(rawScore);
+  const score = Number.isFinite(numericScore)
+    ? numericScore
+    : playerEntry?.score;
   const rank = playerEntry?.rank;
   const playerCount = session.players?.length ?? 0;
   const isMultiplayer = playerCount > 1;

--- a/front-mobile/components/games/GameHistory.tsx
+++ b/front-mobile/components/games/GameHistory.tsx
@@ -153,7 +153,12 @@ export function HistoryRow({ session, currentUserId }: HistoryRowProps) {
   const playerEntry = currentUserId
     ? session.players?.find((p) => p.userId === currentUserId)
     : undefined;
-  const score = playerEntry?.score;
+  // gameData.score is the authoritative final score for solo games (mobile updates
+  // it on completion). players[].score stays at 0 in the DB, so prefer gameData.
+  const gameDataScore = (session.gameData as { score?: unknown } | undefined)
+    ?.score;
+  const score =
+    typeof gameDataScore === "number" ? gameDataScore : playerEntry?.score;
   const rank = playerEntry?.rank;
   const playerCount = session.players?.length ?? 0;
   const isMultiplayer = playerCount > 1;

--- a/front-mobile/hooks/feature/parkeur/__tests__/useParkeurGame.test.ts
+++ b/front-mobile/hooks/feature/parkeur/__tests__/useParkeurGame.test.ts
@@ -1,0 +1,374 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+import { useParkeurGame } from "../useParkeurGame";
+import { useLocalSearchParams } from "expo-router";
+import { useAuthStore } from "@/stores/authStore";
+import {
+  getMyActiveSession,
+  updateGameSession,
+} from "@/services/gameSessionService";
+import {
+  CuratedPlaylist,
+  getCuratedPlaylists,
+} from "@/services/curatedPlaylistService";
+import { startParkeurSession } from "@/services/parkeurService";
+import {
+  deleteGameState,
+  getGameState,
+  saveGameState,
+} from "@/services/gameStorageService";
+import type { ParkeurRound } from "@/types/gameSession";
+
+jest.mock("@/services/gameSessionService");
+jest.mock("@/services/curatedPlaylistService");
+jest.mock("@/services/parkeurService");
+jest.mock("@/services/gameStorageService");
+jest.mock("@/stores/authStore");
+jest.mock("expo-router", () => ({
+  useLocalSearchParams: jest.fn(),
+  router: { back: jest.fn(), push: jest.fn() },
+}));
+
+const mockUseLocalSearchParams = useLocalSearchParams as jest.MockedFunction<
+  typeof useLocalSearchParams
+>;
+const mockUseAuthStore = useAuthStore as unknown as jest.Mock;
+const mockGetCuratedPlaylists = getCuratedPlaylists as jest.MockedFunction<
+  typeof getCuratedPlaylists
+>;
+const mockStartParkeurSession = startParkeurSession as jest.MockedFunction<
+  typeof startParkeurSession
+>;
+const mockUpdateGameSession = updateGameSession as jest.MockedFunction<
+  typeof updateGameSession
+>;
+const mockGetMyActiveSession = getMyActiveSession as jest.MockedFunction<
+  typeof getMyActiveSession
+>;
+const mockGetGameState = getGameState as jest.MockedFunction<
+  typeof getGameState
+>;
+const mockSaveGameState = saveGameState as jest.MockedFunction<
+  typeof saveGameState
+>;
+const mockDeleteGameState = deleteGameState as jest.MockedFunction<
+  typeof deleteGameState
+>;
+
+const buildPlaylist = (id: number, name: string): CuratedPlaylist => ({
+  id,
+  deezerPlaylistId: id * 100,
+  name,
+  genreLabel: "Rap FR",
+  coverUrl: null,
+  trackCount: 50,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+});
+
+const buildRound = (id: number, answer: string): ParkeurRound => ({
+  trackId: id,
+  artist: `Artist ${id}`,
+  title: `Track ${id}`,
+  coverUrl: null,
+  lines: [`Line ${id}.1`, `Line ${id}.2`],
+  answerLine: answer,
+});
+
+describe("useParkeurGame", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "42" });
+    mockUseAuthStore.mockImplementation((selector: any) =>
+      selector({ user: { id: "user-1", email: "u@u.fr" } }),
+    );
+    mockGetCuratedPlaylists.mockResolvedValue([buildPlaylist(1, "Rap FR")]);
+    mockUpdateGameSession.mockResolvedValue({} as any);
+    mockGetMyActiveSession.mockResolvedValue(null);
+    mockGetGameState.mockResolvedValue(null);
+    mockSaveGameState.mockResolvedValue();
+    mockDeleteGameState.mockResolvedValue();
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("loads playlists on mount", async () => {
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => {
+      expect(result.current.loadingPlaylists).toBe(false);
+    });
+    expect(result.current.playlists).toHaveLength(1);
+    expect(result.current.gameState).toBe("selection");
+  });
+
+  it("starts a game and exposes the first round", async () => {
+    mockStartParkeurSession.mockResolvedValue({
+      session: { id: "sess-1" } as any,
+      rounds: [buildRound(1, "Premier"), buildRound(2, "Deuxième")],
+    });
+
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
+    await act(async () => {
+      await result.current.startWithPlaylist(buildPlaylist(1, "Rap FR"));
+    });
+
+    expect(result.current.gameState).toBe("playing");
+    expect(result.current.rounds).toHaveLength(2);
+    expect(result.current.currentRound?.answerLine).toBe("Premier");
+  });
+
+  it("scores a correct answer (case/accent tolerant) and advances on goToNextRound", async () => {
+    mockStartParkeurSession.mockResolvedValue({
+      session: { id: "sess-2" } as any,
+      rounds: [buildRound(1, "Téléphone"), buildRound(2, "Suivante")],
+    });
+
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+    await act(async () => {
+      await result.current.startWithPlaylist(buildPlaylist(1, "Pop"));
+    });
+
+    act(() => {
+      result.current.submitAnswer("telephone");
+    });
+
+    expect(result.current.gameState).toBe("reveal");
+    expect(result.current.score).toBe(1);
+    expect(result.current.lastAnswer?.correct).toBe(true);
+    expect(mockUpdateGameSession).toHaveBeenCalledWith(
+      "sess-2",
+      expect.objectContaining({
+        gameData: expect.objectContaining({ score: 1 }),
+      }),
+    );
+
+    // No auto-advance: still on reveal until the player taps "Next".
+    act(() => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(result.current.gameState).toBe("reveal");
+
+    act(() => result.current.goToNextRound());
+
+    expect(result.current.gameState).toBe("playing");
+    expect(result.current.currentRoundIndex).toBe(1);
+  });
+
+  it("skipRound records an empty incorrect answer and stays in reveal", async () => {
+    mockStartParkeurSession.mockResolvedValue({
+      session: { id: "sess-skip" } as any,
+      rounds: [buildRound(1, "Anything"), buildRound(2, "Suivante")],
+    });
+
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+    await act(async () => {
+      await result.current.startWithPlaylist(buildPlaylist(1, "Pop"));
+    });
+
+    act(() => result.current.skipRound());
+
+    expect(result.current.gameState).toBe("reveal");
+    expect(result.current.score).toBe(0);
+    expect(result.current.lastAnswer?.correct).toBe(false);
+    expect(result.current.lastAnswer?.userInput).toBe("");
+  });
+
+  it("ignores skipRound and goToNextRound when called in the wrong state", async () => {
+    mockStartParkeurSession.mockResolvedValue({
+      session: { id: "sess-noop" } as any,
+      rounds: [buildRound(1, "Anything")],
+    });
+
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+    // skipRound from selection state → no-op
+    act(() => result.current.skipRound());
+    expect(result.current.gameState).toBe("selection");
+    // goToNextRound from selection state → no-op
+    act(() => result.current.goToNextRound());
+    expect(result.current.gameState).toBe("selection");
+  });
+
+  it("scores an incorrect answer as 0", async () => {
+    mockStartParkeurSession.mockResolvedValue({
+      session: { id: "sess-3" } as any,
+      rounds: [buildRound(1, "Bonjour"), buildRound(2, "Suivante")],
+    });
+
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+    await act(async () => {
+      await result.current.startWithPlaylist(buildPlaylist(1, "Pop"));
+    });
+
+    act(() => {
+      result.current.submitAnswer("au revoir");
+    });
+
+    expect(result.current.score).toBe(0);
+    expect(result.current.lastAnswer?.correct).toBe(false);
+  });
+
+  it("transitions to result on goToNextRound after the last round", async () => {
+    mockStartParkeurSession.mockResolvedValue({
+      session: { id: "sess-end" } as any,
+      rounds: [buildRound(1, "Final")],
+    });
+
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+    await act(async () => {
+      await result.current.startWithPlaylist(buildPlaylist(1, "Pop"));
+    });
+
+    act(() => {
+      result.current.submitAnswer("Final");
+    });
+    act(() => result.current.goToNextRound());
+
+    expect(result.current.gameState).toBe("result");
+    expect(result.current.score).toBe(1);
+    expect(mockUpdateGameSession).toHaveBeenLastCalledWith(
+      "sess-end",
+      expect.objectContaining({
+        status: "completed",
+        gameData: expect.objectContaining({ score: 1 }),
+      }),
+    );
+  });
+
+  it("surfaces an error message when startParkeurSession fails", async () => {
+    mockStartParkeurSession.mockRejectedValue(new Error("Boom"));
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+
+    await act(async () => {
+      await result.current.startWithPlaylist(buildPlaylist(1, "Pop"));
+    });
+
+    expect(result.current.gameState).toBe("selection");
+    expect(result.current.errorMessage).toBe("Boom");
+  });
+
+  it("resetGame clears state back to selection", async () => {
+    mockStartParkeurSession.mockResolvedValue({
+      session: { id: "sess-r" } as any,
+      rounds: [buildRound(1, "X")],
+    });
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+    await act(async () => {
+      await result.current.startWithPlaylist(buildPlaylist(1, "Pop"));
+    });
+    act(() => result.current.resetGame());
+    expect(result.current.gameState).toBe("selection");
+    expect(result.current.rounds).toHaveLength(0);
+    expect(mockDeleteGameState).toHaveBeenCalledWith("42");
+  });
+
+  it("resumes from saved AsyncStorage state when resume=true", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "42", resume: "true" });
+    const savedRounds = [buildRound(11, "Suite"), buildRound(12, "Encore")];
+    mockGetGameState.mockResolvedValue({
+      selectedPlaylist: buildPlaylist(7, "Saved"),
+      rounds: savedRounds,
+      currentRoundIndex: 1,
+      score: 1,
+      answers: [
+        {
+          correct: true,
+          durationMs: 1234,
+          userInput: "Suite",
+          expected: "Suite",
+        },
+      ],
+      sessionId: "sess-saved",
+      startedAt: Date.now() - 60_000,
+    } as any);
+
+    const { result } = renderHook(() => useParkeurGame());
+
+    await waitFor(() => expect(result.current.gameState).toBe("playing"));
+    expect(result.current.rounds).toHaveLength(2);
+    expect(result.current.currentRoundIndex).toBe(1);
+    expect(result.current.score).toBe(1);
+    expect(result.current.currentRound?.answerLine).toBe("Encore");
+    expect(mockGetGameState).toHaveBeenCalledWith("42");
+    expect(mockDeleteGameState).not.toHaveBeenCalled();
+  });
+
+  it("hydrates from server active session when resume=true and no local save exists", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "42", resume: "true" });
+    mockGetGameState.mockResolvedValue(null);
+    mockGetMyActiveSession.mockResolvedValue({
+      id: "sess-server",
+      gameData: {
+        playlistId: 9,
+        playlistName: "Server Pop",
+        rounds: [buildRound(20, "Server line"), buildRound(21, "Other")],
+        currentRound: 1,
+        score: 1,
+        answers: [
+          {
+            correct: true,
+            durationMs: 800,
+            userInput: "Server line",
+            expected: "Server line",
+          },
+        ],
+        startedAt: "2026-05-04T10:00:00.000Z",
+      },
+    } as any);
+
+    const { result } = renderHook(() => useParkeurGame());
+
+    await waitFor(() => expect(result.current.gameState).toBe("playing"));
+    expect(mockGetMyActiveSession).toHaveBeenCalledWith(42);
+    expect(result.current.rounds).toHaveLength(2);
+    expect(result.current.currentRoundIndex).toBe(1);
+    expect(result.current.score).toBe(1);
+    expect(result.current.currentRound?.answerLine).toBe("Other");
+  });
+
+  it("clears any stale saved state when entering without resume", async () => {
+    mockUseLocalSearchParams.mockReturnValue({ gameId: "42" });
+    renderHook(() => useParkeurGame());
+    await waitFor(() => expect(mockDeleteGameState).toHaveBeenCalledWith("42"));
+  });
+
+  it("persists saved state on startGame and clears it on completion", async () => {
+    mockStartParkeurSession.mockResolvedValue({
+      session: { id: "sess-final" } as any,
+      rounds: [buildRound(1, "Final")],
+    });
+    const { result } = renderHook(() => useParkeurGame());
+    await waitFor(() => expect(result.current.loadingPlaylists).toBe(false));
+    await act(async () => {
+      await result.current.startWithPlaylist(buildPlaylist(1, "Pop"));
+    });
+    expect(mockSaveGameState).toHaveBeenCalledWith(
+      "42",
+      expect.objectContaining({
+        sessionId: "sess-final",
+        currentRoundIndex: 0,
+      }),
+    );
+
+    act(() => {
+      result.current.submitAnswer("Final");
+    });
+    act(() => result.current.goToNextRound());
+
+    expect(result.current.gameState).toBe("result");
+    expect(mockDeleteGameState).toHaveBeenCalledWith("42");
+  });
+});

--- a/front-mobile/hooks/feature/parkeur/useParkeurGame.ts
+++ b/front-mobile/hooks/feature/parkeur/useParkeurGame.ts
@@ -1,0 +1,445 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useLocalSearchParams } from "expo-router";
+import { useAuthStore } from "@/stores/authStore";
+import {
+  getMyActiveSession,
+  updateGameSession,
+} from "@/services/gameSessionService";
+import {
+  CuratedPlaylist,
+  getCuratedPlaylists,
+} from "@/services/curatedPlaylistService";
+import { startParkeurSession } from "@/services/parkeurService";
+import {
+  deleteGameState,
+  getGameState,
+  saveGameState,
+} from "@/services/gameStorageService";
+import type { ParkeurAnswer, ParkeurRound } from "@/types/gameSession";
+import { compareAnswers } from "@/utils/parkeur";
+
+export type ParkeurGameState =
+  | "selection"
+  | "loading"
+  | "playing"
+  | "reveal"
+  | "result";
+
+export type ParkeurMode = "pick" | "playlist" | "artist";
+
+export interface ParkeurArtist {
+  id: number;
+  name: string;
+  pictureUrl?: string;
+}
+
+interface ParkeurSaveState {
+  selectedPlaylist: CuratedPlaylist | null;
+  selectedArtist: ParkeurArtist | null;
+  rounds: ParkeurRound[];
+  currentRoundIndex: number;
+  score: number;
+  answers: ParkeurAnswer[];
+  sessionId: string;
+  startedAt: number;
+}
+
+export interface UseParkeurGameResult {
+  gameState: ParkeurGameState;
+  mode: ParkeurMode;
+  setMode: (mode: ParkeurMode) => void;
+  playlists: CuratedPlaylist[];
+  loadingPlaylists: boolean;
+  selectedPlaylist: CuratedPlaylist | null;
+  selectedArtist: ParkeurArtist | null;
+  sessionId: string | null;
+  rounds: ParkeurRound[];
+  currentRoundIndex: number;
+  currentRound: ParkeurRound | null;
+  score: number;
+  answers: ParkeurAnswer[];
+  lastAnswer: ParkeurAnswer | null;
+  startWithPlaylist: (playlist: CuratedPlaylist) => Promise<void>;
+  startWithArtist: (artist: ParkeurArtist) => Promise<void>;
+  submitAnswer: (input: string) => void;
+  skipRound: () => void;
+  goToNextRound: () => void;
+  resetGame: () => void;
+  abandonGame: () => void;
+  saveCurrentState: () => void;
+  errorMessage: string | null;
+}
+
+export function useParkeurGame(): UseParkeurGameResult {
+  const { gameId, resume } = useLocalSearchParams<{
+    gameId: string;
+    resume?: string;
+  }>();
+  const user = useAuthStore((state) => state.user);
+
+  const [gameState, setGameState] = useState<ParkeurGameState>("selection");
+  const [mode, setMode] = useState<ParkeurMode>("pick");
+  const [playlists, setPlaylists] = useState<CuratedPlaylist[]>([]);
+  const [loadingPlaylists, setLoadingPlaylists] = useState(true);
+  const [selectedPlaylist, setSelectedPlaylist] =
+    useState<CuratedPlaylist | null>(null);
+  const [selectedArtist, setSelectedArtist] = useState<ParkeurArtist | null>(
+    null,
+  );
+  const [rounds, setRounds] = useState<ParkeurRound[]>([]);
+  const [currentRoundIndex, setCurrentRoundIndex] = useState(0);
+  const [score, setScore] = useState(0);
+  const [answers, setAnswers] = useState<ParkeurAnswer[]>([]);
+  const [lastAnswer, setLastAnswer] = useState<ParkeurAnswer | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const startedAtRef = useRef<number>(0);
+  const roundStartedAtRef = useRef<number>(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoadingPlaylists(true);
+      try {
+        const data = await getCuratedPlaylists();
+        if (!cancelled) setPlaylists(data);
+      } catch (error) {
+        console.error("[Parkeur] Failed to load playlists:", error);
+        if (!cancelled) setErrorMessage("Impossible de charger les playlists.");
+      } finally {
+        if (!cancelled) setLoadingPlaylists(false);
+      }
+    };
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!gameId) return;
+    let cancelled = false;
+    const restore = async () => {
+      if (resume !== "true") {
+        await deleteGameState(gameId);
+        return;
+      }
+      const saved = await getGameState<ParkeurSaveState>(gameId);
+      if (!cancelled && saved) {
+        setSelectedPlaylist(saved.selectedPlaylist);
+        setSelectedArtist(saved.selectedArtist);
+        setRounds(saved.rounds);
+        setCurrentRoundIndex(saved.currentRoundIndex);
+        setScore(saved.score);
+        setAnswers(saved.answers);
+        setSessionId(saved.sessionId);
+        setLastAnswer(null);
+        startedAtRef.current = saved.startedAt;
+        roundStartedAtRef.current = Date.now();
+        setGameState("playing");
+        return;
+      }
+      // No local save (reinstall, different device, AsyncStorage cleared) —
+      // hydrate from the server-side active session instead.
+      try {
+        const session = await getMyActiveSession(Number(gameId));
+        if (cancelled || !session) return;
+        const data = session.gameData as any;
+        const serverRounds: ParkeurRound[] = data?.rounds ?? [];
+        if (serverRounds.length === 0) return;
+        const playlist = data?.playlistName
+          ? ({
+              id: data.playlistId ?? 0,
+              name: data.playlistName,
+              deezerPlaylistId: 0,
+              genreLabel: "",
+              coverUrl: null,
+              trackCount: 0,
+              createdAt: "",
+              updatedAt: "",
+            } as CuratedPlaylist)
+          : null;
+        const artist: ParkeurArtist | null = data?.artistName
+          ? { id: data.artistId ?? 0, name: data.artistName }
+          : null;
+        const startedAt = data?.startedAt
+          ? new Date(data.startedAt).getTime()
+          : Date.now();
+        setSelectedPlaylist(playlist);
+        setSelectedArtist(artist);
+        setRounds(serverRounds);
+        setCurrentRoundIndex(data?.currentRound ?? 0);
+        setScore(data?.score ?? 0);
+        setAnswers(data?.answers ?? []);
+        setSessionId(session.id);
+        setLastAnswer(null);
+        startedAtRef.current = startedAt;
+        roundStartedAtRef.current = Date.now();
+        setGameState("playing");
+      } catch (error) {
+        console.warn("[Parkeur] Failed to hydrate from server:", error);
+      }
+    };
+    void restore();
+    return () => {
+      cancelled = true;
+    };
+  }, [gameId, resume]);
+
+  const persistState = useCallback(
+    (overrides: Partial<ParkeurSaveState> = {}) => {
+      if (!gameId || !sessionId) return;
+      if (!selectedPlaylist && !selectedArtist) return;
+      const state: ParkeurSaveState = {
+        selectedPlaylist,
+        selectedArtist,
+        rounds,
+        currentRoundIndex,
+        score,
+        answers,
+        sessionId,
+        startedAt: startedAtRef.current,
+        ...overrides,
+      };
+      void saveGameState(gameId, state);
+    },
+    [
+      gameId,
+      sessionId,
+      selectedPlaylist,
+      selectedArtist,
+      rounds,
+      currentRoundIndex,
+      score,
+      answers,
+    ],
+  );
+
+  const launchSession = useCallback(
+    async (
+      input: { playlistId: number } | { artistId: number },
+      onSuccess: (
+        result: Awaited<ReturnType<typeof startParkeurSession>>,
+        startedAt: number,
+      ) => Promise<void>,
+    ) => {
+      if (!user || !gameId) return;
+      setGameState("loading");
+      setErrorMessage(null);
+      try {
+        const result = await startParkeurSession(input);
+        const startedAt = Date.now();
+        setRounds(result.rounds);
+        setSessionId(result.session.id);
+        setCurrentRoundIndex(0);
+        setScore(0);
+        setAnswers([]);
+        setLastAnswer(null);
+        startedAtRef.current = startedAt;
+        roundStartedAtRef.current = startedAt;
+        setGameState("playing");
+        await onSuccess(result, startedAt);
+      } catch (error: any) {
+        console.error("[Parkeur] startParkeurSession failed:", error);
+        const message =
+          error?.message ??
+          "Impossible de démarrer la partie. Essaie une autre source.";
+        setErrorMessage(message);
+        setGameState("selection");
+      }
+    },
+    [user, gameId],
+  );
+
+  const startWithPlaylist = useCallback(
+    async (playlist: CuratedPlaylist) => {
+      setSelectedPlaylist(playlist);
+      setSelectedArtist(null);
+      await launchSession(
+        { playlistId: playlist.id },
+        async (result, startedAt) => {
+          if (!gameId) return;
+          await saveGameState<ParkeurSaveState>(gameId, {
+            selectedPlaylist: playlist,
+            selectedArtist: null,
+            rounds: result.rounds,
+            currentRoundIndex: 0,
+            score: 0,
+            answers: [],
+            sessionId: result.session.id,
+            startedAt,
+          });
+        },
+      );
+    },
+    [gameId, launchSession],
+  );
+
+  const startWithArtist = useCallback(
+    async (artist: ParkeurArtist) => {
+      setSelectedArtist(artist);
+      setSelectedPlaylist(null);
+      await launchSession(
+        { artistId: artist.id },
+        async (result, startedAt) => {
+          if (!gameId) return;
+          await saveGameState<ParkeurSaveState>(gameId, {
+            selectedPlaylist: null,
+            selectedArtist: artist,
+            rounds: result.rounds,
+            currentRoundIndex: 0,
+            score: 0,
+            answers: [],
+            sessionId: result.session.id,
+            startedAt,
+          });
+        },
+      );
+    },
+    [gameId, launchSession],
+  );
+
+  const finishGame = useCallback(
+    (finalAnswers: ParkeurAnswer[], finalScore: number) => {
+      if (gameId) void deleteGameState(gameId);
+      if (!sessionId) {
+        setGameState("result");
+        return;
+      }
+      const startedAt = startedAtRef.current || Date.now();
+      const completedAt = Date.now();
+      const timeElapsed = Math.round((completedAt - startedAt) / 1000);
+      updateGameSession(sessionId, {
+        status: "completed",
+        gameData: {
+          score: finalScore,
+          answers: finalAnswers,
+          completedAt: new Date(completedAt).toISOString(),
+          timeElapsed,
+          currentRound: finalAnswers.length,
+        } as unknown as Record<string, unknown>,
+      }).catch((e) =>
+        console.warn("[Parkeur] Final session update failed:", e),
+      );
+      setGameState("result");
+    },
+    [sessionId, gameId],
+  );
+
+  const recordAnswer = useCallback(
+    (input: string, correct: boolean) => {
+      const round = rounds[currentRoundIndex];
+      if (!round) return;
+      const durationMs = Date.now() - roundStartedAtRef.current;
+      const answer: ParkeurAnswer = {
+        correct,
+        durationMs,
+        userInput: input,
+        expected: round.answerLine,
+      };
+      const nextAnswers = [...answers, answer];
+      const nextScore = score + (correct ? 1 : 0);
+      setAnswers(nextAnswers);
+      setScore(nextScore);
+      setLastAnswer(answer);
+      setGameState("reveal");
+
+      persistState({ answers: nextAnswers, score: nextScore });
+
+      if (sessionId) {
+        updateGameSession(sessionId, {
+          gameData: {
+            score: nextScore,
+            answers: nextAnswers,
+            currentRound: currentRoundIndex + 1,
+          } as unknown as Record<string, unknown>,
+        }).catch((e) => console.warn("[Parkeur] Session update failed:", e));
+      }
+    },
+    [rounds, currentRoundIndex, answers, score, sessionId, persistState],
+  );
+
+  const submitAnswer = useCallback(
+    (input: string) => {
+      if (gameState !== "playing") return;
+      const round = rounds[currentRoundIndex];
+      if (!round) return;
+      const correct = compareAnswers(input, round.answerLine);
+      recordAnswer(input, correct);
+    },
+    [gameState, rounds, currentRoundIndex, recordAnswer],
+  );
+
+  const skipRound = useCallback(() => {
+    if (gameState !== "playing") return;
+    recordAnswer("", false);
+  }, [gameState, recordAnswer]);
+
+  const goToNextRound = useCallback(() => {
+    if (gameState !== "reveal") return;
+    const isLast = currentRoundIndex + 1 >= rounds.length;
+    if (isLast) {
+      finishGame(answers, score);
+      return;
+    }
+    const nextIndex = currentRoundIndex + 1;
+    setCurrentRoundIndex(nextIndex);
+    setLastAnswer(null);
+    roundStartedAtRef.current = Date.now();
+    setGameState("playing");
+    persistState({ currentRoundIndex: nextIndex });
+  }, [
+    gameState,
+    currentRoundIndex,
+    rounds.length,
+    answers,
+    score,
+    finishGame,
+    persistState,
+  ]);
+
+  const resetGame = useCallback(() => {
+    if (gameId) void deleteGameState(gameId);
+    setGameState("selection");
+    setMode("pick");
+    setSelectedPlaylist(null);
+    setSelectedArtist(null);
+    setRounds([]);
+    setCurrentRoundIndex(0);
+    setScore(0);
+    setAnswers([]);
+    setLastAnswer(null);
+    setSessionId(null);
+    setErrorMessage(null);
+  }, [gameId]);
+
+  const abandonGame = useCallback(() => {
+    finishGame(answers, score);
+  }, [answers, score, finishGame]);
+
+  return {
+    gameState,
+    mode,
+    setMode,
+    playlists,
+    loadingPlaylists,
+    selectedPlaylist,
+    selectedArtist,
+    sessionId,
+    rounds,
+    currentRoundIndex,
+    currentRound: rounds[currentRoundIndex] ?? null,
+    score,
+    answers,
+    lastAnswer,
+    startWithPlaylist,
+    startWithArtist,
+    submitAnswer,
+    skipRound,
+    goToNextRound,
+    resetGame,
+    abandonGame,
+    saveCurrentState: persistState,
+    errorMessage,
+  };
+}

--- a/front-mobile/hooks/feature/parkeur/useParkeurGame.ts
+++ b/front-mobile/hooks/feature/parkeur/useParkeurGame.ts
@@ -15,7 +15,11 @@ import {
   getGameState,
   saveGameState,
 } from "@/services/gameStorageService";
-import type { ParkeurAnswer, ParkeurRound } from "@/types/gameSession";
+import type {
+  ParkeurAnswer,
+  ParkeurGameData,
+  ParkeurRound,
+} from "@/types/gameSession";
 import { compareAnswers } from "@/utils/parkeur";
 
 export type ParkeurGameState =
@@ -144,10 +148,10 @@ export function useParkeurGame(): UseParkeurGameResult {
       try {
         const session = await getMyActiveSession(Number(gameId));
         if (cancelled || !session) return;
-        const data = session.gameData as any;
-        const serverRounds: ParkeurRound[] = data?.rounds ?? [];
+        const data = session.gameData as Partial<ParkeurGameData>;
+        const serverRounds = data.rounds ?? [];
         if (serverRounds.length === 0) return;
-        const playlist = data?.playlistName
+        const playlist = data.playlistName
           ? ({
               id: data.playlistId ?? 0,
               name: data.playlistName,
@@ -159,18 +163,22 @@ export function useParkeurGame(): UseParkeurGameResult {
               updatedAt: "",
             } as CuratedPlaylist)
           : null;
-        const artist: ParkeurArtist | null = data?.artistName
+        const artist: ParkeurArtist | null = data.artistName
           ? { id: data.artistId ?? 0, name: data.artistName }
           : null;
-        const startedAt = data?.startedAt
+        const startedAt = data.startedAt
           ? new Date(data.startedAt).getTime()
           : Date.now();
+        const restoredRound = Math.min(
+          Math.max(data.currentRound ?? 0, 0),
+          Math.max(serverRounds.length - 1, 0),
+        );
         setSelectedPlaylist(playlist);
         setSelectedArtist(artist);
         setRounds(serverRounds);
-        setCurrentRoundIndex(data?.currentRound ?? 0);
-        setScore(data?.score ?? 0);
-        setAnswers(data?.answers ?? []);
+        setCurrentRoundIndex(restoredRound);
+        setScore(data.score ?? 0);
+        setAnswers(data.answers ?? []);
         setSessionId(session.id);
         setLastAnswer(null);
         startedAtRef.current = startedAt;
@@ -309,15 +317,16 @@ export function useParkeurGame(): UseParkeurGameResult {
       const startedAt = startedAtRef.current || Date.now();
       const completedAt = Date.now();
       const timeElapsed = Math.round((completedAt - startedAt) / 1000);
+      const finalGameData: Partial<ParkeurGameData> = {
+        score: finalScore,
+        answers: finalAnswers,
+        completedAt: new Date(completedAt).toISOString(),
+        timeElapsed,
+        currentRound: finalAnswers.length,
+      };
       updateGameSession(sessionId, {
         status: "completed",
-        gameData: {
-          score: finalScore,
-          answers: finalAnswers,
-          completedAt: new Date(completedAt).toISOString(),
-          timeElapsed,
-          currentRound: finalAnswers.length,
-        } as unknown as Record<string, unknown>,
+        gameData: finalGameData as Record<string, unknown>,
       }).catch((e) =>
         console.warn("[Parkeur] Final session update failed:", e),
       );
@@ -347,12 +356,13 @@ export function useParkeurGame(): UseParkeurGameResult {
       persistState({ answers: nextAnswers, score: nextScore });
 
       if (sessionId) {
+        const partialUpdate: Partial<ParkeurGameData> = {
+          score: nextScore,
+          answers: nextAnswers,
+          currentRound: currentRoundIndex + 1,
+        };
         updateGameSession(sessionId, {
-          gameData: {
-            score: nextScore,
-            answers: nextAnswers,
-            currentRound: currentRoundIndex + 1,
-          } as unknown as Record<string, unknown>,
+          gameData: partialUpdate as Record<string, unknown>,
         }).catch((e) => console.warn("[Parkeur] Session update failed:", e));
       }
     },

--- a/front-mobile/hooks/useGameIndex.ts
+++ b/front-mobile/hooks/useGameIndex.ts
@@ -13,9 +13,19 @@ import * as Haptics from "expo-haptics";
 interface UseGameIndexOptions {
   gameName: string;
   gamePath: string;
+  /**
+   * When true, an active server session is treated as resumable even if no local
+   * AsyncStorage save exists. Set this for games whose round data lives on the
+   * server (e.g. Parkeur) so reinstalls/cross-device users don't lose progress.
+   */
+  canResumeFromServer?: boolean;
 }
 
-export function useGameIndex({ gameName, gamePath }: UseGameIndexOptions) {
+export function useGameIndex({
+  gameName,
+  gamePath,
+  canResumeFromServer = false,
+}: UseGameIndexOptions) {
   const [gameId, setGameId] = useState<number | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -39,12 +49,21 @@ export function useGameIndex({ gameName, gamePath }: UseGameIndexOptions) {
       );
       if (game) {
         setGameId(game.id);
-        const [savedStateExists, history] = await Promise.all([
-          hasGameState(game.id.toString()),
-          getMyGameHistory(game.id, { limit: 1 }),
-        ]);
+        const [savedStateExists, history, activeServerSession] =
+          await Promise.all([
+            hasGameState(game.id.toString()),
+            getMyGameHistory(game.id, { limit: 1 }),
+            canResumeFromServer
+              ? getMyActiveSession(game.id)
+              : Promise.resolve(null),
+          ]);
         setHasSavedGame(savedStateExists);
         setHasPlayedBefore(history.meta.total > 0);
+        if (activeServerSession && activeServerSession.status === "active") {
+          setActiveSession(activeServerSession);
+        } else {
+          setActiveSession(null);
+        }
       } else {
         setError(true);
       }
@@ -83,7 +102,7 @@ export function useGameIndex({ gameName, gamePath }: UseGameIndexOptions) {
 
       if (session && session.status === "active") {
         const localSaveExists = await hasGameState(gameId.toString());
-        if (localSaveExists) {
+        if (localSaveExists || canResumeFromServer) {
           setActiveSession(session);
           setIsResumeModalVisible(true);
         } else {
@@ -131,6 +150,7 @@ export function useGameIndex({ gameName, gamePath }: UseGameIndexOptions) {
     error,
     hasSavedGame,
     hasPlayedBefore,
+    activeSession,
     isResumeModalVisible,
     setIsResumeModalVisible,
     isRulesModalVisible,

--- a/front-mobile/services/__tests__/parkeurService.test.ts
+++ b/front-mobile/services/__tests__/parkeurService.test.ts
@@ -1,0 +1,69 @@
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
+
+import { searchDeezerArtists, startParkeurSession } from "../parkeurService";
+import { post } from "../api";
+import { deezerAPI } from "../deezer-api";
+
+jest.mock("../api", () => ({
+  post: jest.fn(),
+}));
+jest.mock("../deezer-api", () => ({
+  deezerAPI: { searchArtists: jest.fn() },
+  DeezerArtist: undefined,
+}));
+
+const mockPost = post as jest.MockedFunction<typeof post>;
+const mockSearchArtists = deezerAPI.searchArtists as jest.MockedFunction<
+  typeof deezerAPI.searchArtists
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("startParkeurSession", () => {
+  it("forwards the playlist input to the backend", async () => {
+    mockPost.mockResolvedValueOnce({
+      session: { id: "s1" },
+      rounds: [],
+    } as any);
+    await startParkeurSession({ playlistId: 42 });
+    expect(mockPost).toHaveBeenCalledWith("/api/games/parkeur/start", {
+      playlistId: 42,
+    });
+  });
+
+  it("forwards the artist input to the backend", async () => {
+    mockPost.mockResolvedValueOnce({
+      session: { id: "s2" },
+      rounds: [],
+    } as any);
+    await startParkeurSession({ artistId: 27 });
+    expect(mockPost).toHaveBeenCalledWith("/api/games/parkeur/start", {
+      artistId: 27,
+    });
+  });
+});
+
+describe("searchDeezerArtists", () => {
+  it("returns an empty array when the query is blank", async () => {
+    const result = await searchDeezerArtists("   ");
+    expect(result).toEqual([]);
+    expect(mockSearchArtists).not.toHaveBeenCalled();
+  });
+
+  it("delegates to deezerAPI.searchArtists with the trimmed query", async () => {
+    mockSearchArtists.mockResolvedValueOnce({
+      data: [{ id: 27, name: "Stromae" } as any],
+    });
+    const result = await searchDeezerArtists("  Stromae  ", 5);
+    expect(result).toEqual([{ id: 27, name: "Stromae" }]);
+    expect(mockSearchArtists).toHaveBeenCalledWith("Stromae", 5);
+  });
+
+  it("returns an empty array when deezerAPI returns no data field", async () => {
+    mockSearchArtists.mockResolvedValueOnce({} as any);
+    const result = await searchDeezerArtists("X");
+    expect(result).toEqual([]);
+  });
+});

--- a/front-mobile/services/parkeurService.ts
+++ b/front-mobile/services/parkeurService.ts
@@ -1,0 +1,29 @@
+import { post } from "./api";
+import { deezerAPI, DeezerArtist } from "./deezer-api";
+import type { GameSession, ParkeurRound } from "@/types/gameSession";
+
+export interface StartParkeurSessionResponse {
+  session: GameSession;
+  rounds: ParkeurRound[];
+}
+
+export type StartParkeurSessionInput =
+  | { playlistId: number }
+  | { artistId: number };
+
+export const startParkeurSession = async (
+  input: StartParkeurSessionInput,
+): Promise<StartParkeurSessionResponse> => {
+  return post<StartParkeurSessionResponse>("/api/games/parkeur/start", input);
+};
+
+export type DeezerArtistSearchResult = DeezerArtist;
+
+export const searchDeezerArtists = async (
+  query: string,
+  limit = 15,
+): Promise<DeezerArtistSearchResult[]> => {
+  if (!query.trim()) return [];
+  const response = await deezerAPI.searchArtists(query.trim(), limit);
+  return response.data ?? [];
+};

--- a/front-mobile/types/gameSession.ts
+++ b/front-mobile/types/gameSession.ts
@@ -189,3 +189,33 @@ export interface BlindtestGameData {
   startedAt: string;
   completedAt: string | null;
 }
+
+// Types spécifiques pour le jeu Parkeur (devine la suite des paroles)
+export interface ParkeurRound {
+  trackId: number;
+  artist: string;
+  title: string;
+  coverUrl: string | null;
+  lines: [string, string];
+  answerLine: string;
+}
+
+export interface ParkeurAnswer {
+  correct: boolean;
+  durationMs: number;
+  userInput: string;
+  expected: string;
+}
+
+export interface ParkeurGameData {
+  playlistId: number;
+  playlistName: string;
+  rounds: ParkeurRound[];
+  currentRound: number;
+  score: number;
+  maxScore: number;
+  answers: ParkeurAnswer[];
+  startedAt: string;
+  completedAt: string | null;
+  timeElapsed: number;
+}

--- a/front-mobile/types/gameSession.ts
+++ b/front-mobile/types/gameSession.ts
@@ -208,8 +208,10 @@ export interface ParkeurAnswer {
 }
 
 export interface ParkeurGameData {
-  playlistId: number;
-  playlistName: string;
+  playlistId?: number;
+  playlistName?: string;
+  artistId?: number;
+  artistName?: string;
   rounds: ParkeurRound[];
   currentRound: number;
   score: number;

--- a/front-mobile/utils/__tests__/parkeur.test.ts
+++ b/front-mobile/utils/__tests__/parkeur.test.ts
@@ -1,0 +1,138 @@
+import { answerHintTokens, compareAnswers, normalizeAnswer } from "../parkeur";
+
+describe("parkeur utils", () => {
+  describe("normalizeAnswer", () => {
+    it("strips accents, casing and punctuation", () => {
+      expect(normalizeAnswer("Téléphone, allô !")).toBe("telephone allo");
+    });
+
+    it("collapses repeated whitespace", () => {
+      expect(normalizeAnswer("  hello   world  ")).toBe("hello world");
+    });
+
+    it("returns empty string for whitespace only", () => {
+      expect(normalizeAnswer("   ")).toBe("");
+    });
+  });
+
+  describe("compareAnswers", () => {
+    it("matches identical strings", () => {
+      expect(compareAnswers("hello world", "hello world")).toBe(true);
+    });
+
+    it("ignores case differences", () => {
+      expect(compareAnswers("HELLO World", "hello world")).toBe(true);
+    });
+
+    it("ignores accents", () => {
+      expect(compareAnswers("telephone", "Téléphone")).toBe(true);
+    });
+
+    it("ignores punctuation", () => {
+      expect(compareAnswers("comment vas tu", "Comment vas-tu ?")).toBe(true);
+    });
+
+    it("ignores leading and trailing whitespace", () => {
+      expect(compareAnswers("  bonjour ", "bonjour")).toBe(true);
+    });
+
+    it("returns false on different content", () => {
+      expect(compareAnswers("hello", "world")).toBe(false);
+    });
+
+    it("returns false when expected is empty", () => {
+      expect(compareAnswers("hello", "   ")).toBe(false);
+    });
+
+    it("returns false when input is empty", () => {
+      expect(compareAnswers("", "hello")).toBe(false);
+    });
+
+    it("treats typographic quotes like apostrophes", () => {
+      expect(
+        compareAnswers("j’pense qu’à mailler", "j'pense qu'à mailler"),
+      ).toBe(true);
+      expect(
+        compareAnswers("j ‘pense qu ’a mailler", "j'pense qu'à mailler"),
+      ).toBe(true);
+    });
+
+    it("tolerates small typos via Levenshtein distance", () => {
+      // 1-letter typo on a long sentence should match
+      expect(
+        compareAnswers(
+          "trop souvent dans mes oreille on m'a dit laisse tomber",
+          "Trop souvent dans mes oreilles, on m'a dit laisse tomber",
+        ),
+      ).toBe(true);
+    });
+
+    it("tolerates trailing filler words like (yeah)", () => {
+      expect(
+        compareAnswers(
+          "commis tant de delits grace au baveux on s'ra gracies",
+          "Commis tant de délits, grâce au baveux, on s'ra graciés (yeah)",
+        ),
+      ).toBe(true);
+    });
+
+    it("strips long trailing parenthetical fillers", () => {
+      // Real DB case: user typed correctly but the "(gang, gang, gang)" trailer
+      // inflated the Levenshtein threshold and the answer was rejected.
+      expect(
+        compareAnswers(
+          "sur du triple chaine gang",
+          "Sur du triple chain gang (gang, gang, gang)",
+        ),
+      ).toBe(true);
+      expect(
+        compareAnswers(
+          "en vrai meme un marron ici qui tle donne sans arriere pensee",
+          "En vrai, même un marron, ici qui t'le donne sans arrière pensée (regarde-moi bien)",
+        ),
+      ).toBe(true);
+    });
+
+    it("strips inline parenthetical content too", () => {
+      expect(
+        compareAnswers(
+          "et je ne vois que mon putain dreflet dans la codeine",
+          "Et je ne vois que mon putain d'reflet (oh) dans la codéine",
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects answers that exceed the typo budget", () => {
+      expect(
+        compareAnswers(
+          "completely different sentence here",
+          "Trop souvent dans mes oreilles, on m'a dit laisse tomber",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("answerHintTokens", () => {
+    it("masks letters/digits while keeping punctuation visible", () => {
+      expect(answerHintTokens("J'aime le rap, vraiment !")).toEqual([
+        "_'____",
+        "__",
+        "___,",
+        "________",
+        "!",
+      ]);
+    });
+
+    it("preserves accents-tracking underscores per visible char", () => {
+      expect(answerHintTokens("Allô, comment ?")).toEqual([
+        "____,",
+        "_______",
+        "?",
+      ]);
+    });
+
+    it("returns an empty array for empty input", () => {
+      expect(answerHintTokens("")).toEqual([]);
+    });
+  });
+});

--- a/front-mobile/utils/parkeur.ts
+++ b/front-mobile/utils/parkeur.ts
@@ -10,7 +10,7 @@ export function normalizeAnswer(value: string): string {
     .toLowerCase()
     .replace(/\([^)]*\)/g, " ")
     .normalize("NFD")
-    .replace(/[̀-ͯ]/g, "")
+    .replace(/[\u0300-\u036f]/g, "")
     .replace(/[.,!?;:'"`\-()…«»“”‘’]/g, " ")
     .replace(/\s+/g, " ")
     .trim();

--- a/front-mobile/utils/parkeur.ts
+++ b/front-mobile/utils/parkeur.ts
@@ -1,0 +1,47 @@
+import { levenshteinDistance } from "@/utils/stringUtils";
+
+/**
+ * Normalises an answer string for Parkeur: strips parenthetical fillers like
+ * "(yeah)" or "(gang, gang, gang)", lowercases, removes accents and punctuation
+ * (incl. typographic quotes), and collapses whitespace.
+ */
+export function normalizeAnswer(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\([^)]*\)/g, " ")
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[.,!?;:'"`\-()…«»“”‘’]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Tolerant comparison. Accepts a normalised match OR a Levenshtein distance
+ * within ~20% of the expected length (capped at min 2 to allow short answers
+ * to absorb a couple of typos / missing trailing words like "(yeah)").
+ */
+export function compareAnswers(input: string, expected: string): boolean {
+  const a = normalizeAnswer(input);
+  const b = normalizeAnswer(expected);
+  if (!b) return false;
+  if (a === b) return true;
+  const threshold = Math.max(2, Math.floor(b.length * 0.2));
+  return levenshteinDistance(a, b) <= threshold;
+}
+
+/**
+ * Builds the underscore hint shown to the player: each letter/digit is replaced
+ * with `_`, while spaces, apostrophes and punctuation stay visible — like
+ * "N'oubliez pas les paroles" on TV. Returns one token per whitespace-separated
+ * group so the UI can render them on a wrapping row.
+ */
+export function answerHintTokens(expected: string): string[] {
+  if (!expected) return [];
+  return expected
+    .normalize("NFC")
+    .trim()
+    .split(/\s+/)
+    .map((token) => token.replace(/[\p{L}\p{N}]/gu, "_"))
+    .filter((token) => token.length > 0);
+}


### PR DESCRIPTION
## Description

Ajoute le jeu **Parkeur** (devine la suite des paroles, inspiré de *N'oubliez pas les paroles*). Le backend agrège les paroles depuis plusieurs sources (Genius, AZLyrics, Paroles.net, Letras, Lyrics.com, LyricsMania) avec un cache LRU en mémoire, et expose un endpoint qui pré-charge 10 rounds depuis une playlist curated **ou** les top tracks d'un artiste Deezer. Le mobile ajoute un écran de sélection de mode (playlist / artiste avec recherche), un écran de jeu avec indice à trous (ponctuation préservée), reprise de session (locale + serveur, cross-device), modal de confirmation save/abandon au quit et historique avec score réel.

Inclut aussi une protection critique du runner de tests backend qui écrasait la DB de dev (override forcé de `DB_DATABASE` avant le chargement de l'env AdonisJS).

## Parcours utilisateur

1. Sur l'onglet Jeux, taper sur la carte **Parkeur** (plus de badge "Bientôt")
2. Sur l'écran d'intro : règles affichées si première partie + bouton **Commencer à jouer**
3. Choix du mode :
   - **Playlist** → liste des playlists Rythmix → sélectionner une playlist
   - **Artiste** → barre de recherche → taper un nom (ex. "Stromae") → sélectionner un artiste
4. Préparation (5–15 s) puis écran de jeu :
   - Pochette + artiste + titre affichés
   - 2 vers visibles
   - Indice avec ponctuation et apostrophes préservées (ex. `_'____ ___, ________ !`)
   - Champ de saisie + bouton envoyer
5. Saisir une mauvaise réponse → feedback rouge, révèle la bonne réponse, bouton **Suivant**
6. Saisir la bonne réponse (avec accents/casse/ponctuation différents → fuzzy match) → feedback vert, score +1
7. Pendant la partie, taper sur la flèche back → modal **Quitter la partie ?** avec 3 options :
   - Sauvegarder et quitter → reprend plus tard
   - Abandonner la partie → va à l'écran score immédiatement
   - Annuler → reste dans la partie
8. Round 10 → écran récap : score X/10, replay
9. Revenir sur l'intro Parkeur après avoir quitté en sauvegardant : **Reprendre la partie** + **Nouvelle partie** (bouton outline) avec confirmation rouge avant de cancel la session active
10. Historique en bas de l'intro : affiche les 5 dernières parties avec **leur score réel** (lu depuis `gameData.score`)
11. Cas d'erreur : playlist sans paroles ou artiste sans top tracks → message 422 explicite