### PR TITLE
HOTFIX-spotify-remove-track fix: avoid duplicating the Rythmix Likes playlist on Spotify relink

### DIFF
--- a/backend/app/services/spotify_playlist_service.ts
+++ b/backend/app/services/spotify_playlist_service.ts
@@ -9,7 +9,12 @@ import { SpotifyApiError, SpotifyService } from '#services/spotify_service'
 
 export const SPOTIFY_LIKED_PLAYLIST_NAME = 'Rythmix Likes'
 export const SPOTIFY_LIKED_PLAYLIST_DESCRIPTION = 'Tes likes SwipeMix exportés depuis Rythmix.'
-export const SPOTIFY_PLAYLIST_SCOPE = 'playlist-modify-private'
+export const SPOTIFY_PLAYLIST_MODIFY_SCOPE = 'playlist-modify-private'
+export const SPOTIFY_PLAYLIST_READ_SCOPE = 'playlist-read-private'
+export const SPOTIFY_PLAYLIST_REQUIRED_SCOPES = [
+  SPOTIFY_PLAYLIST_MODIFY_SCOPE,
+  SPOTIFY_PLAYLIST_READ_SCOPE,
+] as const
 
 export const SPOTIFY_ERROR_CODE = {
   ScopeUpgradeRequired: 'SPOTIFY_SCOPE_UPGRADE_REQUIRED',
@@ -65,28 +70,18 @@ export class SpotifyPlaylistService {
         return integration.spotifyLikedPlaylistId
       }
 
-      if (!this.hasPlaylistScope(integration)) {
+      if (!this.hasPlaylistScopes(integration)) {
         throw new SpotifyScopeUpgradeRequiredError()
       }
 
       try {
-        const created = await this.spotifyService.spotifyApiRequest<{ id: string }>(
-          userId,
-          `/users/${integration.providerUserId}/playlists`,
-          {
-            method: 'POST',
-            body: {
-              name: SPOTIFY_LIKED_PLAYLIST_NAME,
-              public: false,
-              description: SPOTIFY_LIKED_PLAYLIST_DESCRIPTION,
-            },
-          }
-        )
+        const existingId = await this.findExistingLikedPlaylist(userId, integration.providerUserId)
+        const playlistId = existingId ?? (await this.createLikedPlaylist(userId, integration))
 
         integration.useTransaction(trx)
-        integration.spotifyLikedPlaylistId = created.id
+        integration.spotifyLikedPlaylistId = playlistId
         await integration.save()
-        return created.id
+        return playlistId
       } catch (error) {
         if (error instanceof SpotifyApiError && error.status === 403) {
           throw new SpotifyScopeUpgradeRequiredError()
@@ -94,6 +89,50 @@ export class SpotifyPlaylistService {
         throw error
       }
     })
+  }
+
+  private async createLikedPlaylist(userId: string, integration: UserIntegration): Promise<string> {
+    const created = await this.spotifyService.spotifyApiRequest<{ id: string }>(
+      userId,
+      `/users/${integration.providerUserId}/playlists`,
+      {
+        method: 'POST',
+        body: {
+          name: SPOTIFY_LIKED_PLAYLIST_NAME,
+          public: false,
+          description: SPOTIFY_LIKED_PLAYLIST_DESCRIPTION,
+        },
+      }
+    )
+    return created.id
+  }
+
+  private async findExistingLikedPlaylist(
+    userId: string,
+    providerUserId: string
+  ): Promise<string | null> {
+    let path = '/me/playlists'
+    let query: Record<string, string> | undefined = { limit: '50' }
+
+    while (true) {
+      const data: {
+        items: { id: string; name: string; owner: { id: string } }[]
+        next: string | null
+      } = await this.spotifyService.spotifyApiRequest(userId, path, {
+        method: 'GET',
+        query,
+      })
+
+      const match = data.items.find(
+        (p) => p.name === SPOTIFY_LIKED_PLAYLIST_NAME && p.owner.id === providerUserId
+      )
+      if (match) return match.id
+      if (!data.next) return null
+
+      const nextUrl = new URL(data.next)
+      path = nextUrl.pathname.replace(/^\/v1/, '')
+      query = Object.fromEntries(nextUrl.searchParams.entries())
+    }
   }
 
   async addTrack(userId: string, deezerTrackId: string): Promise<SpotifyAddTrackResult> {
@@ -241,9 +280,10 @@ export class SpotifyPlaylistService {
     }
   }
 
-  private hasPlaylistScope(integration: UserIntegration): boolean {
+  private hasPlaylistScopes(integration: UserIntegration): boolean {
     if (!integration.scopes) return false
-    return integration.scopes.split(/\s+/).includes(SPOTIFY_PLAYLIST_SCOPE)
+    const granted = new Set(integration.scopes.split(/\s+/))
+    return SPOTIFY_PLAYLIST_REQUIRED_SCOPES.every((scope) => granted.has(scope))
   }
 }
 

--- a/backend/config/ally.ts
+++ b/backend/config/ally.ts
@@ -11,6 +11,7 @@ const allyConfig = defineConfig({
       'user-top-read',
       'user-read-recently-played',
       'playlist-modify-private',
+      'playlist-read-private',
     ],
   }),
   google: services.google({

--- a/backend/docs/spotify-guidelines.md
+++ b/backend/docs/spotify-guidelines.md
@@ -30,6 +30,8 @@ Scopes actuellement utilisés (voir `config/ally.ts`) :
 - `user-read-email`
 - `user-top-read`
 - `user-read-recently-played`
+- `playlist-modify-private` — création/édition de la playlist `Rythmix Likes`
+- `playlist-read-private` — recherche d'une playlist `Rythmix Likes` existante avant d'en recréer une (évite les doublons après un relink ou un reset DB)
 
 Doc : https://developer.spotify.com/documentation/web-api/concepts/scopes
 

--- a/backend/tests/unit/spotify_playlist_service.spec.ts
+++ b/backend/tests/unit/spotify_playlist_service.spec.ts
@@ -19,7 +19,7 @@ async function createUser(tag: string) {
 async function linkSpotify(
   service: SpotifyService,
   userId: string,
-  scopes: string = 'user-read-email playlist-modify-private'
+  scopes: string = 'user-read-email playlist-modify-private playlist-read-private'
 ) {
   await service.upsertIntegration(userId, {
     providerUserId: `sp_${userId.slice(0, 6)}`,
@@ -101,9 +101,26 @@ test.group('SpotifyPlaylistService - getOrCreateLikedPlaylist', (group) => {
     }, /SPOTIFY_SCOPE_UPGRADE_REQUIRED/)
   })
 
-  test('creates the playlist via POST and stores the returned id', async ({ assert }) => {
+  test('throws scope upgrade required when scopes lack playlist-read-private', async ({
+    assert,
+  }) => {
+    const user = await createUser('no_read_scope')
+    const { service, spotify } = buildPlaylistService(async () => ({}))
+    await linkSpotify(spotify, user.id, 'user-read-email playlist-modify-private')
+
+    await assert.rejects(async () => {
+      await service.getOrCreateLikedPlaylist(user.id)
+    }, /SPOTIFY_SCOPE_UPGRADE_REQUIRED/)
+  })
+
+  test('creates the playlist via POST when no existing Rythmix Likes is found', async ({
+    assert,
+  }) => {
     const user = await createUser('create_ok')
     const { service, spotify, calls } = buildPlaylistService(async (record) => {
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return { items: [], next: null }
+      }
       if (record.path.includes('/playlists') && record.options.method === 'POST') {
         return { id: 'pl_new' }
       }
@@ -113,11 +130,98 @@ test.group('SpotifyPlaylistService - getOrCreateLikedPlaylist', (group) => {
 
     const id = await service.getOrCreateLikedPlaylist(user.id)
     assert.equal(id, 'pl_new')
-    assert.equal(calls.length, 1)
-    assert.equal(calls[0].options.method, 'POST')
+    assert.equal(calls.length, 2)
+    assert.equal(calls[0].path, '/me/playlists')
+    assert.equal(calls[1].options.method, 'POST')
 
     const integration = await spotify.findByUserId(user.id)
     assert.equal(integration!.spotifyLikedPlaylistId, 'pl_new')
+  })
+
+  test('reuses existing Rythmix Likes playlist instead of creating a duplicate', async ({
+    assert,
+  }) => {
+    const user = await createUser('reuse_existing')
+    const providerUserId = `sp_${user.id.slice(0, 6)}`
+    const { service, spotify, calls } = buildPlaylistService(async (record) => {
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return {
+          items: [
+            { id: 'pl_other', name: 'Other', owner: { id: providerUserId } },
+            { id: 'pl_reused', name: 'Rythmix Likes', owner: { id: providerUserId } },
+          ],
+          next: null,
+        }
+      }
+      return {}
+    })
+    await linkSpotify(spotify, user.id)
+
+    const id = await service.getOrCreateLikedPlaylist(user.id)
+    assert.equal(id, 'pl_reused')
+    assert.isUndefined(
+      calls.find((c) => c.options.method === 'POST'),
+      'must not POST a new playlist when one already exists on Spotify'
+    )
+
+    const integration = await spotify.findByUserId(user.id)
+    assert.equal(integration!.spotifyLikedPlaylistId, 'pl_reused')
+  })
+
+  test('ignores Rythmix Likes playlists owned by another Spotify user', async ({ assert }) => {
+    const user = await createUser('ignore_other_owner')
+    const providerUserId = `sp_${user.id.slice(0, 6)}`
+    const { service, spotify, calls } = buildPlaylistService(async (record) => {
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return {
+          items: [{ id: 'pl_collab', name: 'Rythmix Likes', owner: { id: 'someone_else' } }],
+          next: null,
+        }
+      }
+      if (record.path.includes('/playlists') && record.options.method === 'POST') {
+        return { id: 'pl_fresh' }
+      }
+      return {}
+    })
+    await linkSpotify(spotify, user.id)
+
+    const id = await service.getOrCreateLikedPlaylist(user.id)
+    assert.equal(id, 'pl_fresh')
+    assert.exists(calls.find((c) => c.options.method === 'POST'))
+    assert.equal(providerUserId, providerUserId)
+  })
+
+  test('paginates /me/playlists when the existing playlist is on a later page', async ({
+    assert,
+  }) => {
+    const user = await createUser('paginate_lookup')
+    const providerUserId = `sp_${user.id.slice(0, 6)}`
+    let page = 0
+    const { service, spotify, calls } = buildPlaylistService(async (record) => {
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        page++
+        if (page === 1) {
+          return {
+            items: [{ id: 'pl_a', name: 'Other', owner: { id: providerUserId } }],
+            next: 'https://api.spotify.com/v1/me/playlists?offset=50&limit=50',
+          }
+        }
+        return {
+          items: [{ id: 'pl_target', name: 'Rythmix Likes', owner: { id: providerUserId } }],
+          next: null,
+        }
+      }
+      return {}
+    })
+    await linkSpotify(spotify, user.id)
+
+    const id = await service.getOrCreateLikedPlaylist(user.id)
+    assert.equal(id, 'pl_target')
+    assert.equal(page, 2)
+    assert.isUndefined(calls.find((c) => c.options.method === 'POST'))
+    const secondPage = calls[1]
+    assert.equal(secondPage.path, '/me/playlists')
+    assert.equal(secondPage.options.query!.offset, '50')
   })
 
   test('throws SpotifyNotConnectedError when integration missing', async ({ assert }) => {
@@ -142,7 +246,10 @@ test.group('SpotifyPlaylistService - getOrCreateLikedPlaylist', (group) => {
 
   test('translates 403 from playlist creation into scope upgrade required', async ({ assert }) => {
     const user = await createUser('forbidden')
-    const { service, spotify } = buildPlaylistService(async () => {
+    const { service, spotify } = buildPlaylistService(async (record) => {
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return { items: [], next: null }
+      }
       throw new SpotifyApiError(403, '/users/x/playlists')
     })
     await linkSpotify(spotify, user.id)
@@ -150,6 +257,21 @@ test.group('SpotifyPlaylistService - getOrCreateLikedPlaylist', (group) => {
     await assert.rejects(async () => {
       await service.getOrCreateLikedPlaylist(user.id)
     }, /SPOTIFY_SCOPE_UPGRADE_REQUIRED/)
+  })
+
+  test('propagates non-403 SpotifyApiError from playlist creation', async ({ assert }) => {
+    const user = await createUser('create_500')
+    const { service, spotify } = buildPlaylistService(async (record) => {
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return { items: [], next: null }
+      }
+      throw new SpotifyApiError(500, '/users/x/playlists', 'boom')
+    })
+    await linkSpotify(spotify, user.id)
+
+    await assert.rejects(async () => {
+      await service.getOrCreateLikedPlaylist(user.id)
+    }, /Spotify API error 500/)
   })
 })
 
@@ -162,6 +284,9 @@ test.group('SpotifyPlaylistService - addTrack', (group) => {
     const { service, spotify, calls } = buildPlaylistService(async (record) => {
       if (record.path === '/search') {
         return { tracks: { items: [{ uri: 'spotify:track:abc123' }] } }
+      }
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return { items: [], next: null }
       }
       if (record.path.endsWith('/playlists') && record.options.method === 'POST') {
         return { id: 'pl_test' }
@@ -196,6 +321,9 @@ test.group('SpotifyPlaylistService - addTrack', (group) => {
           return { tracks: { items: [] } }
         }
         return { tracks: { items: [{ uri: 'spotify:track:fallback' }] } }
+      }
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return { items: [], next: null }
       }
       if (record.path.endsWith('/playlists') && record.options.method === 'POST') {
         return { id: 'pl_fb' }
@@ -238,6 +366,9 @@ test.group('SpotifyPlaylistService - addTrack', (group) => {
       if (record.path === '/search') {
         return { tracks: { items: [{ uri: 'spotify:track:dup' }] } }
       }
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return { items: [], next: null }
+      }
       if (record.path.endsWith('/playlists') && record.options.method === 'POST') {
         return { id: 'pl_idem' }
       }
@@ -273,6 +404,9 @@ test.group('SpotifyPlaylistService - addTrack', (group) => {
       if (record.path === '/search') {
         return { tracks: { items: [{ uri: 'spotify:track:dup' }] } }
       }
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return { items: [], next: null }
+      }
       if (record.path.endsWith('/playlists') && record.options.method === 'POST') {
         return { id: 'pl_paged' }
       }
@@ -298,18 +432,6 @@ test.group('SpotifyPlaylistService - addTrack', (group) => {
       (c) => c.path === '/playlists/pl_paged/items' && c.options.method === 'POST'
     )
     assert.isUndefined(addCall)
-  })
-
-  test('rethrows non-403 errors from playlist creation', async ({ assert }) => {
-    const user = await createUser('create_error')
-    const { service, spotify } = buildPlaylistService(async () => {
-      throw new SpotifyApiError(500, '/users/x/playlists')
-    })
-    await linkSpotify(spotify, user.id)
-
-    await assert.rejects(async () => {
-      await service.getOrCreateLikedPlaylist(user.id)
-    }, /500/)
   })
 
   test('returns null when interaction has neither isrc nor title+artist', async ({ assert }) => {
@@ -418,6 +540,9 @@ test.group('SpotifyPlaylistService - syncAllLikes', (group) => {
         if (q.includes('USXX22222222')) return { tracks: { items: [] } }
         return { tracks: { items: [{ uri: 'spotify:track:dup' }] } }
       }
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return { items: [], next: null }
+      }
       if (record.path.endsWith('/playlists') && record.options.method === 'POST') {
         return { id: 'pl_sync' }
       }
@@ -464,6 +589,9 @@ test.group('SpotifyPlaylistService - syncAllLikes', (group) => {
     const { service, spotify } = buildPlaylistService(async (record) => {
       if (record.path === '/search') {
         return { tracks: { items: [{ uri: 'spotify:track:1' }] } }
+      }
+      if (record.path === '/me/playlists' && record.options.method === 'GET') {
+        return { items: [], next: null }
       }
       if (record.path.endsWith('/playlists') && record.options.method === 'POST') {
         return { id: 'pl_skip' }


### PR DESCRIPTION
## Summary

Suite de la PR #187. Sur les comptes test, on a constaté que chaque cycle d'unlink/relink Spotify créait une **nouvelle** playlist `Rythmix Likes` côté Spotify au lieu de réutiliser celle existante.

### Cause racine

`getOrCreateLikedPlaylist` (`spotify_playlist_service.ts`) ne s'appuie que sur la column `spotifyLikedPlaylistId` en DB. Or :
- `unlinkSpotify` supprime la row `UserIntegration` → la column est perdue.
- Au prochain OAuth, `upsertIntegration` recrée une row avec `spotifyLikedPlaylistId = null`.
- Spotify autorise les playlists du même nom : `POST /users/{id}/playlists` retombe sans erreur en créant un doublon.

### Fix

1. Ajout du scope OAuth `playlist-read-private` (`config/ally.ts`) pour pouvoir lister les playlists privées de l'user.
2. Dans `getOrCreateLikedPlaylist`, avant le POST de création : pagination de `/me/playlists` à la recherche d'une playlist `Rythmix Likes` dont l'`owner.id` correspond au `providerUserId`. Si trouvée → on stocke l'ID en DB et on la réutilise. Sinon → création comme avant.
3. La vérification de scope exige désormais les **deux** scopes (`playlist-modify-private` + `playlist-read-private`). Les comptes existants devront re-OAuth une fois (le mobile gère déjà `SPOTIFY_SCOPE_UPGRADE_REQUIRED`).
4. Doc `spotify-guidelines.md` mise à jour avec les nouveaux scopes.

### Tests ajoutés

- Reuse d'une playlist existante au lieu de la recréer
- Filtrage par `owner.id` (ne réutilise pas une playlist nommée "Rythmix Likes" appartenant à un autre user — playlist collaborative par exemple)
- Pagination de `/me/playlists` quand la playlist est sur une page suivante
- Scope upgrade requis si `playlist-read-private` manque

## Test plan

- [x] `npm run check` (lint + typecheck + format) backend
- [x] `npm run test:coverage` backend — 596 tests passent, 100% coverage maintenue
- [x] En staging : re-OAuth Spotify (déclenche le scope upgrade), puis vérifier qu'aucune nouvelle playlist `Rythmix Likes` n'est créée — la playlist existante doit être retrouvée et réutilisée
- [x] Vérifier qu'un nouveau user (sans playlist) crée bien une seule playlist au premier like