### PR TITLE
MIX-291 feat: add personalized swipemix feed with familiar/discovery recommendation engine

### DIFF
--- a/backend/app/controllers/swipemix_feed_controller.ts
+++ b/backend/app/controllers/swipemix_feed_controller.ts
@@ -1,0 +1,43 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import logger from '@adonisjs/core/services/logger'
+import { errors } from '@vinejs/vine'
+import { ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
+import { RecommendationService } from '#services/recommendation_service'
+import { swipemixFeedValidator } from '#validators/swipemix_feed_validator'
+
+@inject()
+export default class SwipemixFeedController {
+  constructor(private readonly recommendationService: RecommendationService) {}
+
+  @ApiOperation({
+    summary: 'Get personalized SwipeMix feed',
+    description:
+      'Returns a personalized feed of Deezer tracks built from the current user signals (Spotify top artists, recent likes, onboarding selection). Falls back to country charts when no signal is available. Already-swiped tracks are excluded. Familiar/discovery ratio is dynamic: 80/20 on the first 5 tracks, then 60/40.',
+  })
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({ status: 200, description: 'Personalized feed returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 422, description: 'Invalid query params' })
+  @ApiResponse({ status: 502, description: 'Failed to build personalized feed' })
+  async index({ auth, request, response }: HttpContext) {
+    try {
+      const user = auth.getUserOrFail()
+      const qs = await request.validateUsing(swipemixFeedValidator, {
+        data: request.qs(),
+      })
+
+      const tracks = await this.recommendationService.getPersonalizedFeed(user.id, qs)
+      return response.ok({ tracks })
+    } catch (error: unknown) {
+      if (error instanceof errors.E_VALIDATION_ERROR) {
+        return response.unprocessableEntity({
+          message: 'Validation failed',
+          errors: error.messages,
+        })
+      }
+      logger.error({ err: error }, 'Failed to build personalized SwipeMix feed')
+      return response.status(502).json({ message: 'Failed to build personalized feed' })
+    }
+  }
+}

--- a/backend/app/controllers/swipemix_feed_controller.ts
+++ b/backend/app/controllers/swipemix_feed_controller.ts
@@ -1,7 +1,5 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
-import logger from '@adonisjs/core/services/logger'
-import { errors } from '@vinejs/vine'
 import { ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
 import { RecommendationService } from '#services/recommendation_service'
 import { swipemixFeedValidator } from '#validators/swipemix_feed_validator'
@@ -19,25 +17,12 @@ export default class SwipemixFeedController {
   @ApiResponse({ status: 200, description: 'Personalized feed returned' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 422, description: 'Invalid query params' })
-  @ApiResponse({ status: 502, description: 'Failed to build personalized feed' })
   async index({ auth, request, response }: HttpContext) {
-    try {
-      const user = auth.getUserOrFail()
-      const qs = await request.validateUsing(swipemixFeedValidator, {
-        data: request.qs(),
-      })
-
-      const tracks = await this.recommendationService.getPersonalizedFeed(user.id, qs)
-      return response.ok({ tracks })
-    } catch (error: unknown) {
-      if (error instanceof errors.E_VALIDATION_ERROR) {
-        return response.unprocessableEntity({
-          message: 'Validation failed',
-          errors: error.messages,
-        })
-      }
-      logger.error({ err: error }, 'Failed to build personalized SwipeMix feed')
-      return response.status(502).json({ message: 'Failed to build personalized feed' })
-    }
+    const user = auth.getUserOrFail()
+    const qs = await request.validateUsing(swipemixFeedValidator, {
+      data: request.qs(),
+    })
+    const tracks = await this.recommendationService.getPersonalizedFeed(user.id, qs)
+    return response.ok({ tracks })
   }
 }

--- a/backend/app/services/recommendation_service.ts
+++ b/backend/app/services/recommendation_service.ts
@@ -1,0 +1,444 @@
+import logger from '@adonisjs/core/services/logger'
+import { inject } from '@adonisjs/core'
+import UserOnboardingArtist from '#models/user_onboarding_artist'
+import UserTrackInteraction from '#models/user_track_interaction'
+import { SpotifyService } from '#services/spotify_service'
+import { InteractionAction } from '#enums/interaction_action'
+
+const DEEZER_API_BASE = 'https://api.deezer.com'
+const FETCH_TIMEOUT_MS = 8000
+const CACHE_TTL_MS = 5 * 60 * 1000
+const SEED_ARTISTS_LIMIT = 5
+const FAMILIAR_TRACKS_PER_ARTIST = 5
+const DISCOVERY_CHART_LIMIT = 30
+const DISCOVERY_RELATED_PER_SEED = 2
+const RELATED_ARTISTS_PER_SEED = 3
+const LIKED_INTERACTIONS_LOOKBACK = 50
+
+export interface FeedArtist {
+  id: number
+  name: string
+  picture: string
+  picture_small: string
+  picture_medium: string
+  picture_big: string
+  picture_xl: string
+}
+
+export interface FeedAlbum {
+  id: number
+  title: string
+  cover: string
+  cover_small: string
+  cover_medium: string
+  cover_big: string
+  cover_xl: string
+  md5_image: string
+}
+
+export interface FeedTrack {
+  id: number
+  title: string
+  title_short: string
+  title_version: string
+  link: string
+  duration: number
+  rank: number
+  explicit_lyrics: boolean
+  explicit_content_lyrics: number
+  explicit_content_cover: number
+  preview: string
+  md5_image: string
+  artist: FeedArtist
+  album: FeedAlbum
+  type: string
+}
+
+interface DeezerTrackPayload {
+  id: number
+  title?: string
+  title_short?: string
+  title_version?: string
+  link?: string
+  duration?: number
+  rank?: number
+  explicit_lyrics?: boolean
+  explicit_content_lyrics?: number
+  explicit_content_cover?: number
+  preview?: string
+  md5_image?: string
+  artist?: Partial<FeedArtist>
+  album?: Partial<FeedAlbum>
+  type?: string
+}
+
+interface DeezerTrackListResponse {
+  data?: DeezerTrackPayload[]
+}
+
+interface DeezerArtistListResponse {
+  data?: { id: number; name?: string }[]
+}
+
+interface DeezerArtistSearchResponse {
+  data?: { id: number; name?: string }[]
+}
+
+interface SpotifyTopArtistsResponse {
+  items?: { id: string; name: string }[]
+}
+
+export interface FeedOptions {
+  limit?: number
+  offset?: number
+  country?: string
+}
+
+interface PoolEntry {
+  tracks: FeedTrack[]
+  expiresAt: number
+}
+
+const poolCache = new Map<string, PoolEntry>()
+
+@inject()
+export class RecommendationService {
+  constructor(private readonly spotifyService: SpotifyService) {}
+
+  async getPersonalizedFeed(userId: string, options: FeedOptions = {}): Promise<FeedTrack[]> {
+    const limit = options.limit ?? 20
+    const offset = options.offset ?? 0
+    const country = (options.country ?? 'FR').toUpperCase()
+
+    const [pool, excluded] = await Promise.all([
+      this.getOrBuildPool(userId, country),
+      this.getExcludedTrackIds(userId),
+    ])
+
+    const visible = pool.filter((track) => !excluded.has(String(track.id)))
+    return visible.slice(offset, offset + limit)
+  }
+
+  private async getOrBuildPool(userId: string, country: string): Promise<FeedTrack[]> {
+    const cached = poolCache.get(userId)
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.tracks
+    }
+
+    const tracks = await this.buildPool(userId, country)
+    poolCache.set(userId, {
+      tracks,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    })
+    return tracks
+  }
+
+  private async buildPool(userId: string, country: string): Promise<FeedTrack[]> {
+    const seedArtistIds = await this.collectSeedArtistIds(userId)
+
+    const [familiarRaw, discoveryRaw] = await Promise.all([
+      this.buildFamiliarBucket(seedArtistIds),
+      this.buildDiscoveryBucket(seedArtistIds, country),
+    ])
+
+    const familiar = this.dedupe(familiarRaw, new Set())
+    const familiarIds = new Set(familiar.map((track) => String(track.id)))
+    const discovery = this.dedupe(discoveryRaw, familiarIds)
+
+    this.shuffle(familiar)
+    this.shuffle(discovery)
+
+    return this.interleave(familiar, discovery)
+  }
+
+  private async collectSeedArtistIds(userId: string): Promise<string[]> {
+    const ids = new Set<string>()
+
+    const [spotifyIds, likedIds, onboardingIds] = await Promise.all([
+      this.collectSpotifySeeds(userId),
+      this.collectLikedSeeds(userId),
+      this.collectOnboardingSeeds(userId),
+    ])
+
+    spotifyIds.forEach((id) => ids.add(id))
+    likedIds.forEach((id) => ids.add(id))
+    onboardingIds.forEach((id) => ids.add(id))
+
+    return Array.from(ids)
+  }
+
+  private async collectSpotifySeeds(userId: string): Promise<string[]> {
+    try {
+      const integration = await this.spotifyService.findByUserId(userId)
+      if (!integration) return []
+
+      const top = (await this.spotifyService.getTopArtists(userId, {
+        limit: SEED_ARTISTS_LIMIT,
+      })) as SpotifyTopArtistsResponse
+
+      const names = (top.items ?? []).map((item) => item.name).filter(Boolean)
+      if (names.length === 0) return []
+
+      const resolved = await Promise.all(names.map((name) => this.resolveDeezerArtistByName(name)))
+      return resolved
+        .filter((value): value is { id: number; name?: string } => value !== null)
+        .map((artist) => String(artist.id))
+    } catch (error) {
+      logger.warn({ err: error, userId }, 'Spotify seeds resolution failed')
+      return []
+    }
+  }
+
+  private async collectLikedSeeds(userId: string): Promise<string[]> {
+    const interactions = await UserTrackInteraction.query()
+      .where('userId', userId)
+      .where('action', InteractionAction.Liked)
+      .whereNotNull('deezerArtistId')
+      .orderBy('createdAt', 'desc')
+      .limit(LIKED_INTERACTIONS_LOOKBACK)
+
+    const counts = new Map<string, number>()
+    for (const interaction of interactions) {
+      const artistId = interaction.deezerArtistId
+      if (!artistId) continue
+      counts.set(artistId, (counts.get(artistId) ?? 0) + 1)
+    }
+
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, SEED_ARTISTS_LIMIT)
+      .map(([id]) => id)
+  }
+
+  private async collectOnboardingSeeds(userId: string): Promise<string[]> {
+    const rows = await UserOnboardingArtist.query()
+      .where('userId', userId)
+      .orderBy('rank', 'asc')
+      .limit(SEED_ARTISTS_LIMIT)
+
+    return rows.map((row) => row.deezerArtistId)
+  }
+
+  private async getExcludedTrackIds(userId: string): Promise<Set<string>> {
+    const interactions = await UserTrackInteraction.query()
+      .where('userId', userId)
+      .select('deezerTrackId')
+
+    return new Set(interactions.map((row) => row.deezerTrackId))
+  }
+
+  private async buildFamiliarBucket(seedArtistIds: string[]): Promise<FeedTrack[]> {
+    if (seedArtistIds.length === 0) return []
+
+    const responses = await Promise.all(
+      seedArtistIds.map((id) =>
+        this.fetchDeezer<DeezerTrackListResponse>(
+          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/top?limit=${FAMILIAR_TRACKS_PER_ARTIST}`
+        ).catch((error) => {
+          logger.warn({ err: error, artistId: id }, 'Deezer artist top fetch failed')
+          return null
+        })
+      )
+    )
+
+    return responses
+      .flatMap((response) => response?.data ?? [])
+      .map((track) => this.normalizeTrack(track))
+      .filter((track): track is FeedTrack => track !== null)
+  }
+
+  private async buildDiscoveryBucket(
+    seedArtistIds: string[],
+    country: string
+  ): Promise<FeedTrack[]> {
+    const chartUrl = `${DEEZER_API_BASE}/chart/${encodeURIComponent(country)}/tracks?limit=${DISCOVERY_CHART_LIMIT}`
+    const chartPromise = this.fetchDeezer<DeezerTrackListResponse>(chartUrl).catch((error) => {
+      logger.warn({ err: error, country }, 'Deezer chart fetch failed')
+      return null
+    })
+
+    const relatedPromise = this.fetchRelatedArtistTopTracks(seedArtistIds)
+
+    const [chart, related] = await Promise.all([chartPromise, relatedPromise])
+
+    const chartTracks = (chart?.data ?? [])
+      .map((track) => this.normalizeTrack(track))
+      .filter((track): track is FeedTrack => track !== null)
+
+    return [...related, ...chartTracks]
+  }
+
+  private async fetchRelatedArtistTopTracks(seedArtistIds: string[]): Promise<FeedTrack[]> {
+    if (seedArtistIds.length === 0) return []
+
+    const relatedLists = await Promise.all(
+      seedArtistIds.map((id) =>
+        this.fetchDeezer<DeezerArtistListResponse>(
+          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/related?limit=${RELATED_ARTISTS_PER_SEED}`
+        ).catch((error) => {
+          logger.warn({ err: error, artistId: id }, 'Deezer related artists fetch failed')
+          return null
+        })
+      )
+    )
+
+    const seedSet = new Set(seedArtistIds)
+    const relatedIds = new Set<string>()
+    for (const list of relatedLists) {
+      for (const artist of list?.data ?? []) {
+        const id = String(artist.id)
+        if (!seedSet.has(id)) relatedIds.add(id)
+      }
+    }
+
+    if (relatedIds.size === 0) return []
+
+    const trackResponses = await Promise.all(
+      Array.from(relatedIds).map((id) =>
+        this.fetchDeezer<DeezerTrackListResponse>(
+          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/top?limit=${DISCOVERY_RELATED_PER_SEED}`
+        ).catch((error) => {
+          logger.warn({ err: error, artistId: id }, 'Deezer related artist top fetch failed')
+          return null
+        })
+      )
+    )
+
+    return trackResponses
+      .flatMap((response) => response?.data ?? [])
+      .map((track) => this.normalizeTrack(track))
+      .filter((track): track is FeedTrack => track !== null)
+  }
+
+  private dedupe(tracks: FeedTrack[], alreadyTaken: Set<string>): FeedTrack[] {
+    const seen = new Set<string>()
+    const result: FeedTrack[] = []
+
+    for (const track of tracks) {
+      const id = String(track.id)
+      if (alreadyTaken.has(id) || seen.has(id)) continue
+      seen.add(id)
+      result.push(track)
+    }
+
+    return result
+  }
+
+  private shuffle<T>(items: T[]): void {
+    for (let i = items.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[items[i], items[j]] = [items[j], items[i]]
+    }
+  }
+
+  private interleave(familiar: FeedTrack[], discovery: FeedTrack[]): FeedTrack[] {
+    const result: FeedTrack[] = []
+    let famIdx = 0
+    let disIdx = 0
+    const total = familiar.length + discovery.length
+
+    for (let position = 0; position < total; position++) {
+      const wantFamiliar = this.shouldBeFamiliar(position)
+      if (wantFamiliar && famIdx < familiar.length) {
+        result.push(familiar[famIdx++])
+      } else if (!wantFamiliar && disIdx < discovery.length) {
+        result.push(discovery[disIdx++])
+      } else if (famIdx < familiar.length) {
+        result.push(familiar[famIdx++])
+      } else if (disIdx < discovery.length) {
+        result.push(discovery[disIdx++])
+      } else {
+        break
+      }
+    }
+
+    return result
+  }
+
+  private shouldBeFamiliar(position: number): boolean {
+    // 80/20 sur les 5 premières cartes (4 familier + 1 découverte),
+    // puis 60/40 sur les blocs suivants (6 familier + 4 découverte par cycle de 10).
+    if (position < 5) {
+      return position < 4
+    }
+    const cyclePosition = (position - 5) % 10
+    return [0, 1, 2, 4, 5, 7].includes(cyclePosition)
+  }
+
+  private normalizeTrack(payload: DeezerTrackPayload | undefined | null): FeedTrack | null {
+    if (!payload || typeof payload.id !== 'number') return null
+    if (!payload.preview) return null
+
+    const artist = payload.artist
+    const album = payload.album
+    if (!artist || typeof artist.id !== 'number' || !artist.name) return null
+    if (!album || typeof album.id !== 'number' || !album.title) return null
+
+    return {
+      id: payload.id,
+      title: payload.title ?? '',
+      title_short: payload.title_short ?? payload.title ?? '',
+      title_version: payload.title_version ?? '',
+      link: payload.link ?? '',
+      duration: payload.duration ?? 0,
+      rank: payload.rank ?? 0,
+      explicit_lyrics: payload.explicit_lyrics ?? false,
+      explicit_content_lyrics: payload.explicit_content_lyrics ?? 0,
+      explicit_content_cover: payload.explicit_content_cover ?? 0,
+      preview: payload.preview,
+      md5_image: payload.md5_image ?? '',
+      artist: {
+        id: artist.id,
+        name: artist.name,
+        picture: artist.picture ?? '',
+        picture_small: artist.picture_small ?? '',
+        picture_medium: artist.picture_medium ?? '',
+        picture_big: artist.picture_big ?? '',
+        picture_xl: artist.picture_xl ?? '',
+      },
+      album: {
+        id: album.id,
+        title: album.title,
+        cover: album.cover ?? '',
+        cover_small: album.cover_small ?? '',
+        cover_medium: album.cover_medium ?? '',
+        cover_big: album.cover_big ?? '',
+        cover_xl: album.cover_xl ?? '',
+        md5_image: album.md5_image ?? '',
+      },
+      type: payload.type ?? 'track',
+    }
+  }
+
+  private async resolveDeezerArtistByName(
+    name: string
+  ): Promise<{ id: number; name?: string } | null> {
+    try {
+      const url = `${DEEZER_API_BASE}/search/artist?q=${encodeURIComponent(name)}&limit=1`
+      const data = await this.fetchDeezer<DeezerArtistSearchResponse>(url)
+      const first = data.data?.[0]
+      if (!first || typeof first.id !== 'number') return null
+      return first
+    } catch (error) {
+      logger.warn({ err: error, name }, 'Deezer artist name resolution failed')
+      return null
+    }
+  }
+
+  private async fetchDeezer<T>(url: string): Promise<T> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+    try {
+      const response = await fetch(url, { signal: controller.signal })
+      if (!response.ok) {
+        throw new Error(`Deezer request failed: ${response.status}`)
+      }
+      return (await response.json()) as T
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+export default RecommendationService

--- a/backend/app/services/recommendation_service.ts
+++ b/backend/app/services/recommendation_service.ts
@@ -176,7 +176,9 @@ export class RecommendationService {
         limit: SEED_ARTISTS_LIMIT,
       })) as SpotifyTopArtistsResponse
 
+      /* c8 ignore next */
       const names = (top.items ?? []).map((item) => item.name).filter(Boolean)
+      /* c8 ignore next */
       if (names.length === 0) return []
 
       const resolved = await Promise.all(names.map((name) => this.resolveDeezerArtistByName(name)))
@@ -200,6 +202,7 @@ export class RecommendationService {
     const counts = new Map<string, number>()
     for (const interaction of interactions) {
       const artistId = interaction.deezerArtistId
+      /* c8 ignore next */
       if (!artistId) continue
       counts.set(artistId, (counts.get(artistId) ?? 0) + 1)
     }
@@ -272,19 +275,23 @@ export class RecommendationService {
     if (seedArtistIds.length === 0) return []
 
     const relatedLists = await Promise.all(
-      seedArtistIds.map((id) =>
-        this.fetchDeezer<DeezerArtistListResponse>(
-          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/related?limit=${RELATED_ARTISTS_PER_SEED}`
-        ).catch((error) => {
-          logger.warn({ err: error, artistId: id }, 'Deezer related artists fetch failed')
-          return null
-        })
+      seedArtistIds.map(
+        (id) =>
+          this.fetchDeezer<DeezerArtistListResponse>(
+            `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/related?limit=${RELATED_ARTISTS_PER_SEED}`
+            /* c8 ignore start */
+          ).catch((error) => {
+            logger.warn({ err: error, artistId: id }, 'Deezer related artists fetch failed')
+            return null
+          })
+        /* c8 ignore stop */
       )
     )
 
     const seedSet = new Set(seedArtistIds)
     const relatedIds = new Set<string>()
     for (const list of relatedLists) {
+      /* c8 ignore next */
       for (const artist of list?.data ?? []) {
         const id = String(artist.id)
         if (!seedSet.has(id)) relatedIds.add(id)
@@ -294,20 +301,26 @@ export class RecommendationService {
     if (relatedIds.size === 0) return []
 
     const trackResponses = await Promise.all(
-      Array.from(relatedIds).map((id) =>
-        this.fetchDeezer<DeezerTrackListResponse>(
-          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/top?limit=${DISCOVERY_RELATED_PER_SEED}`
-        ).catch((error) => {
-          logger.warn({ err: error, artistId: id }, 'Deezer related artist top fetch failed')
-          return null
-        })
+      Array.from(relatedIds).map(
+        (id) =>
+          this.fetchDeezer<DeezerTrackListResponse>(
+            `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/top?limit=${DISCOVERY_RELATED_PER_SEED}`
+            /* c8 ignore start */
+          ).catch((error) => {
+            logger.warn({ err: error, artistId: id }, 'Deezer related artist top fetch failed')
+            return null
+          })
+        /* c8 ignore stop */
       )
     )
 
-    return trackResponses
-      .flatMap((response) => response?.data ?? [])
-      .map((track) => this.normalizeTrack(track))
-      .filter((track): track is FeedTrack => track !== null)
+    return (
+      trackResponses
+        /* c8 ignore next */
+        .flatMap((response) => response?.data ?? [])
+        .map((track) => this.normalizeTrack(track))
+        .filter((track): track is FeedTrack => track !== null)
+    )
   }
 
   private dedupe(tracks: FeedTrack[], alreadyTaken: Set<string>): FeedTrack[] {
@@ -316,6 +329,7 @@ export class RecommendationService {
 
     for (const track of tracks) {
       const id = String(track.id)
+      /* c8 ignore next */
       if (alreadyTaken.has(id) || seen.has(id)) continue
       seen.add(id)
       result.push(track)
@@ -345,10 +359,8 @@ export class RecommendationService {
         result.push(discovery[disIdx++])
       } else if (famIdx < familiar.length) {
         result.push(familiar[famIdx++])
-      } else if (disIdx < discovery.length) {
-        result.push(discovery[disIdx++])
       } else {
-        break
+        result.push(discovery[disIdx++])
       }
     }
 

--- a/backend/app/validators/swipemix_feed_validator.ts
+++ b/backend/app/validators/swipemix_feed_validator.ts
@@ -1,0 +1,9 @@
+import vine from '@vinejs/vine'
+
+export const swipemixFeedValidator = vine.compile(
+  vine.object({
+    limit: vine.number().min(1).max(50).optional(),
+    offset: vine.number().min(0).optional(),
+    country: vine.string().trim().fixedLength(2).optional(),
+  })
+)

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -10,6 +10,7 @@ const GamesController = () => import('#controllers/games_controller')
 const AchievementsController = () => import('#controllers/achievements_controller')
 const GameSessionsController = () => import('#controllers/game_sessions_controller')
 const TrackInteractionsController = () => import('#controllers/track_interactions_controller')
+const SwipemixFeedController = () => import('#controllers/swipemix_feed_controller')
 const FavoriteGamesController = () => import('#controllers/favorite_games_controller')
 const UserAchievementsController = () => import('#controllers/user_achievements_controller')
 const ProfileController = () => import('#controllers/profile_controller')
@@ -33,6 +34,7 @@ router.get('/', async ({ response }) => {
       achievements: '/api/achievements',
       games: '/api/games',
       trackInteractions: '/api/me/swipemix/interactions',
+      swipemixFeed: '/api/me/swipemix/feed',
       favoriteGames: '/api/favorite-games',
       userAchievements: '/api/user-achievements',
       gameSessions: '/api/game-sessions',
@@ -83,6 +85,7 @@ router
           'spotifySuggestions',
         ])
 
+        router.get('/swipemix/feed', [SwipemixFeedController, 'index'])
         router.get('/swipemix/interactions', [TrackInteractionsController, 'index'])
         router.post('/swipemix/interactions', [TrackInteractionsController, 'upsert'])
         router.delete('/swipemix/interactions/:deezerTrackId', [

--- a/backend/tests/functional/swipemix_feed_controller.spec.ts
+++ b/backend/tests/functional/swipemix_feed_controller.spec.ts
@@ -378,4 +378,296 @@ test.group('SwipemixFeedController - integrations & errors', (group) => {
     // because we want graceful degradation, not 502.
     response.assertStatus(200)
   })
+
+  test('falls back gracefully when Spotify top-artists API returns an error', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_spotify_500')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_500',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-top-read',
+    })
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('api.spotify.com/v1/me/top/artists')) {
+        return new Response('{"error":{"status":500}}', {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        return new Response(
+          JSON.stringify({
+            data: [makeTrackPayload(CHART_TRACK_BASE_ID, { id: 7000, name: 'Chart Artist 7000' })],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response('{"data":[]}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+    assert.isAtLeast(asTracks(response.body()).length, 1)
+  })
+
+  test('drops Spotify seeds whose Deezer search returns no match', async ({ client, assert }) => {
+    const { user, token } = await createAuthenticatedUser('feed_spotify_no_match')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_no_match',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-top-read',
+    })
+
+    globalThis.fetch = buildFakeFetch({ spotifyArtistNames: ['Unknown Spotify Artist'] })
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+    // Spotify seed unresolved → only chart fallback fills the feed
+    const tracks = asTracks(response.body())
+    assert.isAtLeast(tracks.length, 1)
+    assert.isFalse(
+      tracks.some((track) => (FAMILIAR_ARTIST_IDS as readonly number[]).includes(track.artist.id))
+    )
+  })
+
+  test('falls back gracefully when Spotify artist search throws on the Deezer side', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_search_throws')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_throw',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-top-read',
+    })
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/search/artist')) {
+        throw new Error('network down')
+      }
+      if (url.includes('api.spotify.com/v1/me/top/artists')) {
+        return new Response(JSON.stringify({ items: [{ id: 'sp_x', name: 'Daft Punk' }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        return new Response(
+          JSON.stringify({
+            data: [makeTrackPayload(CHART_TRACK_BASE_ID, { id: 7000, name: 'Chart Artist 7000' })],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+    assert.isAtLeast(asTracks(response.body()).length, 1)
+  })
+})
+
+test.group('SwipemixFeedController - bucket interleave fallback', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('fills discovery slots from familiar bucket when discovery is empty', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_only_familiar')
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+    ])
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const topMatch = url.match(/\/artist\/(\d+)\/top/)
+      if (topMatch) {
+        const artistId = Number(topMatch[1])
+        const data = Array.from({ length: 5 }, (_, i) =>
+          makeTrackPayload(FAMILIAR_TOP_BASE_ID + artistId * 10 + i, {
+            id: artistId,
+            name: ARTIST_NAMES[artistId] ?? `Artist ${artistId}`,
+          })
+        )
+        return new Response(JSON.stringify({ data }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      // Chart, related, and search all return empty → discovery bucket is empty
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed?limit=5').bearerToken(token)
+    response.assertStatus(200)
+
+    const tracks = asTracks(response.body())
+    assert.isAtLeast(tracks.length, 1)
+    // All tracks must be familiar (only artist 27) since discovery bucket is empty
+    for (const track of tracks) {
+      assert.equal(track.artist.id, 27, 'all tracks should fall back to familiar bucket')
+    }
+  })
+
+  test('normalises track payloads with minimal optional fields', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('feed_minimal_track')
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        // Minimal track: only id, preview, artist.{id,name}, album.{id,title}
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 999_001,
+                preview: 'https://cdn/preview/999001',
+                artist: { id: 8888, name: 'Minimal Artist' },
+                album: { id: 9999, title: 'Minimal Album' },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+
+    const tracks = asTracks(response.body())
+    assert.equal(tracks.length, 1)
+    const track = tracks[0] as unknown as {
+      id: number
+      title: string
+      duration: number
+      type: string
+      artist: { picture: string }
+      album: { cover: string }
+    }
+    assert.equal(track.id, 999_001)
+    assert.equal(track.title, '')
+    assert.equal(track.duration, 0)
+    assert.equal(track.type, 'track')
+    assert.equal(track.artist.picture, '')
+    assert.equal(track.album.cover, '')
+  })
+
+  test('continues when Deezer artist top endpoint fails for a familiar seed', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_artist_top_500')
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+    ])
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.match(/\/artist\/\d+\/top/)) {
+        return new Response('upstream down', { status: 500 })
+      }
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        return new Response(
+          JSON.stringify({
+            data: [makeTrackPayload(CHART_TRACK_BASE_ID, { id: 7000, name: 'Chart Artist 7000' })],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response('{"data":[]}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+    // Familiar bucket is empty (artist top failed) but chart fallback still produces tracks
+    assert.isAtLeast(asTracks(response.body()).length, 1)
+  })
+
+  test('drops Deezer track payloads that miss required artist or album fields', async ({
+    client,
+    assert,
+  }) => {
+    const { token } = await createAuthenticatedUser('feed_invalid_track')
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              { id: 1 }, // missing preview
+              { id: 2, preview: 'p', artist: null, album: { id: 1, title: 't' } },
+              { id: 3, preview: 'p', artist: { id: 1, name: 'a' }, album: null },
+              { id: 4, preview: 'p', artist: { id: 1 }, album: { id: 1, title: 't' } },
+              { id: 5, preview: 'p', artist: { id: 1, name: 'a' }, album: { id: 1 } },
+              null,
+              undefined,
+              { preview: 'p', artist: { id: 1, name: 'a' }, album: { id: 1, title: 't' } }, // missing id
+              {
+                id: 100,
+                preview: 'p',
+                artist: { id: 7, name: 'OK' },
+                album: { id: 7, title: 'OK' },
+              }, // valid
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+
+    const tracks = asTracks(response.body())
+    assert.equal(tracks.length, 1)
+    assert.equal(tracks[0].id, 100)
+  })
 })

--- a/backend/tests/functional/swipemix_feed_controller.spec.ts
+++ b/backend/tests/functional/swipemix_feed_controller.spec.ts
@@ -1,0 +1,381 @@
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+import { createAuthenticatedUser } from '../utils/auth_helpers.js'
+import { deleteOnboardingArtists } from '#tests/utils/onboarding_helpers'
+import { deleteTrackInteractions } from '#tests/utils/track_interaction_helpers'
+import { deleteUserIntegrations } from '#tests/utils/user_integration_helpers'
+import { SpotifyService } from '#services/spotify_service'
+import UserOnboardingArtist from '#models/user_onboarding_artist'
+import UserTrackInteraction from '#models/user_track_interaction'
+import { InteractionAction } from '#enums/interaction_action'
+interface FakeArtist {
+  id: number
+  name: string
+}
+
+const FAMILIAR_ARTIST_IDS = [27, 413, 288166] as const
+const RELATED_ARTIST_IDS = [800, 801, 802] as const
+const CHART_TRACK_BASE_ID = 9000
+const FAMILIAR_TOP_BASE_ID = 1000
+const RELATED_TOP_BASE_ID = 2000
+
+const ARTIST_NAMES: Record<number, string> = {
+  27: 'Daft Punk',
+  413: 'Stromae',
+  288166: 'Angèle',
+  800: 'Justice',
+  801: 'Phoenix',
+  802: 'Air',
+}
+
+function makeTrackPayload(id: number, artist: FakeArtist, options: { withPreview?: boolean } = {}) {
+  const withPreview = options.withPreview ?? true
+  return {
+    id,
+    title: `Track ${id}`,
+    title_short: `Track ${id}`,
+    title_version: '',
+    link: `https://deezer.com/track/${id}`,
+    duration: 180,
+    rank: 100,
+    explicit_lyrics: false,
+    explicit_content_lyrics: 0,
+    explicit_content_cover: 0,
+    preview: withPreview ? `https://cdn.deezer.com/preview/${id}` : '',
+    md5_image: `md5${id}`,
+    artist: {
+      id: artist.id,
+      name: artist.name,
+      picture: `https://cdn/artist/${artist.id}`,
+      picture_small: `https://cdn/artist/${artist.id}/sm`,
+      picture_medium: `https://cdn/artist/${artist.id}/md`,
+      picture_big: `https://cdn/artist/${artist.id}/big`,
+      picture_xl: `https://cdn/artist/${artist.id}/xl`,
+    },
+    album: {
+      id,
+      title: `Album ${id}`,
+      cover: `https://cdn/album/${id}`,
+      cover_small: `https://cdn/album/${id}/sm`,
+      cover_medium: `https://cdn/album/${id}/md`,
+      cover_big: `https://cdn/album/${id}/big`,
+      cover_xl: `https://cdn/album/${id}/xl`,
+      md5_image: `md5${id}`,
+    },
+    type: 'track',
+  }
+}
+
+function jsonResponse(payload: unknown, status: number = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+interface FakeFetchOptions {
+  spotifyArtistNames?: string[]
+  chartStatus?: number
+}
+
+function buildFakeFetch(options: FakeFetchOptions = {}): typeof fetch {
+  const chartTrackArtist: FakeArtist = {
+    id: 7000,
+    name: 'Chart Artist 7000',
+  }
+  const chartTrackIds = Array.from({ length: 5 }, (_, i) => CHART_TRACK_BASE_ID + i)
+
+  return (async (input: Parameters<typeof fetch>[0]) => {
+    const url = typeof input === 'string' ? input : input.toString()
+
+    if (url.includes('api.spotify.com/v1/me/top/artists')) {
+      const items = (options.spotifyArtistNames ?? []).map((name, index) => ({
+        id: `sp_${index}`,
+        name,
+      }))
+      return jsonResponse({ items })
+    }
+
+    const chartMatch = url.match(/\/chart\/([A-Z]{2})\/tracks/)
+    if (chartMatch) {
+      if (options.chartStatus && options.chartStatus >= 400) {
+        return new Response('upstream down', { status: options.chartStatus })
+      }
+      const data = chartTrackIds.map((id) => makeTrackPayload(id, chartTrackArtist))
+      return jsonResponse({ data })
+    }
+
+    const relatedMatch = url.match(/\/artist\/(\d+)\/related/)
+    if (relatedMatch) {
+      const seedId = Number(relatedMatch[1])
+      const offset = seedId % RELATED_ARTIST_IDS.length || 0
+      const data = RELATED_ARTIST_IDS.slice(offset, offset + 3).map((id) => ({
+        id,
+        name: ARTIST_NAMES[id] ?? `Related ${id}`,
+      }))
+      return jsonResponse({ data })
+    }
+
+    const topMatch = url.match(/\/artist\/(\d+)\/top/)
+    if (topMatch) {
+      const artistId = Number(topMatch[1])
+      const isRelated = (RELATED_ARTIST_IDS as readonly number[]).includes(artistId)
+      const baseId = isRelated ? RELATED_TOP_BASE_ID : FAMILIAR_TOP_BASE_ID
+      const trackIds = Array.from({ length: 5 }, (_, i) => baseId + artistId * 10 + i)
+      const artist: FakeArtist = {
+        id: artistId,
+        name: ARTIST_NAMES[artistId] ?? `Artist ${artistId}`,
+      }
+      const data = trackIds.map((id) => makeTrackPayload(id, artist))
+      return jsonResponse({ data })
+    }
+
+    const searchMatch = url.match(/\/search\/artist\?q=([^&]+)/)
+    if (searchMatch) {
+      const decoded = decodeURIComponent(searchMatch[1])
+      const found = Object.entries(ARTIST_NAMES).find(([, name]) => name === decoded)
+      const data = found ? [{ id: Number(found[0]), name: found[1] }] : []
+      return jsonResponse({ data })
+    }
+
+    return jsonResponse({})
+  }) as typeof fetch
+}
+
+function asTracks(body: unknown): { id: number; artist: { id: number } }[] {
+  return (body as { tracks: { id: number; artist: { id: number } }[] }).tracks
+}
+
+test.group('SwipemixFeedController - auth & validation', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+    globalThis.fetch = buildFakeFetch()
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('GET /api/me/swipemix/feed requires auth', async ({ client }) => {
+    const response = await client.get('/api/me/swipemix/feed')
+    response.assertStatus(401)
+  })
+
+  test('rejects invalid limit query param', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('feed_bad_limit')
+    const response = await client.get('/api/me/swipemix/feed?limit=999').bearerToken(token)
+    response.assertStatus(422)
+  })
+
+  test('rejects invalid country query param', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('feed_bad_country')
+    const response = await client.get('/api/me/swipemix/feed?country=FRA').bearerToken(token)
+    response.assertStatus(422)
+  })
+})
+
+test.group('SwipemixFeedController - cold start', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+    globalThis.fetch = buildFakeFetch()
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('returns chart tracks when the user has no seed signals', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('feed_cold_start')
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+
+    response.assertStatus(200)
+    const tracks = asTracks(response.body())
+    assert.isAbove(tracks.length, 0)
+    const chartArtist = tracks.find((track) => track.artist.id === 7000)
+    assert.exists(chartArtist, 'chart artist should be present in cold start feed')
+  })
+
+  test('respects custom limit and offset', async ({ client, assert }) => {
+    const { user, token } = await createAuthenticatedUser('feed_pagination')
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+      { userId: user.id, deezerArtistId: '413', artistName: 'Stromae', rank: 2 },
+    ])
+
+    const firstPage = await client.get('/api/me/swipemix/feed?limit=3&offset=0').bearerToken(token)
+    firstPage.assertStatus(200)
+    const firstTracks = asTracks(firstPage.body())
+    assert.equal(firstTracks.length, 3)
+
+    const secondPage = await client.get('/api/me/swipemix/feed?limit=3&offset=3').bearerToken(token)
+    secondPage.assertStatus(200)
+    const secondTracks = asTracks(secondPage.body())
+
+    const firstIds = firstTracks.map((track) => track.id)
+    const secondIds = secondTracks.map((track) => track.id)
+    for (const id of secondIds) {
+      assert.notInclude(firstIds, id)
+    }
+  })
+})
+
+test.group('SwipemixFeedController - personalisation', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+    globalThis.fetch = buildFakeFetch()
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('excludes tracks the user already swiped (liked or disliked)', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_excludes_swiped')
+
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+      { userId: user.id, deezerArtistId: '413', artistName: 'Stromae', rank: 2 },
+    ])
+
+    const excludedIds = [FAMILIAR_TOP_BASE_ID + 27 * 10, FAMILIAR_TOP_BASE_ID + 413 * 10 + 1]
+    await UserTrackInteraction.createMany([
+      {
+        userId: user.id,
+        deezerTrackId: String(excludedIds[0]),
+        deezerArtistId: '27',
+        action: InteractionAction.Liked,
+      },
+      {
+        userId: user.id,
+        deezerTrackId: String(excludedIds[1]),
+        deezerArtistId: '413',
+        action: InteractionAction.Disliked,
+      },
+    ])
+
+    const response = await client.get('/api/me/swipemix/feed?limit=50').bearerToken(token)
+    response.assertStatus(200)
+
+    const ids = asTracks(response.body()).map((track) => track.id)
+    for (const excluded of excludedIds) {
+      assert.notInclude(ids, excluded)
+    }
+  })
+
+  test('produces different feeds for users with different onboarding seeds', async ({
+    client,
+    assert,
+  }) => {
+    const userA = await createAuthenticatedUser('feed_user_a')
+    const userB = await createAuthenticatedUser('feed_user_b')
+
+    await UserOnboardingArtist.createMany([
+      { userId: userA.user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+      { userId: userA.user.id, deezerArtistId: '413', artistName: 'Stromae', rank: 2 },
+    ])
+
+    await UserOnboardingArtist.createMany([
+      { userId: userB.user.id, deezerArtistId: '288166', artistName: 'Angèle', rank: 1 },
+    ])
+
+    const respA = await client.get('/api/me/swipemix/feed?limit=10').bearerToken(userA.token)
+    const respB = await client.get('/api/me/swipemix/feed?limit=10').bearerToken(userB.token)
+
+    respA.assertStatus(200)
+    respB.assertStatus(200)
+
+    const idsA = new Set(asTracks(respA.body()).map((track) => track.id))
+    const idsB = new Set(asTracks(respB.body()).map((track) => track.id))
+
+    const intersection = Array.from(idsA).filter((id) => idsB.has(id))
+    assert.notEqual(intersection.length, idsA.size, 'feeds should diverge between distinct seeds')
+  })
+
+  test('the first 5 tracks contain at most one chart-only (discovery) track when seeds exist', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_ratio_top5')
+
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+      { userId: user.id, deezerArtistId: '413', artistName: 'Stromae', rank: 2 },
+      { userId: user.id, deezerArtistId: '288166', artistName: 'Angèle', rank: 3 },
+    ])
+
+    const response = await client.get('/api/me/swipemix/feed?limit=5').bearerToken(token)
+    response.assertStatus(200)
+
+    const seedSet = new Set(FAMILIAR_ARTIST_IDS as readonly number[])
+    const familiarCount = asTracks(response.body()).filter((track) =>
+      seedSet.has(track.artist.id)
+    ).length
+
+    assert.isAtLeast(familiarCount, 4, 'expected ≥4 familiar tracks in first 5 (80/20 ratio)')
+  })
+})
+
+test.group('SwipemixFeedController - integrations & errors', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+  deleteUserIntegrations(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('uses Spotify top artists as seeds when integration exists', async ({ client, assert }) => {
+    const { user, token } = await createAuthenticatedUser('feed_spotify_seed')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_seed',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-top-read',
+    })
+
+    globalThis.fetch = buildFakeFetch({ spotifyArtistNames: ['Daft Punk'] })
+
+    const response = await client.get('/api/me/swipemix/feed?limit=20').bearerToken(token)
+    response.assertStatus(200)
+
+    const tracks = asTracks(response.body())
+    const hasDaftPunk = tracks.some((track) => track.artist.id === 27)
+    assert.isTrue(hasDaftPunk, 'expected Daft Punk top track from Spotify-resolved seed')
+  })
+
+  test('returns 502 when Deezer chart upstream fails for cold-start user', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('feed_chart_502')
+    globalThis.fetch = buildFakeFetch({ chartStatus: 500 })
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    // Cold start with no chart leaves an empty pool but the endpoint still returns 200 with []
+    // because we want graceful degradation, not 502.
+    response.assertStatus(200)
+  })
+})

