### PR TITLE
HOTFIX-spotify-remove-track fix: Spotify dislike sync 400 "No uris provided"

### DIFF
--- a/backend/app/services/spotify_playlist_service.ts
+++ b/backend/app/services/spotify_playlist_service.ts
@@ -146,7 +146,7 @@ export class SpotifyPlaylistService {
 
     await this.spotifyService.spotifyApiRequest(
       userId,
-      `/playlists/${integration.spotifyLikedPlaylistId}/items`,
+      `/playlists/${integration.spotifyLikedPlaylistId}/tracks`,
       {
         method: 'DELETE',
         body: { tracks: [{ uri: trackUri }] },

--- a/backend/tests/unit/spotify_playlist_service.spec.ts
+++ b/backend/tests/unit/spotify_playlist_service.spec.ts
@@ -394,8 +394,12 @@ test.group('SpotifyPlaylistService - removeTrack', (group) => {
     assert.deepEqual(result, { removed: true })
 
     const del = calls.find(
-      (c) => c.path === '/playlists/pl_rm/items' && c.options.method === 'DELETE'
+      (c) => c.path === '/playlists/pl_rm/tracks' && c.options.method === 'DELETE'
     )!
+    assert.exists(
+      del,
+      'DELETE must target /tracks endpoint, not /items (Spotify rejects DELETE on /items with 400 "No uris provided")'
+    )
     assert.deepEqual(del.options.body, { tracks: [{ uri: 'spotify:track:rm' }] })
   })
 })


### PR DESCRIPTION
## Summary

- Le sync Spotify déclenché par un `dislike` (track interaction → `removeTrack`) échouait en staging avec `400 "No uris provided"` sur `/playlists/{id}/items`.
- Cause : on appelait `DELETE /playlists/{id}/items` avec un body `{ tracks: [{ uri }] }`. Spotify n'accepte pas la suppression sur `/items` — l'endpoint correct pour la suppression est `DELETE /playlists/{id}/tracks`. Le serveur retombait sur le parser POST de `/items` qui s'attend à `uris`, d'où l'erreur.
- Fix : pointer le DELETE sur `/tracks` (le body `{ tracks: [{ uri }] }` est déjà au format attendu par cet endpoint).
- Le test `issues DELETE on the playlist when the track is found` assertait justement le mauvais path (`/items`) — c'est pour ça que le bug n'a pas été détecté. Test mis à jour pour pointer `/tracks` + assertion explicite avec message de régression.

## Référence

- Erreur staging : `SpotifyApiError: Spotify API error 400 on /playlists/6PICn1Q5apNbR7uZX4qSQp/items` — body `{"error": {"status": 400, "message": "No uris provided" }}`
- Stack : `SpotifyPlaylistService.removeTrack` → `TrackInteractionsController.syncToSpotifyPlaylist`

## Test plan

- [x] `npm run check` (lint + typecheck + format) backend
- [x] `npm run test:coverage` backend — 592 tests passent, 100% coverage maintenue
- [ ] Vérifier en staging qu'un dislike sur une track précédemment likée la retire bien de la playlist `Rythmix Likes`