### PR TITLE
HOTFIX-profile-null-name-crash fix: prevent profile screen crash when user firstName or lastName is null

### DIFF
--- a/front-mobile/app/(tabs)/profile/index.tsx
+++ b/front-mobile/app/(tabs)/profile/index.tsx
@@ -88,8 +88,9 @@ export default function ProfileScreen() {
             <View style={styles.avatar}>
               <Text style={styles.avatarInitials}>
                 {user
-                  ? user.firstName[0].toUpperCase() +
-                    user.lastName[0].toUpperCase()
+                  ? (
+                      (user.firstName?.[0] ?? "") + (user.lastName?.[0] ?? "")
+                    ).toUpperCase() || "??"
                   : "??"}
               </Text>
             </View>
@@ -99,7 +100,9 @@ export default function ProfileScreen() {
             {user ? `@${user.username}` : "@utilisateur"}
           </Text>
           <Text style={styles.fullName}>
-            {user ? `${user.firstName} ${user.lastName}` : ""}
+            {user
+              ? `${user.firstName ?? ""} ${user.lastName ?? ""}`.trim()
+              : ""}
           </Text>
           <Text style={styles.memberSince}>
             {getMemberSince(user?.createdAt)}

--- a/front-mobile/types/auth.ts
+++ b/front-mobile/types/auth.ts
@@ -2,8 +2,8 @@ export interface User {
   id: string;
   email: string;
   username: string;
-  firstName: string;
-  lastName: string;
+  firstName: string | null;
+  lastName: string | null;
   role: string;
   emailVerifiedAt: string;
   createdAt?: string;


### PR DESCRIPTION
## Description

L'écran Profil mobile crashait (`Cannot convert null value to object`) quand `user.firstName` ou `user.lastName` arrivait à `null` depuis le backend (champs déclarés `string | null` côté serveur, mais typés `string` non-null côté mobile). Le fix aligne le type `User` mobile sur la réalité du backend et durcit le rendu des initiales et du nom complet avec un chaînage optionnel et un fallback `??`.

## Parcours utilisateur

1. Se connecter à l'app mobile avec un compte dont `firstName` et/ou `lastName` est `null` en BDD.
2. Ouvrir l'onglet Profil.
3. Vérifier que l'écran s'affiche sans crash : `??` à la place des initiales si les deux champs sont null, et la zone "nom complet" reste vide proprement.
4. Se reconnecter avec un compte ayant un prénom et un nom remplis.
5. Vérifier que les initiales et le nom complet s'affichent normalement (pas de régression).