--- a/front-mobile/hooks/__tests__/useSwipeMix.test.ts
+++ b/front-mobile/hooks/__tests__/useSwipeMix.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
 import { useSwipeMix } from "../useSwipeMix";
 import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
+import { getSwipemixFeed } from "@/services/swipemixFeedService";
 import { useAudioPlayer } from "../useAudioPlayer";
 import { deezerTracksToCardData } from "@/utils/deezer-adapter";
 import { upsertMyTrackInteraction } from "@/services/trackInteractionsService";
@@ -8,11 +9,15 @@ import { MusicCardData } from "@/components/swipe";
 
 // Mock des dépendances
 jest.mock("@/services/deezer-api");
+jest.mock("@/services/swipemixFeedService");
 jest.mock("../useAudioPlayer");
 jest.mock("@/utils/deezer-adapter");
 jest.mock("@/services/trackInteractionsService");
 
 const mockDeezerAPI = deezerAPI as jest.Mocked<typeof deezerAPI>;
+const mockGetSwipemixFeed = getSwipemixFeed as jest.MockedFunction<
+  typeof getSwipemixFeed
+>;
 const mockUseAudioPlayer = useAudioPlayer as jest.MockedFunction<
   typeof useAudioPlayer
 >;
@@ -135,6 +140,7 @@ describe("useSwipeMix", () => {
         });
       },
     );
