### PR TITLE
HOTFIX-onboarding-artists-ux fix: empty Spotify fallback and short artist search

### DIFF
--- a/front-mobile/app/onboarding/artists.tsx
+++ b/front-mobile/app/onboarding/artists.tsx
@@ -106,6 +106,13 @@ export default function OnboardingArtistsScreen() {
         const artists = await getOnboardingSpotifySuggestions();
         if (cancelled) return;
         setSpotifyArtists(artists);
+        if (artists.length === 0 && selectedById.size === 0) {
+          show({
+            type: "warning",
+            message: "Aucun artiste Spotify trouvé, choisis-les manuellement",
+          });
+          setMode("manual");
+        }
       } catch (error) {
         if (cancelled) return;
         console.error("Failed to load Spotify suggestions:", error);
@@ -122,7 +129,7 @@ export default function OnboardingArtistsScreen() {
     return () => {
       cancelled = true;
     };
-  }, [mode, spotifyStatus?.connected, show]);
+  }, [mode, spotifyStatus?.connected, show, selectedById.size]);
 
   const selectedCount = selectedById.size;
   const canValidate =

--- a/front-mobile/hooks/__tests__/useArtistSearch.test.ts
+++ b/front-mobile/hooks/__tests__/useArtistSearch.test.ts
@@ -73,7 +73,7 @@ describe("useArtistSearch", () => {
     });
   });
 
-  it("does not search when query is shorter than 3 characters", async () => {
+  it("does not search when query is empty", async () => {
     const { rerender } = renderHook<
       ReturnType<typeof useArtistSearch>,
       { q: string }
@@ -85,13 +85,36 @@ describe("useArtistSearch", () => {
       expect(mockDeezerAPI.getTopArtists).toHaveBeenCalled();
     });
 
-    rerender({ q: "ab" });
+    rerender({ q: "   " });
 
     await act(async () => {
       jest.advanceTimersByTime(500);
     });
 
     expect(mockDeezerAPI.searchArtists).not.toHaveBeenCalled();
+  });
+
+  it("searches with a single character query", async () => {
+    const { rerender } = renderHook<
+      ReturnType<typeof useArtistSearch>,
+      { q: string }
+    >(({ q }) => useArtistSearch(q), {
+      initialProps: { q: "" },
+    });
+
+    await waitFor(() => {
+      expect(mockDeezerAPI.getTopArtists).toHaveBeenCalled();
+    });
+
+    rerender({ q: "M" });
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    await waitFor(() => {
+      expect(mockDeezerAPI.searchArtists).toHaveBeenCalledWith("M", 20);
+    });
   });
 
   it("debounces the search by 400ms and returns results", async () => {
@@ -127,7 +150,7 @@ describe("useArtistSearch", () => {
     expect(result.current.searchResults[0].name).toBe("Daft Punk");
   });
 
-  it("clears isSearching immediately when query drops below 3 characters mid-flight", async () => {
+  it("clears isSearching immediately when query drops below the min length mid-flight", async () => {
     let resolveSearch: (value: { data: DeezerArtist[] }) => void = () => {};
     mockDeezerAPI.searchArtists.mockImplementationOnce(
       () =>
@@ -155,7 +178,7 @@ describe("useArtistSearch", () => {
       expect(result.current.isSearching).toBe(true);
     });
 
-    rerender({ q: "da" });
+    rerender({ q: "" });
 
     await waitFor(() => {
       expect(result.current.isSearching).toBe(false);
@@ -170,7 +193,7 @@ describe("useArtistSearch", () => {
     expect(result.current.isSearching).toBe(false);
   });
 
-  it("resets search results when query drops below 3 characters", async () => {
+  it("resets search results when query is cleared", async () => {
     const { result, rerender } = renderHook<
       ReturnType<typeof useArtistSearch>,
       { q: string }
@@ -190,7 +213,7 @@ describe("useArtistSearch", () => {
       expect(result.current.searchResults).toHaveLength(1);
     });
 
-    rerender({ q: "da" });
+    rerender({ q: "" });
 
     await waitFor(() => {
       expect(result.current.searchResults).toEqual([]);

--- a/front-mobile/hooks/useArtistSearch.ts
+++ b/front-mobile/hooks/useArtistSearch.ts
@@ -3,7 +3,7 @@ import { deezerAPI, DeezerArtist } from "@/services/deezer-api";
 import { useToast } from "@/components/Toast";
 
 const SEARCH_DEBOUNCE_MS = 400;
-const MIN_QUERY_LENGTH = 3;
+const MIN_QUERY_LENGTH = 1;
 const TOP_ARTISTS_LIMIT = 20;
 const SEARCH_RESULTS_LIMIT = 20;
 


### PR DESCRIPTION
## Description

Deux correctifs UX remontés par les testeurs sur l'écran d'onboarding "Tes artistes favoris" (post-MIX-290).

1. **Compte Spotify neuf bloquant** : `getOnboardingSpotifySuggestions()` renvoie `[]` pour un compte Spotify sans top artists, l'utilisateur restait coincé sur "Aucune suggestion Spotify disponible". Désormais, on bascule automatiquement en mode manuel (recherche Deezer) avec un toast `warning` informatif lorsque la liste Spotify est vide ET qu'aucun artiste n'est déjà sélectionné.
2. **Recherche d'artiste limitée à 3 caractères** : un testeur ne pouvait pas chercher "MZ". `MIN_QUERY_LENGTH` passe de 3 à 1, ce qui permet une recherche dès la 1ère lettre tout en conservant l'affichage des "Artistes populaires en France" en état neutre (champ vide). Tests mis à jour + nouveau test 1-caractère.

## Parcours utilisateur

**Fix 1 — Spotify vide :**
1. Connecter un compte Spotify neuf (sans écoutes / sans top artists)
2. Onboarding > "Tes artistes favoris" > "Connecter Spotify"
3. Vérifier l'apparition du toast _"Aucun artiste Spotify trouvé, choisis-les manuellement"_
4. Vérifier que l'écran bascule sur la recherche manuelle Deezer

**Fix 2 — recherche courte :**
1. Onboarding > "Tes artistes favoris" > "Choisir manuellement"
2. Taper `M` → résultats Deezer s'affichent
3. Taper `MZ` → l'artiste MZ remonte
4. Effacer le champ → retour sur "Artistes populaires en France"