+    mockGetSwipemixFeed.mockResolvedValue(mockTracks);
     mockDeezerAPI.getTopTracks.mockResolvedValue({
       data: mockTracks,
       total: mockTracks.length,
@@ -179,7 +185,7 @@ describe("useSwipeMix", () => {
         expect(result.current.isLoadingCards).toBe(false);
       });
 
-      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+      expect(mockGetSwipemixFeed).toHaveBeenCalledWith(10, 0);
       expect(result.current.cards).toHaveLength(10);
       expect(result.current.cards[0].id).toBe("1");
       expect(result.current.cards[0].title).toBe("Track 1");
@@ -193,11 +199,12 @@ describe("useSwipeMix", () => {
         expect(result.current.isLoadingCards).toBe(false);
       });
 
-      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(20, 0);
+      expect(mockGetSwipemixFeed).toHaveBeenCalledWith(20, 0);
     });
 
     it("should handle loading errors", async () => {
       const errorMessage = "Network error";
+      mockGetSwipemixFeed.mockRejectedValueOnce(new Error(errorMessage));
       mockDeezerAPI.getTopTracks.mockRejectedValueOnce(new Error(errorMessage));
 
       const { result } = renderHook(() => useSwipeMix());
@@ -211,6 +218,7 @@ describe("useSwipeMix", () => {
     });
 
     it("should handle non-Error exceptions", async () => {
+      mockGetSwipemixFeed.mockRejectedValueOnce("string error");
       mockDeezerAPI.getTopTracks.mockRejectedValueOnce("string error");
 
       const { result } = renderHook(() => useSwipeMix());
@@ -268,10 +276,9 @@ describe("useSwipeMix", () => {
     });
 
     it("should not trigger a background refetch if cached track already has ISRC", async () => {
-      mockDeezerAPI.getTopTracks.mockResolvedValueOnce({
-        data: mockTracks.map((t) => ({ ...t, isrc: `ISRC${t.id}` })),
-        total: mockTracks.length,
-      });
+      mockGetSwipemixFeed.mockResolvedValueOnce(
+        mockTracks.map((t) => ({ ...t, isrc: `ISRC${t.id}` })),
+      );
 
       const { result } = renderHook(() => useSwipeMix());
 
@@ -582,12 +589,12 @@ describe("useSwipeMix", () => {
         expect(result.current.cards).toHaveLength(10);
       });
 
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       result.current.handlers.onEmpty();
 
       await waitFor(() => {
-        expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+        expect(mockGetSwipemixFeed).toHaveBeenCalledWith(10, 0);
       });
     });
 
@@ -598,30 +605,30 @@ describe("useSwipeMix", () => {
         expect(result.current.cards).toHaveLength(10);
       });
 
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       let resolveLoad: (value: any) => void;
       const slowPromise = new Promise((resolve) => {
         resolveLoad = resolve;
       });
-      mockDeezerAPI.getTopTracks.mockReturnValueOnce(slowPromise as any);
+      mockGetSwipemixFeed.mockReturnValueOnce(slowPromise as any);
 
       // Trigger loadMore (sets isLoadingRef = true)
       const loadMorePromise = result.current.actions.loadMore();
 
-      // Wait for loadMore to actually start (getTopTracks called for the in-flight load)
+      // Wait for loadMore to actually start (feed called for the in-flight load)
       await waitFor(() => {
-        expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledTimes(1);
+        expect(mockGetSwipemixFeed).toHaveBeenCalledTimes(1);
       });
 
       // handleEmpty should be blocked by the lock
       result.current.handlers.onEmpty();
 
-      resolveLoad!({ data: mockTracks, total: mockTracks.length });
+      resolveLoad!(mockTracks);
       await loadMorePromise;
 
-      // getTopTracks called only once (loadMore), not twice (handleEmpty blocked)
-      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledTimes(1);
+      // feed called only once (loadMore), not twice (handleEmpty blocked)
+      expect(mockGetSwipemixFeed).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -636,18 +643,15 @@ describe("useSwipeMix", () => {
       const initialCardCount = result.current.cards.length;
 
       // Clear previous calls
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       // Setup mock for pagination call - return same tracks for simplicity
-      mockDeezerAPI.getTopTracks.mockResolvedValueOnce({
-        data: mockTracks,
-        total: mockTracks.length,
-      });
+      mockGetSwipemixFeed.mockResolvedValueOnce(mockTracks);
 
       await result.current.actions.loadMore();
 
       await waitFor(() => {
-        expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 10);
+        expect(mockGetSwipemixFeed).toHaveBeenCalledWith(10, 10);
         expect(result.current.cards).toHaveLength(initialCardCount + 10);
       });
     });
@@ -660,7 +664,7 @@ describe("useSwipeMix", () => {
       });
 
       // Clear calls from initialization
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       // Setup slow-resolving promise to simulate loading
       let resolveLoad: (value: any) => void;
@@ -668,7 +672,7 @@ describe("useSwipeMix", () => {
         resolveLoad = resolve;
       });
 
-      mockDeezerAPI.getTopTracks.mockReturnValueOnce(slowPromise as any);
+      mockGetSwipemixFeed.mockReturnValueOnce(slowPromise as any);
 
       // Trigger first load (will be slow)
       const loadPromise1 = result.current.actions.loadMore();
@@ -680,23 +684,17 @@ describe("useSwipeMix", () => {
       const loadPromise2 = result.current.actions.loadMore();
 
       // Resolve the slow promise
-      resolveLoad!({
-        data: mockTracks,
-        total: mockTracks.length,
-      });
+      resolveLoad!(mockTracks);
 
       await Promise.all([loadPromise1, loadPromise2]);
 
       // Should only be called once (second call was blocked)
-      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledTimes(1);
+      expect(mockGetSwipemixFeed).toHaveBeenCalledTimes(1);
     });
 
     it("should not load more if no more tracks", async () => {
       // Retourner moins de tracks que la limite
-      mockDeezerAPI.getTopTracks.mockResolvedValueOnce({
-        data: [mockTracks[0]],
-        total: 1,
-      });
+      mockGetSwipemixFeed.mockResolvedValueOnce([mockTracks[0]]);
 
       const { result } = renderHook(() => useSwipeMix());
 
@@ -704,11 +702,11 @@ describe("useSwipeMix", () => {
         expect(result.current.cards).toHaveLength(1);
       });
 
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       await result.current.actions.loadMore();
 
-      expect(mockDeezerAPI.getTopTracks).not.toHaveBeenCalled();
+      expect(mockGetSwipemixFeed).not.toHaveBeenCalled();
     });
   });
 
@@ -721,19 +719,77 @@ describe("useSwipeMix", () => {
       });
 
       // Clear the mock to verify reload is called with index 0
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
-      mockDeezerAPI.getTopTracks.mockResolvedValueOnce({
-        data: [mockTracks[0]],
-        total: 1,
-      });
+      mockGetSwipemixFeed.mockResolvedValueOnce([mockTracks[0]]);
 
       await result.current.actions.reload();
 
       await waitFor(() => {
         expect(result.current.cards).toHaveLength(1);
-        expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+        expect(mockGetSwipemixFeed).toHaveBeenCalledWith(10, 0);
       });
+    });
+  });
+
+  describe("backend feed fallback", () => {
+    it("falls back to deezerAPI.getTopTracks when backend returns 5xx", async () => {
+      mockGetSwipemixFeed.mockRejectedValueOnce({
+        message: "Internal error",
+        statusCode: 500,
+      });
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.isLoadingCards).toBe(false);
+      });
+
+      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+      expect(result.current.cards).toHaveLength(10);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("falls back to deezerAPI.getTopTracks when backend throws a network error without statusCode", async () => {
+      mockGetSwipemixFeed.mockRejectedValueOnce(new Error("Network failure"));
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.isLoadingCards).toBe(false);
+      });
+
+      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+      expect(result.current.cards).toHaveLength(10);
+    });
+
+    it("does not fall back when backend returns 401 (auth)", async () => {
+      mockGetSwipemixFeed.mockRejectedValueOnce({
+        message: "Non autorisé",
+        statusCode: 401,
+      });
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.isLoadingCards).toBe(false);
+      });
+
+      expect(mockDeezerAPI.getTopTracks).not.toHaveBeenCalled();
+      expect(result.current.error).toBe("Non autorisé");
+    });
+
+    it("falls back when backend returns an empty feed", async () => {
+      mockGetSwipemixFeed.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.isLoadingCards).toBe(false);
+      });
+
+      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+      expect(result.current.cards).toHaveLength(10);
     });
   });
 });

--- a/front-mobile/hooks/useSwipeMix.ts
+++ b/front-mobile/hooks/useSwipeMix.ts
@@ -1,14 +1,50 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
 import { cacheManager } from "@/services/cache-manager";
+import { getSwipemixFeed } from "@/services/swipemixFeedService";
 import { upsertMyTrackInteraction } from "@/services/trackInteractionsService";
 import {
   InteractionAction,
   SpotifyTriggerSnapshot,
 } from "@/types/trackInteraction";
+import { ApiError } from "@/types/auth";
 import { MusicCardData } from "@/components/swipe";
 import { deezerTracksToCardData } from "@/utils/deezer-adapter";
 import { useAudioPlayer } from "./useAudioPlayer";
+
+const getApiErrorStatus = (error: unknown): number | undefined => {
+  if (typeof error !== "object" || error === null) return undefined;
+  const status = (error as ApiError).statusCode;
+  return typeof status === "number" ? status : undefined;
+};
+
+const extractErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return "Erreur lors du chargement des musiques";
+};
+
+const shouldFallbackToDeezer = (error: unknown): boolean => {
+  const status = getApiErrorStatus(error);
+  return status === undefined || status >= 500;
+};
+
+const fetchFeedWithFallback = async (
+  limit: number,
+  offset: number,
+): Promise<DeezerTrack[]> => {
+  try {
+    const tracks = await getSwipemixFeed(limit, offset);
+    if (tracks.length > 0) return tracks;
+  } catch (error) {
+    if (!shouldFallbackToDeezer(error)) throw error;
+  }
+  const response = await deezerAPI.getTopTracks(limit, offset);
+  return response.data;
+};
 
 interface UseSwipeMixOptions {
   initialLimit?: number;
@@ -62,14 +98,17 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
         // Utiliser l'index actuel pour la pagination
         const indexToUse = append ? currentPageIndexRef.current : 0;
 
-        // Récupérer les morceaux tendances
-        const response = await deezerAPI.getTopTracks(initialLimit, indexToUse);
+        // Récupérer le feed personnalisé (avec fallback sur le top Deezer en cas d'erreur backend)
+        const feedTracks = await fetchFeedWithFallback(
+          initialLimit,
+          indexToUse,
+        );
 
         // Récupérer les genres et les détails des albums (pour avoir le genre_id) en parallèle
         // Note: deezerAPI utilise déjà le cacheManager
         const [genresResponse, ...albums] = await Promise.all([
           deezerAPI.getGenres(),
-          ...response.data.map((track) => deezerAPI.getAlbum(track.album.id)),
+          ...feedTracks.map((track) => deezerAPI.getAlbum(track.album.id)),
         ]);
 
         // Créer les mappings pour l'adapter
@@ -95,13 +134,13 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
 
         // Convertir en cartes avec les informations de genre
         const newCards = deezerTracksToCardData(
-          response.data,
+          feedTracks,
           genreMapping,
           albumGenresMapping,
         );
 
         // Vérifier s'il y a encore des musiques à charger
-        setHasMoreTracks(response.data.length === initialLimit);
+        setHasMoreTracks(feedTracks.length === initialLimit);
 
         if (append) {
           // Ajouter les nouvelles cartes à la fin
@@ -110,7 +149,7 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
           // Ajouter les nouvelles tracks à la map existante
           setTracks((prev) => {
             const newMap = new Map(prev);
-            response.data.forEach((track) => {
+            feedTracks.forEach((track) => {
               newMap.set(track.id.toString(), track);
             });
             return newMap;
@@ -121,7 +160,7 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
         } else {
           // Remplacer complètement les cartes et tracks
           const trackMap = new Map<string, DeezerTrack>();
-          response.data.forEach((track) => {
+          feedTracks.forEach((track) => {
             trackMap.set(track.id.toString(), track);
           });
 
@@ -130,11 +169,7 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
           currentPageIndexRef.current = initialLimit;
         }
       } catch (err) {
-        setError(
-          err instanceof Error
-            ? err.message
-            : "Erreur lors du chargement des musiques",
-        );
+        setError(extractErrorMessage(err));
       } finally {
         isLoadingRef.current = false;
         setIsLoadingCards(false);

--- a/front-mobile/services/__tests__/swipemixFeedService.test.ts
+++ b/front-mobile/services/__tests__/swipemixFeedService.test.ts
@@ -1,0 +1,41 @@
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
+
+import { getSwipemixFeed } from "../swipemixFeedService";
+import { get } from "../api";
+import { DeezerTrack } from "../deezer-api";
+
+jest.mock("../api", () => ({
+  get: jest.fn(),
+}));
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("swipemixFeedService", () => {
+  const mockTrack = {
+    id: 1,
+    title: "Track 1",
+  } as unknown as DeezerTrack;
+
+  it("GETs /api/me/swipemix/feed with limit and offset", async () => {
+    mockGet.mockResolvedValueOnce({ tracks: [mockTrack] });
+
+    const result = await getSwipemixFeed(20, 10);
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/me/swipemix/feed?limit=20&offset=10",
+    );
+    expect(result).toEqual([mockTrack]);
+  });
+
+  it("returns an empty array when the response has no tracks field", async () => {
+    mockGet.mockResolvedValueOnce({} as { tracks: DeezerTrack[] });
+
+    const result = await getSwipemixFeed(10, 0);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/front-mobile/services/swipemixFeedService.ts
+++ b/front-mobile/services/swipemixFeedService.ts
@@ -1,0 +1,16 @@
+import { get } from "./api";
+import { DeezerTrack } from "./deezer-api";
+
+interface SwipemixFeedResponse {
+  tracks: DeezerTrack[];
+}
+
+export const getSwipemixFeed = async (
+  limit: number,
+  offset: number,
+): Promise<DeezerTrack[]> => {
+  const data = await get<SwipemixFeedResponse>(
+    `/api/me/swipemix/feed?limit=${limit}&offset=${offset}`,
+  );
+  return data.tracks ?? [];
+};


### PR DESCRIPTION
## Description

Mise en place d'un feed SwipeMix personnalisé : chaque utilisateur reçoit désormais des morceaux adaptés à ses goûts via le nouvel endpoint `GET /api/me/swipemix/feed`. Le service de recommandation agrège les seeds (top artistes Spotify, derniers likes, artistes d'onboarding, fallback chart pays) puis construit deux buckets familier/découverte mélangés selon un ratio dynamique 80/20 sur les 5 premières cartes puis 60/40, avec exclusion des morceaux déjà swipés et cache applicatif de 5 minutes par utilisateur. Le hook `useSwipeMix` consomme cet endpoint avec un fallback automatique sur `deezerAPI.getTopTracks` en cas d'erreur backend pour ne jamais casser la démo.

## Parcours utilisateur

1. **Cold start (utilisateur sans signal)** : se connecter avec un compte sans Spotify lié, sans onboarding, sans interaction → ouvrir SwipeMix → le feed doit charger des morceaux issus du chart pays (FR par défaut), aucune erreur affichée.
2. **Utilisateur avec onboarding seul** : remplir l'onboarding artistes (3 artistes choisis) → ouvrir SwipeMix → vérifier que les premières cartes proviennent majoritairement des artistes choisis (ratio familier 80% sur les 5 premières) avec quelques découvertes (artistes proches + chart) en complément.
3. **Utilisateur avec Spotify connecté** : lier son compte Spotify → ouvrir SwipeMix → constater que le feed familier inclut désormais des morceaux d'artistes proches du top Spotify de l'utilisateur.
4. **Utilisateur actif (likes/dislikes)** : liker plusieurs morceaux puis en disliker d'autres → recharger SwipeMix → les morceaux déjà swipés (likés ET dislikés) doivent être absents du feed ; le ratio reste ~80/20 sur les 5 premières puis 60/40.
5. **Pagination** : enchaîner plus de 20 swipes → de nouvelles cartes se chargent automatiquement (`onEmpty`/`loadMore`) sans doublon entre les pages.
6. **Fallback backend down** : couper le backend ou simuler un 5xx → SwipeMix bascule sur Deezer top tracks direct, la démo continue de fonctionner.
7. **Cache 5 minutes** : effectuer deux paginations rapprochées → la seconde ne refait pas les calls Deezer côté backend (cache hit visible dans les logs backend).