### PR TITLE
MIX-312 feat: add recent activities endpoint and profile section

### DIFF
--- a/backend/app/controllers/me_activities_controller.ts
+++ b/backend/app/controllers/me_activities_controller.ts
@@ -1,0 +1,46 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { errors } from '@vinejs/vine'
+import { ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
+import { MeActivitiesService } from '#services/me_activities_service'
+import { listActivitiesValidator } from '#validators/me_activities_validator'
+
+const DEFAULT_LIMIT = 5
+
+@inject()
+export default class MeActivitiesController {
+  constructor(private readonly meActivitiesService: MeActivitiesService) {}
+
+  @ApiOperation({
+    summary: 'List my recent activities',
+    description:
+      'Returns the latest user events (completed game sessions + liked tracks) sorted by date desc.',
+  })
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({ status: 200, description: 'Activities returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 422, description: 'Invalid query parameters' })
+  async index({ auth, request, response }: HttpContext) {
+    try {
+      const user = auth.getUserOrFail()
+      const { limit } = await request.validateUsing(listActivitiesValidator, {
+        data: request.qs(),
+      })
+
+      const activities = await this.meActivitiesService.getRecentActivities(
+        user.id,
+        limit ?? DEFAULT_LIMIT
+      )
+
+      return response.ok({ activities })
+    } catch (error: unknown) {
+      if (error instanceof errors.E_VALIDATION_ERROR) {
+        return response.unprocessableEntity({
+          message: 'Validation failed',
+          errors: error.messages,
+        })
+      }
+      return response.internalServerError({ message: 'Error while fetching activities' })
+    }
+  }
+}

--- a/backend/app/services/me_activities_service.ts
+++ b/backend/app/services/me_activities_service.ts
@@ -1,0 +1,58 @@
+import GameSession from '#models/game_session'
+import UserTrackInteraction from '#models/user_track_interaction'
+import { GameSessionStatus } from '#enums/game_session_status'
+import { InteractionAction } from '#enums/interaction_action'
+
+export type ActivityEvent =
+  | {
+      type: 'game_session'
+      date: string
+      gameTitle: string
+      score: number
+      maxScore: number
+    }
+  | {
+      type: 'liked_track'
+      date: string
+      trackTitle: string | null
+      artist: string | null
+    }
+
+export class MeActivitiesService {
+  public async getRecentActivities(userId: string, limit: number): Promise<ActivityEvent[]> {
+    const [sessions, likes] = await Promise.all([
+      GameSession.query()
+        .whereRaw('players::jsonb @> ?::jsonb', [JSON.stringify([{ userId }])])
+        .where('status', GameSessionStatus.Completed)
+        .preload('game')
+        .orderBy('updated_at', 'desc')
+        .limit(limit),
+      UserTrackInteraction.query()
+        .where('userId', userId)
+        .where('action', InteractionAction.Liked)
+        .orderBy('updated_at', 'desc')
+        .limit(limit),
+    ])
+
+    const sessionEvents: ActivityEvent[] = sessions.map((session) => ({
+      type: 'game_session',
+      date: session.updatedAt.toISO()!,
+      gameTitle: session.game?.name ?? '',
+      score: Number(session.gameData?.score ?? 0),
+      maxScore: Number(session.gameData?.maxScore ?? 0),
+    }))
+
+    const likeEvents: ActivityEvent[] = likes.map((like) => ({
+      type: 'liked_track',
+      date: like.updatedAt.toISO()!,
+      trackTitle: like.title,
+      artist: like.artist,
+    }))
+
+    return [...sessionEvents, ...likeEvents]
+      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+      .slice(0, limit)
+  }
+}
+
+export default MeActivitiesService

--- a/backend/app/services/me_activities_service.ts
+++ b/backend/app/services/me_activities_service.ts
@@ -34,13 +34,16 @@ export class MeActivitiesService {
         .limit(limit),
     ])
 
-    const sessionEvents: ActivityEvent[] = sessions.map((session) => ({
-      type: 'game_session',
-      date: session.updatedAt.toISO()!,
-      gameTitle: session.game?.name ?? '',
-      score: Number(session.gameData?.score ?? 0),
-      maxScore: Number(session.gameData?.maxScore ?? 0),
-    }))
+    const sessionEvents: ActivityEvent[] = sessions.map((session) => {
+      const data = (session.gameData ?? {}) as Record<string, unknown>
+      return {
+        type: 'game_session',
+        date: session.updatedAt.toISO()!,
+        gameTitle: session.game.name,
+        score: Number(data.score ?? 0),
+        maxScore: Number(data.maxScore ?? 0),
+      }
+    })
 
     const likeEvents: ActivityEvent[] = likes.map((like) => ({
       type: 'liked_track',

--- a/backend/app/validators/me_activities_validator.ts
+++ b/backend/app/validators/me_activities_validator.ts
@@ -1,0 +1,7 @@
+import vine from '@vinejs/vine'
+
+export const listActivitiesValidator = vine.compile(
+  vine.object({
+    limit: vine.number().min(1).max(20).optional(),
+  })
+)

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8496,9 +8496,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -45,6 +45,9 @@
         "prettier": "^3.5.3",
         "ts-node-maintained": "^10.9.5",
         "typescript": "~5.8"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -16,6 +16,7 @@ const ProfileController = () => import('#controllers/profile_controller')
 const SpotifyAuthController = () => import('#controllers/spotify_auth_controller')
 const GoogleAuthController = () => import('#controllers/google_auth_controller')
 const MeIntegrationsController = () => import('#controllers/me_integrations_controller')
+const MeActivitiesController = () => import('#controllers/me_activities_controller')
 const OnboardingController = () => import('#controllers/onboarding_controller')
 const CuratedPlaylistsController = () => import('#controllers/curated_playlists_controller')
 
@@ -82,6 +83,8 @@ router
           OnboardingController,
           'spotifySuggestions',
         ])
+
+        router.get('/activities', [MeActivitiesController, 'index'])
 
         router.get('/swipemix/interactions', [TrackInteractionsController, 'index'])
         router.post('/swipemix/interactions', [TrackInteractionsController, 'upsert'])

--- a/backend/tests/functional/me_activities_controller.spec.ts
+++ b/backend/tests/functional/me_activities_controller.spec.ts
@@ -1,0 +1,93 @@
+import { test } from '@japa/runner'
+import Game from '#models/game'
+import GameSession from '#models/game_session'
+import UserTrackInteraction from '#models/user_track_interaction'
+import { GameSessionStatus } from '#enums/game_session_status'
+import { InteractionAction } from '#enums/interaction_action'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteGameSession } from '#tests/utils/game_session_helpers'
+import { deleteTrackInteractions } from '#tests/utils/track_interaction_helpers'
+
+test.group('MeActivitiesController - auth guard', (group) => {
+  deleteGameSession(group)
+  deleteTrackInteractions(group)
+
+  test('GET /api/me/activities requires auth', async ({ client }) => {
+    const response = await client.get('/api/me/activities')
+    response.assertStatus(401)
+  })
+})
+
+test.group('MeActivitiesController - index', (group) => {
+  deleteGameSession(group)
+  deleteTrackInteractions(group)
+
+  test('returns aggregated activities for the authenticated user', async ({ client, assert }) => {
+    const { user, token } = await createAuthenticatedUser('act_idx')
+    const game = await Game.create({
+      name: 'Blurchette Test',
+      description: 'd',
+      isEnabled: true,
+      isMultiplayer: false,
+    })
+
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'completed', score: 8, rank: 1 }],
+      gameData: { score: 8, maxScore: 10 },
+    })
+    await UserTrackInteraction.create({
+      userId: user.id,
+      deezerTrackId: '42',
+      action: InteractionAction.Liked,
+      title: 'Papaoutai',
+      artist: 'Stromae',
+    })
+
+    const response = await client.get('/api/me/activities').bearerToken(token)
+    response.assertStatus(200)
+
+    const activities = response.body().activities
+    assert.equal(activities.length, 2)
+    const session = activities.find((a: any) => a.type === 'game_session')
+    const like = activities.find((a: any) => a.type === 'liked_track')
+    assert.exists(session)
+    assert.exists(like)
+    assert.equal(session.gameTitle, 'Blurchette Test')
+    assert.equal(session.score, 8)
+    assert.equal(session.maxScore, 10)
+    assert.equal(like.trackTitle, 'Papaoutai')
+    assert.equal(like.artist, 'Stromae')
+  })
+
+  test('respects the limit query parameter', async ({ client, assert }) => {
+    const { user, token } = await createAuthenticatedUser('act_idx_lim')
+    for (let i = 0; i < 6; i++) {
+      await UserTrackInteraction.create({
+        userId: user.id,
+        deezerTrackId: `t${i}`,
+        action: InteractionAction.Liked,
+        title: `Track ${i}`,
+        artist: 'A',
+      })
+    }
+
+    const response = await client.get('/api/me/activities?limit=3').bearerToken(token)
+    response.assertStatus(200)
+    assert.equal(response.body().activities.length, 3)
+  })
+
+  test('returns 422 when limit is out of range', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('act_idx_bad')
+    const response = await client.get('/api/me/activities?limit=99').bearerToken(token)
+    response.assertStatus(422)
+  })
+
+  test('returns an empty array when the user has no events', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('act_idx_empty')
+    const response = await client.get('/api/me/activities').bearerToken(token)
+    response.assertStatus(200)
+    assert.deepEqual(response.body().activities, [])
+  })
+})

--- a/backend/tests/unit/me_activities_controller.spec.ts
+++ b/backend/tests/unit/me_activities_controller.spec.ts
@@ -1,0 +1,106 @@
+import { test } from '@japa/runner'
+import MeActivitiesController from '#controllers/me_activities_controller'
+import { HttpContext } from '@adonisjs/core/http'
+import { makeResponse } from '#tests/utils/http_helpers'
+import { errors } from '@vinejs/vine'
+
+function makeCtx(validated: { limit?: number } = {}, validationError = false) {
+  const response = makeResponse()
+  const auth = { getUserOrFail: () => ({ id: 'user-1' }) } as any
+  const request = {
+    qs: () => ({}),
+    validateUsing: async () => {
+      if (validationError) {
+        throw new errors.E_VALIDATION_ERROR([{ field: 'limit', message: 'out of range' }])
+      }
+      return validated
+    },
+  } as any
+  return {
+    response,
+    ctx: { auth, request, response } as unknown as HttpContext,
+  }
+}
+
+test.group('MeActivitiesController - Unit', () => {
+  test('returns 200 with the activities on success', async ({ assert }) => {
+    const activities = [
+      {
+        type: 'liked_track' as const,
+        date: '2026-04-25T15:10:00Z',
+        trackTitle: 'Papaoutai',
+        artist: 'Stromae',
+      },
+    ]
+    const service = {
+      getRecentActivities: async () => activities,
+    } as any
+    const controller = new MeActivitiesController(service)
+    const { response, ctx } = makeCtx()
+
+    await controller.index(ctx)
+
+    assert.equal(response.statusCode, 200)
+    assert.deepEqual(response.body, { activities })
+  })
+
+  test('falls back to the default limit when the query param is omitted', async ({ assert }) => {
+    let receivedLimit: number | undefined
+    const service = {
+      getRecentActivities: async (_userId: string, limit: number) => {
+        receivedLimit = limit
+        return []
+      },
+    } as any
+    const controller = new MeActivitiesController(service)
+    const { ctx } = makeCtx()
+
+    await controller.index(ctx)
+
+    assert.equal(receivedLimit, 5)
+  })
+
+  test('forwards the limit query param to the service', async ({ assert }) => {
+    let receivedLimit: number | undefined
+    const service = {
+      getRecentActivities: async (_userId: string, limit: number) => {
+        receivedLimit = limit
+        return []
+      },
+    } as any
+    const controller = new MeActivitiesController(service)
+    const { ctx } = makeCtx({ limit: 10 })
+
+    await controller.index(ctx)
+
+    assert.equal(receivedLimit, 10)
+  })
+
+  test('returns 422 when validation fails', async ({ assert }) => {
+    const service = {
+      getRecentActivities: async () => [],
+    } as any
+    const controller = new MeActivitiesController(service)
+    const { response, ctx } = makeCtx({}, true)
+
+    await controller.index(ctx)
+
+    assert.equal(response.statusCode, 422)
+    assert.equal(response.body.message, 'Validation failed')
+  })
+
+  test('returns 500 when the service throws an unexpected error', async ({ assert }) => {
+    const service = {
+      getRecentActivities: async () => {
+        throw new Error('boom')
+      },
+    } as any
+    const controller = new MeActivitiesController(service)
+    const { response, ctx } = makeCtx()
+
+    await controller.index(ctx)
+
+    assert.equal(response.statusCode, 500)
+    assert.equal(response.body.message, 'Error while fetching activities')
+  })
+})

--- a/backend/tests/unit/me_activities_service.spec.ts
+++ b/backend/tests/unit/me_activities_service.spec.ts
@@ -124,6 +124,45 @@ test.group('MeActivitiesService', (group) => {
     assert.equal(limited.length, 2)
   })
 
+  test('falls back to 0 for score and maxScore when gameData is empty', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('act_empty_data')
+    const game = await createTestGame('emptydata')
+
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'completed', score: 0, rank: 1 }],
+      gameData: {},
+    })
+
+    const result = await service.getRecentActivities(user.id, 5)
+    assert.equal(result.length, 1)
+    if (result[0].type === 'game_session') {
+      assert.equal(result[0].score, 0)
+      assert.equal(result[0].maxScore, 0)
+      assert.equal(result[0].gameTitle, game.name)
+    }
+  })
+
+  test('falls back to 0 when gameData itself is null', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('act_null_data')
+    const game = await createTestGame('nulldata')
+
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'completed', score: 0, rank: 1 }],
+      gameData: null,
+    })
+
+    const result = await service.getRecentActivities(user.id, 5)
+    assert.equal(result.length, 1)
+    if (result[0].type === 'game_session') {
+      assert.equal(result[0].score, 0)
+      assert.equal(result[0].maxScore, 0)
+    }
+  })
+
   test('does not include events from other users', async ({ assert }) => {
     const { user: userA } = await createAuthenticatedUser('act_userA')
     const { user: userB } = await createAuthenticatedUser('act_userB')

--- a/backend/tests/unit/me_activities_service.spec.ts
+++ b/backend/tests/unit/me_activities_service.spec.ts
@@ -1,0 +1,149 @@
+import { test } from '@japa/runner'
+import Game from '#models/game'
+import GameSession from '#models/game_session'
+import UserTrackInteraction from '#models/user_track_interaction'
+import { MeActivitiesService } from '#services/me_activities_service'
+import { GameSessionStatus } from '#enums/game_session_status'
+import { InteractionAction } from '#enums/interaction_action'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteGameSession } from '#tests/utils/game_session_helpers'
+import { deleteTrackInteractions } from '#tests/utils/track_interaction_helpers'
+
+async function createTestGame(tag: string) {
+  return Game.create({
+    name: `Game ${tag} ${Date.now()}`,
+    description: `Desc ${tag}`,
+    isEnabled: true,
+    isMultiplayer: false,
+  })
+}
+
+test.group('MeActivitiesService', (group) => {
+  let service: MeActivitiesService
+
+  deleteGameSession(group)
+  deleteTrackInteractions(group)
+
+  group.each.setup(() => {
+    service = new MeActivitiesService()
+  })
+
+  test('returns empty array when user has no events', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('act_empty')
+    const result = await service.getRecentActivities(user.id, 5)
+    assert.deepEqual(result, [])
+  })
+
+  test('returns only completed game sessions for the user', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('act_sessions')
+    const game = await createTestGame('blurchette')
+
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'completed', score: 8, rank: 1 }],
+      gameData: { score: 8, maxScore: 10 },
+    })
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Active,
+      players: [{ userId: user.id, status: 'active', score: 0, rank: 1 }],
+      gameData: { score: 0, maxScore: 10 },
+    })
+
+    const result = await service.getRecentActivities(user.id, 5)
+    assert.equal(result.length, 1)
+    assert.equal(result[0].type, 'game_session')
+    if (result[0].type === 'game_session') {
+      assert.equal(result[0].gameTitle, game.name)
+      assert.equal(result[0].score, 8)
+      assert.equal(result[0].maxScore, 10)
+    }
+  })
+
+  test('returns only liked tracks (not disliked) for the user', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('act_likes')
+
+    await UserTrackInteraction.create({
+      userId: user.id,
+      deezerTrackId: '1',
+      action: InteractionAction.Liked,
+      title: 'Papaoutai',
+      artist: 'Stromae',
+    })
+    await UserTrackInteraction.create({
+      userId: user.id,
+      deezerTrackId: '2',
+      action: InteractionAction.Disliked,
+      title: 'Bad Song',
+      artist: 'X',
+    })
+
+    const result = await service.getRecentActivities(user.id, 5)
+    assert.equal(result.length, 1)
+    assert.equal(result[0].type, 'liked_track')
+    if (result[0].type === 'liked_track') {
+      assert.equal(result[0].trackTitle, 'Papaoutai')
+      assert.equal(result[0].artist, 'Stromae')
+    }
+  })
+
+  test('merges sessions and likes, sorted by date desc and respects limit', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('act_mix')
+    const game = await createTestGame('mix')
+
+    await UserTrackInteraction.create({
+      userId: user.id,
+      deezerTrackId: '10',
+      action: InteractionAction.Liked,
+      title: 'First',
+      artist: 'A',
+    })
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'completed', score: 5, rank: 1 }],
+      gameData: { score: 5, maxScore: 10 },
+    })
+    await UserTrackInteraction.create({
+      userId: user.id,
+      deezerTrackId: '11',
+      action: InteractionAction.Liked,
+      title: 'Last',
+      artist: 'B',
+    })
+
+    const all = await service.getRecentActivities(user.id, 5)
+    assert.equal(all.length, 3)
+    const dates = all.map((e) => new Date(e.date).getTime())
+    for (let i = 1; i < dates.length; i++) {
+      assert.isAtMost(dates[i], dates[i - 1])
+    }
+
+    const limited = await service.getRecentActivities(user.id, 2)
+    assert.equal(limited.length, 2)
+  })
+
+  test('does not include events from other users', async ({ assert }) => {
+    const { user: userA } = await createAuthenticatedUser('act_userA')
+    const { user: userB } = await createAuthenticatedUser('act_userB')
+    const game = await createTestGame('isolation')
+
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: userB.id, status: 'completed', score: 9, rank: 1 }],
+      gameData: { score: 9, maxScore: 10 },
+    })
+    await UserTrackInteraction.create({
+      userId: userB.id,
+      deezerTrackId: 'x',
+      action: InteractionAction.Liked,
+      title: 'Foreign',
+      artist: 'Foreign A',
+    })
+
+    const result = await service.getRecentActivities(userA.id, 5)
+    assert.deepEqual(result, [])
+  })
+})

--- a/front-mobile/app/(tabs)/profile/index.tsx
+++ b/front-mobile/app/(tabs)/profile/index.tsx
@@ -325,6 +325,7 @@ const styles = StyleSheet.create({
   },
   badgeNameLocked: {
     color: Colors.dark.icon,
+  },
   errorContainer: {
     marginTop: 12,
     alignItems: "center",

--- a/front-mobile/app/(tabs)/profile/index.tsx
+++ b/front-mobile/app/(tabs)/profile/index.tsx
@@ -36,7 +36,6 @@ const MOCK_BADGES = [
 // TODO: à modifier plus tard - niveau et titre à récupérer depuis l'API
 const MOCK_LEVEL = { level: 7, title: "Mélomane" };
 
-
 function getMemberSince(createdAt?: string): string {
   if (!createdAt) return "membre récemment";
   const created = new Date(createdAt);

--- a/front-mobile/app/(tabs)/profile/index.tsx
+++ b/front-mobile/app/(tabs)/profile/index.tsx
@@ -6,6 +6,7 @@ import { router } from "expo-router";
 import { Colors } from "@/constants/Colors";
 import { useAuthStore } from "@/stores/authStore";
 import OnboardingBanner from "@/components/OnboardingBanner";
+import { ProfileRecentActivities } from "@/components/profile/ProfileRecentActivities";
 import { useOnboardingStatus } from "@/hooks/useOnboardingStatus";
 
 // TODO: à modifier plus tard - remplacer par des données récupérées depuis l'APIii
@@ -26,34 +27,6 @@ const MOCK_BADGES = [
   { id: "7", name: "Vétéran", icon: "🏆", unlocked: false },
   { id: "8", name: "Légende", icon: "👑", unlocked: false },
   { id: "9", name: "Mélomane absolu", icon: "🎵", unlocked: false },
-];
-
-// TODO: à modifier plus tard - remplacer par des données récupérées depuis l'API
-const MOCK_RECENT_ACTIVITIES = [
-  {
-    id: "1",
-    name: "Partie Blurchette",
-    detail: "Score : 8/10",
-    relativeDate: "Il y a 2h",
-  },
-  {
-    id: "2",
-    name: "Titre mis en favori",
-    detail: "One More Time - Daft Punk",
-    relativeDate: "Il y a 5h",
-  },
-  {
-    id: "3",
-    name: "Partie Tracklist",
-    detail: "Score : 6/10",
-    relativeDate: "Hier",
-  },
-  {
-    id: "4",
-    name: "Titre mis en favori",
-    detail: "Papaoutai - Stromae",
-    relativeDate: "Il y a 2 jours",
-  },
 ];
 
 // TODO: à modifier plus tard - niveau et titre à récupérer depuis l'API
@@ -154,19 +127,7 @@ export default function ProfileScreen() {
         </View>
 
         {/* ── Activités récentes ── */}
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Activités récentes</Text>
-          {MOCK_RECENT_ACTIVITIES.map((activity) => (
-            <View key={activity.id} style={styles.activityItem}>
-              <View style={styles.activityDot} />
-              <View style={styles.activityContent}>
-                <Text style={styles.activityName}>{activity.name}</Text>
-                <Text style={styles.activityDetail}>{activity.detail}</Text>
-              </View>
-              <Text style={styles.activityDate}>{activity.relativeDate}</Text>
-            </View>
-          ))}
-        </View>
+        <ProfileRecentActivities />
 
         {/* ── Mes artistes favoris ── */}
         <View style={styles.section}>
@@ -363,41 +324,6 @@ const styles = StyleSheet.create({
   },
   badgeNameLocked: {
     color: Colors.dark.icon,
-  },
-
-  // Activities
-  activityItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: "#1A1A1A",
-    gap: 12,
-  },
-  activityDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: Colors.primary.CTA,
-    flexShrink: 0,
-  },
-  activityContent: {
-    flex: 1,
-  },
-  activityName: {
-    fontSize: 14,
-    color: Colors.dark.text,
-    fontWeight: "600",
-    marginBottom: 2,
-  },
-  activityDetail: {
-    fontSize: 12,
-    color: Colors.dark.icon,
-  },
-  activityDate: {
-    fontSize: 11,
-    color: Colors.game.textMuted,
-    flexShrink: 0,
   },
 
   // Favorite artists

--- a/front-mobile/components/profile/ProfileRecentActivities.tsx
+++ b/front-mobile/components/profile/ProfileRecentActivities.tsx
@@ -32,11 +32,11 @@ function formatRelativeDate(date: string): string {
   return diffYears === 1 ? "Il y a 1 an" : `Il y a ${diffYears} ans`;
 }
 
-function activityKey(activity: UserActivity, index: number): string {
+function activityBaseKey(activity: UserActivity): string {
   if (activity.type === "game_session") {
-    return `game_session-${activity.date}-${activity.gameTitle}-${activity.score}-${activity.maxScore}-${index}`;
+    return `game_session-${activity.date}-${activity.gameTitle}-${activity.score}-${activity.maxScore}`;
   }
-  return `liked_track-${activity.date}-${activity.trackTitle ?? "unknown"}-${activity.artist ?? "unknown"}-${index}`;
+  return `liked_track-${activity.date}-${activity.trackTitle ?? "unknown"}-${activity.artist ?? "unknown"}`;
 }
 
 function getActivityContent(activity: UserActivity): {
@@ -108,12 +108,19 @@ function renderBody(
       </Text>
     );
   }
-  return activities.map((activity, index) => (
-    <ActivityRow
-      key={activityKey(activity, index)}
-      activity={activity}
-    />
-  ));
+  const keyCounters = new Map<string, number>();
+  return activities.map((activity) => {
+    const baseKey = activityBaseKey(activity);
+    const counter = keyCounters.get(baseKey) ?? 0;
+    keyCounters.set(baseKey, counter + 1);
+
+    return (
+      <ActivityRow
+        key={counter === 0 ? baseKey : `${baseKey}-${counter}`}
+        activity={activity}
+      />
+    );
+  });
 }
 
 export function ProfileRecentActivities() {

--- a/front-mobile/components/profile/ProfileRecentActivities.tsx
+++ b/front-mobile/components/profile/ProfileRecentActivities.tsx
@@ -115,10 +115,7 @@ function renderBody(
     keyCounters.set(baseKey, duplicateCount + 1);
 
     return (
-      <ActivityRow
-        key={`${baseKey}-${duplicateCount}`}
-        activity={activity}
-      />
+      <ActivityRow key={`${baseKey}-${duplicateCount}`} activity={activity} />
     );
   });
 }

--- a/front-mobile/components/profile/ProfileRecentActivities.tsx
+++ b/front-mobile/components/profile/ProfileRecentActivities.tsx
@@ -116,7 +116,7 @@ function renderBody(
 
     return (
       <ActivityRow
-        key={duplicateCount > 0 ? `${baseKey}-${duplicateCount}` : baseKey}
+        key={`${baseKey}-${duplicateCount}`}
         activity={activity}
       />
     );

--- a/front-mobile/components/profile/ProfileRecentActivities.tsx
+++ b/front-mobile/components/profile/ProfileRecentActivities.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { Colors } from "@/constants/Colors";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useMyActivities } from "@/hooks/useMyActivities";
+import { UserActivity } from "@/types/userActivity";
+
+const ACTIVITY_LIMIT = 5;
+const SKELETON_COUNT = 3;
+
+function formatRelativeDate(date: string): string {
+  const target = new Date(date).getTime();
+  const now = Date.now();
+  const diffMs = Math.max(0, now - target);
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  if (diffMinutes < 1) return "À l'instant";
+  if (diffMinutes < 60) return `Il y a ${diffMinutes} min`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `Il y a ${diffHours}h`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays === 1) return "Hier";
+  if (diffDays < 7) return `Il y a ${diffDays} jours`;
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks < 4) return `Il y a ${diffWeeks} sem.`;
+  const diffMonths = Math.floor(diffDays / 30);
+  if (diffMonths < 12) return `Il y a ${diffMonths} mois`;
+  const diffYears = Math.floor(diffDays / 365);
+  return diffYears === 1 ? "Il y a 1 an" : `Il y a ${diffYears} ans`;
+}
+
+function getActivityContent(activity: UserActivity): {
+  name: string;
+  detail: string;
+} {
+  if (activity.type === "game_session") {
+    return {
+      name: `Partie ${activity.gameTitle}`,
+      detail: `Score : ${activity.score}/${activity.maxScore}`,
+    };
+  }
+  return {
+    name: "Titre mis en favori",
+    detail: [activity.trackTitle, activity.artist].filter(Boolean).join(" - "),
+  };
+}
+
+function ActivitySkeletons() {
+  return (
+    <>
+      {Array.from({ length: SKELETON_COUNT }).map((_, idx) => (
+        <View key={`skeleton-${idx}`} style={styles.activityItem}>
+          <View style={styles.activityDot} />
+          <View style={styles.activityContent}>
+            <Skeleton width="60%" height={14} style={styles.skeletonLine} />
+            <Skeleton width="40%" height={12} />
+          </View>
+        </View>
+      ))}
+    </>
+  );
+}
+
+function ActivityRow({ activity }: { activity: UserActivity }) {
+  const { name, detail } = getActivityContent(activity);
+  return (
+    <View style={styles.activityItem}>
+      <View style={styles.activityDot} />
+      <View style={styles.activityContent}>
+        <Text style={styles.activityName}>{name}</Text>
+        <Text style={styles.activityDetail}>{detail}</Text>
+      </View>
+      <Text style={styles.activityDate}>
+        {formatRelativeDate(activity.date)}
+      </Text>
+    </View>
+  );
+}
+
+function renderBody(
+  isLoading: boolean,
+  error: string | null,
+  activities: UserActivity[],
+) {
+  if (isLoading) return <ActivitySkeletons />;
+  if (error) {
+    return (
+      <Text style={styles.feedbackText}>
+        Impossible de charger tes activités, réessaie plus tard.
+      </Text>
+    );
+  }
+  if (activities.length === 0) {
+    return (
+      <Text style={styles.feedbackText}>
+        Tu n&apos;as pas encore d&apos;activité, lance une partie ou like un
+        titre pour commencer&nbsp;!
+      </Text>
+    );
+  }
+  return activities.map((activity) => (
+    <ActivityRow
+      key={`${activity.type}-${activity.date}`}
+      activity={activity}
+    />
+  ));
+}
+
+export function ProfileRecentActivities() {
+  const { activities, isLoading, error } = useMyActivities(ACTIVITY_LIMIT);
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>Activités récentes</Text>
+      {renderBody(isLoading, error, activities)}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: 28,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: Colors.dark.text,
+    marginBottom: 14,
+    borderLeftWidth: 3,
+    borderLeftColor: Colors.primary.CTA,
+    paddingLeft: 10,
+  },
+  activityItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: "#1A1A1A",
+    gap: 12,
+  },
+  activityDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: Colors.primary.CTA,
+    flexShrink: 0,
+  },
+  activityContent: {
+    flex: 1,
+  },
+  activityName: {
+    fontSize: 14,
+    color: Colors.dark.text,
+    fontWeight: "600",
+    marginBottom: 2,
+  },
+  activityDetail: {
+    fontSize: 12,
+    color: Colors.dark.icon,
+  },
+  activityDate: {
+    fontSize: 11,
+    color: Colors.game.textMuted,
+    flexShrink: 0,
+  },
+  feedbackText: {
+    fontSize: 13,
+    color: Colors.dark.icon,
+    fontStyle: "italic",
+    paddingVertical: 8,
+  },
+  skeletonLine: {
+    marginBottom: 4,
+  },
+});

--- a/front-mobile/components/profile/ProfileRecentActivities.tsx
+++ b/front-mobile/components/profile/ProfileRecentActivities.tsx
@@ -111,12 +111,12 @@ function renderBody(
   const keyCounters = new Map<string, number>();
   return activities.map((activity) => {
     const baseKey = activityBaseKey(activity);
-    const counter = keyCounters.get(baseKey) ?? 0;
-    keyCounters.set(baseKey, counter + 1);
+    const duplicateCount = keyCounters.get(baseKey) ?? 0;
+    keyCounters.set(baseKey, duplicateCount + 1);
 
     return (
       <ActivityRow
-        key={counter === 0 ? baseKey : `${baseKey}-${counter}`}
+        key={duplicateCount > 0 ? `${baseKey}-${duplicateCount}` : baseKey}
         activity={activity}
       />
     );

--- a/front-mobile/components/profile/ProfileRecentActivities.tsx
+++ b/front-mobile/components/profile/ProfileRecentActivities.tsx
@@ -20,12 +20,23 @@ function formatRelativeDate(date: string): string {
   const diffDays = Math.floor(diffHours / 24);
   if (diffDays === 1) return "Hier";
   if (diffDays < 7) return `Il y a ${diffDays} jours`;
-  const diffWeeks = Math.floor(diffDays / 7);
-  if (diffWeeks < 4) return `Il y a ${diffWeeks} sem.`;
-  const diffMonths = Math.floor(diffDays / 30);
-  if (diffMonths < 12) return `Il y a ${diffMonths} mois`;
+  if (diffDays < 30) {
+    const diffWeeks = Math.floor(diffDays / 7);
+    return `Il y a ${diffWeeks} sem.`;
+  }
+  if (diffDays < 365) {
+    const diffMonths = Math.floor(diffDays / 30);
+    return `Il y a ${diffMonths} mois`;
+  }
   const diffYears = Math.floor(diffDays / 365);
   return diffYears === 1 ? "Il y a 1 an" : `Il y a ${diffYears} ans`;
+}
+
+function activityKey(activity: UserActivity, index: number): string {
+  if (activity.type === "game_session") {
+    return `game_session-${activity.date}-${activity.gameTitle}-${activity.score}-${activity.maxScore}-${index}`;
+  }
+  return `liked_track-${activity.date}-${activity.trackTitle ?? "unknown"}-${activity.artist ?? "unknown"}-${index}`;
 }
 
 function getActivityContent(activity: UserActivity): {
@@ -97,9 +108,9 @@ function renderBody(
       </Text>
     );
   }
-  return activities.map((activity) => (
+  return activities.map((activity, index) => (
     <ActivityRow
-      key={`${activity.type}-${activity.date}`}
+      key={activityKey(activity, index)}
       activity={activity}
     />
   ));

--- a/front-mobile/components/profile/__tests__/ProfileRecentActivities.test.tsx
+++ b/front-mobile/components/profile/__tests__/ProfileRecentActivities.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, waitFor } from "@testing-library/react-native";
+import { ProfileRecentActivities } from "../ProfileRecentActivities";
+import { useMyActivities } from "@/hooks/useMyActivities";
+import { UserActivity } from "@/types/userActivity";
+
+jest.mock("@/hooks/useMyActivities", () => ({
+  useMyActivities: jest.fn(),
+}));
+
+const mockUseMyActivities = useMyActivities as jest.MockedFunction<
+  typeof useMyActivities
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ProfileRecentActivities", () => {
+  it("renders the empty state when there are no activities", async () => {
+    mockUseMyActivities.mockReturnValue({
+      activities: [],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+
+    const { getByText } = render(<ProfileRecentActivities />);
+    await waitFor(() =>
+      expect(getByText(/Tu n'as pas encore d'activité/i)).toBeTruthy(),
+    );
+  });
+
+  it("renders a game_session activity with score and game title", async () => {
+    const activities: UserActivity[] = [
+      {
+        type: "game_session",
+        date: new Date().toISOString(),
+        gameTitle: "Blurchette",
+        score: 8,
+        maxScore: 10,
+      },
+    ];
+    mockUseMyActivities.mockReturnValue({
+      activities,
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+
+    const { getByText } = render(<ProfileRecentActivities />);
+    expect(getByText("Partie Blurchette")).toBeTruthy();
+    expect(getByText("Score : 8/10")).toBeTruthy();
+  });
+
+  it("renders an error message when the hook reports an error", async () => {
+    mockUseMyActivities.mockReturnValue({
+      activities: [],
+      isLoading: false,
+      error: "network",
+      refresh: jest.fn(),
+    });
+
+    const { getByText } = render(<ProfileRecentActivities />);
+    expect(getByText(/Impossible de charger tes activités/i)).toBeTruthy();
+  });
+
+  it("renders a liked_track activity with track title and artist", async () => {
+    const activities: UserActivity[] = [
+      {
+        type: "liked_track",
+        date: new Date().toISOString(),
+        trackTitle: "Papaoutai",
+        artist: "Stromae",
+      },
+    ];
+    mockUseMyActivities.mockReturnValue({
+      activities,
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+
+    const { getByText } = render(<ProfileRecentActivities />);
+    expect(getByText("Titre mis en favori")).toBeTruthy();
+    expect(getByText("Papaoutai - Stromae")).toBeTruthy();
+  });
+});

--- a/front-mobile/components/profile/__tests__/ProfileRecentActivities.test.tsx
+++ b/front-mobile/components/profile/__tests__/ProfileRecentActivities.test.tsx
@@ -85,4 +85,72 @@ describe("ProfileRecentActivities", () => {
     expect(getByText("Titre mis en favori")).toBeTruthy();
     expect(getByText("Papaoutai - Stromae")).toBeTruthy();
   });
+
+  it("formats recent weeks/months without zero values", () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-05-07T12:00:00.000Z"));
+
+    const activities: UserActivity[] = [
+      {
+        type: "liked_track",
+        date: "2026-04-08T12:00:00.000Z",
+        trackTitle: "Track A",
+        artist: "Artist A",
+      },
+      {
+        type: "liked_track",
+        date: "2025-05-12T12:00:00.000Z",
+        trackTitle: "Track B",
+        artist: "Artist B",
+      },
+    ];
+    mockUseMyActivities.mockReturnValue({
+      activities,
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+
+    const { getByText, queryByText } = render(<ProfileRecentActivities />);
+    expect(getByText("Il y a 4 sem.")).toBeTruthy();
+    expect(getByText("Il y a 12 mois")).toBeTruthy();
+    expect(queryByText("Il y a 0 mois")).toBeNull();
+    expect(queryByText("Il y a 0 ans")).toBeNull();
+    jest.useRealTimers();
+  });
+
+  it("uses unique keys when activities share the same type and date", () => {
+    const consoleErrorSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const activities: UserActivity[] = [
+      {
+        type: "liked_track",
+        date: "2026-05-07T12:00:00.000Z",
+        trackTitle: "Track A",
+        artist: "Artist A",
+      },
+      {
+        type: "liked_track",
+        date: "2026-05-07T12:00:00.000Z",
+        trackTitle: "Track B",
+        artist: "Artist B",
+      },
+    ];
+    mockUseMyActivities.mockReturnValue({
+      activities,
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+
+    render(<ProfileRecentActivities />);
+    expect(
+      consoleErrorSpy.mock.calls.some((call) =>
+        String(call[0]).includes("Encountered two children with the same key"),
+      ),
+    ).toBe(false);
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/front-mobile/hooks/__tests__/useAppStateAuthCheck.test.ts
+++ b/front-mobile/hooks/__tests__/useAppStateAuthCheck.test.ts
@@ -1,6 +1,8 @@
 import { renderHook } from "@testing-library/react-native";
 import { AppState } from "react-native";
 
+import { useAppStateAuthCheck } from "../useAppStateAuthCheck";
+
 const mockCheckAuth = jest.fn();
 const mockGetState = jest.fn();
 
@@ -11,8 +13,6 @@ jest.mock("@/stores/authStore", () => {
     mockGetState();
   return { useAuthStore };
 });
-
-import { useAppStateAuthCheck } from "../useAppStateAuthCheck";
 
 describe("useAppStateAuthCheck", () => {
   let listener: ((state: string) => void) | null = null;

--- a/front-mobile/hooks/__tests__/useMyActivities.test.ts
+++ b/front-mobile/hooks/__tests__/useMyActivities.test.ts
@@ -1,0 +1,64 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+import { useMyActivities } from "../useMyActivities";
+import { getMyActivities } from "@/services/userActivitiesService";
+import { UserActivity } from "@/types/userActivity";
+
+jest.mock("@/services/userActivitiesService", () => ({
+  getMyActivities: jest.fn(),
+}));
+
+const mockGetMyActivities = getMyActivities as jest.MockedFunction<
+  typeof getMyActivities
+>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useMyActivities", () => {
+  it("fetches activities and exposes them", async () => {
+    const activities: UserActivity[] = [
+      {
+        type: "liked_track",
+        date: "2026-04-25T15:10:00Z",
+        trackTitle: "Papaoutai",
+        artist: "Stromae",
+      },
+    ];
+    mockGetMyActivities.mockResolvedValueOnce(activities);
+
+    const { result } = renderHook(() => useMyActivities(5));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetMyActivities).toHaveBeenCalledWith(5);
+    expect(result.current.activities).toEqual(activities);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("captures error message on failure", async () => {
+    mockGetMyActivities.mockRejectedValueOnce(new Error("network"));
+
+    const { result } = renderHook(() => useMyActivities());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("network");
+    expect(result.current.activities).toEqual([]);
+  });
+
+  it("uses a default limit of 5 when no argument is passed", async () => {
+    mockGetMyActivities.mockResolvedValueOnce([]);
+    const { result } = renderHook(() => useMyActivities());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetMyActivities).toHaveBeenCalledWith(5);
+  });
+
+  it("refresh re-triggers the fetch", async () => {
+    mockGetMyActivities.mockResolvedValue([]);
+    const { result } = renderHook(() => useMyActivities(3));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetMyActivities).toHaveBeenCalledTimes(1);
+
+    await result.current.refresh();
+    expect(mockGetMyActivities).toHaveBeenCalledTimes(2);
+  });
+});

--- a/front-mobile/hooks/__tests__/useMyActivities.test.ts
+++ b/front-mobile/hooks/__tests__/useMyActivities.test.ts
@@ -7,6 +7,16 @@ jest.mock("@/services/userActivitiesService", () => ({
   getMyActivities: jest.fn(),
 }));
 
+jest.mock("expo-router", () => ({
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const React = require("react");
+    React.useEffect(() => {
+      const cleanup = callback();
+      return typeof cleanup === "function" ? cleanup : undefined;
+    }, [callback]);
+  },
+}));
+
 const mockGetMyActivities = getMyActivities as jest.MockedFunction<
   typeof getMyActivities
 >;

--- a/front-mobile/hooks/useMyActivities.ts
+++ b/front-mobile/hooks/useMyActivities.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useFocusEffect } from "expo-router";
 import { getMyActivities } from "@/services/userActivitiesService";
 import { UserActivity } from "@/types/userActivity";
 
@@ -47,9 +48,11 @@ export function useMyActivities(limit: number = 5): UseMyActivitiesResult {
     }
   }, [limit]);
 
-  useEffect(() => {
-    void refresh();
-  }, [refresh]);
+  useFocusEffect(
+    useCallback(() => {
+      void refresh();
+    }, [refresh]),
+  );
 
   return { activities, isLoading, error, refresh };
 }

--- a/front-mobile/hooks/useMyActivities.ts
+++ b/front-mobile/hooks/useMyActivities.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getMyActivities } from "@/services/userActivitiesService";
+import { UserActivity } from "@/types/userActivity";
+
+export interface UseMyActivitiesResult {
+  activities: UserActivity[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useMyActivities(limit: number = 5): UseMyActivitiesResult {
+  const [activities, setActivities] = useState<UserActivity[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isMountedRef = useRef(true);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    if (isMountedRef.current) {
+      setIsLoading(true);
+      setError(null);
+    }
+
+    try {
+      const data = await getMyActivities(limit);
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setActivities(data);
+      }
+    } catch (err) {
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    } finally {
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setIsLoading(false);
+      }
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return { activities, isLoading, error, refresh };
+}

--- a/front-mobile/services/__tests__/achievementsService.test.ts
+++ b/front-mobile/services/__tests__/achievementsService.test.ts
@@ -2,8 +2,6 @@ import { getMyAchievements } from "../achievementsService";
 import { get } from "../api";
 import { UserAchievement } from "@/types/achievement";
 
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 jest.mock("../api", () => ({
   get: jest.fn(),
 }));

--- a/front-mobile/services/__tests__/authService.test.ts
+++ b/front-mobile/services/__tests__/authService.test.ts
@@ -1,5 +1,3 @@
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 import { refreshAccessToken, resendVerificationEmail } from "../authService";
 import { post } from "../api";
 

--- a/front-mobile/services/__tests__/curatedPlaylistService.test.ts
+++ b/front-mobile/services/__tests__/curatedPlaylistService.test.ts
@@ -6,8 +6,6 @@ import {
 } from "../curatedPlaylistService";
 import { get } from "../api";
 
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 jest.mock("../api", () => ({
   get: jest.fn(),
 }));

--- a/front-mobile/services/__tests__/curatedPlaylistService.test.ts
+++ b/front-mobile/services/__tests__/curatedPlaylistService.test.ts
@@ -1,5 +1,3 @@
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 import {
   getCuratedPlaylists,
   getCuratedPlaylistTracks,
@@ -7,6 +5,8 @@ import {
   CuratedPlaylistTrack,
 } from "../curatedPlaylistService";
 import { get } from "../api";
+
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
 
 jest.mock("../api", () => ({
   get: jest.fn(),

--- a/front-mobile/services/__tests__/onboardingService.test.ts
+++ b/front-mobile/services/__tests__/onboardingService.test.ts
@@ -1,5 +1,3 @@
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 import {
   getMyOnboardingArtists,
   getMyOnboardingStatus,
@@ -8,6 +6,8 @@ import {
   setMyOnboardingArtists,
 } from "../onboardingService";
 import { get, post } from "../api";
+
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
 
 jest.mock("../api", () => ({
   get: jest.fn(),

--- a/front-mobile/services/__tests__/onboardingService.test.ts
+++ b/front-mobile/services/__tests__/onboardingService.test.ts
@@ -7,8 +7,6 @@ import {
 } from "../onboardingService";
 import { get, post } from "../api";
 
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 jest.mock("../api", () => ({
   get: jest.fn(),
   post: jest.fn(),

--- a/front-mobile/services/__tests__/parkeurService.test.ts
+++ b/front-mobile/services/__tests__/parkeurService.test.ts
@@ -1,5 +1,3 @@
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 import { searchDeezerArtists, startParkeurSession } from "../parkeurService";
 import { post } from "../api";
 import { deezerAPI } from "../deezer-api";

--- a/front-mobile/services/__tests__/spotifyService.test.ts
+++ b/front-mobile/services/__tests__/spotifyService.test.ts
@@ -1,5 +1,3 @@
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 import {
   disconnectSpotify,
   getRecentlyPlayed,
@@ -10,6 +8,8 @@ import {
   syncSpotifyLikedPlaylist,
 } from "../spotifyService";
 import { del, get, post } from "../api";
+
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
 
 jest.mock("../api", () => ({
   get: jest.fn(),

--- a/front-mobile/services/__tests__/spotifyService.test.ts
+++ b/front-mobile/services/__tests__/spotifyService.test.ts
@@ -9,8 +9,6 @@ import {
 } from "../spotifyService";
 import { del, get, post } from "../api";
 
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 jest.mock("../api", () => ({
   get: jest.fn(),
   del: jest.fn(),

--- a/front-mobile/services/__tests__/swipemixFeedService.test.ts
+++ b/front-mobile/services/__tests__/swipemixFeedService.test.ts
@@ -1,5 +1,3 @@
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 import { getSwipemixFeed } from "../swipemixFeedService";
 import { get } from "../api";
 import { DeezerTrack } from "../deezer-api";

--- a/front-mobile/services/__tests__/trackInteractionsService.test.ts
+++ b/front-mobile/services/__tests__/trackInteractionsService.test.ts
@@ -1,11 +1,11 @@
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 import {
   deleteMyTrackInteraction,
   getMyTrackInteractions,
   upsertMyTrackInteraction,
 } from "../trackInteractionsService";
 import { del, get, post } from "../api";
+
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
 
 jest.mock("../api", () => ({
   get: jest.fn(),

--- a/front-mobile/services/__tests__/trackInteractionsService.test.ts
+++ b/front-mobile/services/__tests__/trackInteractionsService.test.ts
@@ -5,8 +5,6 @@ import {
 } from "../trackInteractionsService";
 import { del, get, post } from "../api";
 
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 jest.mock("../api", () => ({
   get: jest.fn(),
   del: jest.fn(),

--- a/front-mobile/services/__tests__/userActivitiesService.test.ts
+++ b/front-mobile/services/__tests__/userActivitiesService.test.ts
@@ -1,8 +1,8 @@
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 import { getMyActivities } from "../userActivitiesService";
 import { get } from "../api";
 import { UserActivity } from "@/types/userActivity";
+
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
 
 jest.mock("../api", () => ({
   get: jest.fn(),

--- a/front-mobile/services/__tests__/userActivitiesService.test.ts
+++ b/front-mobile/services/__tests__/userActivitiesService.test.ts
@@ -1,0 +1,51 @@
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
+
+import { getMyActivities } from "../userActivitiesService";
+import { get } from "../api";
+import { UserActivity } from "@/types/userActivity";
+
+jest.mock("../api", () => ({
+  get: jest.fn(),
+}));
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("userActivitiesService", () => {
+  it("getMyActivities GETs without query when limit is omitted", async () => {
+    mockGet.mockResolvedValueOnce({ activities: [] });
+    const result = await getMyActivities();
+    expect(mockGet).toHaveBeenCalledWith("/api/me/activities");
+    expect(result).toEqual([]);
+  });
+
+  it("getMyActivities forwards the limit query param", async () => {
+    mockGet.mockResolvedValueOnce({ activities: [] });
+    await getMyActivities(10);
+    expect(mockGet).toHaveBeenCalledWith("/api/me/activities?limit=10");
+  });
+
+  it("getMyActivities returns the activities array from the response", async () => {
+    const activities: UserActivity[] = [
+      {
+        type: "game_session",
+        date: "2026-04-25T18:42:00Z",
+        gameTitle: "Blurchette",
+        score: 8,
+        maxScore: 10,
+      },
+      {
+        type: "liked_track",
+        date: "2026-04-25T15:10:00Z",
+        trackTitle: "Papaoutai",
+        artist: "Stromae",
+      },
+    ];
+    mockGet.mockResolvedValueOnce({ activities });
+    const result = await getMyActivities(5);
+    expect(result).toEqual(activities);
+  });
+});

--- a/front-mobile/services/__tests__/userActivitiesService.test.ts
+++ b/front-mobile/services/__tests__/userActivitiesService.test.ts
@@ -2,8 +2,6 @@ import { getMyActivities } from "../userActivitiesService";
 import { get } from "../api";
 import { UserActivity } from "@/types/userActivity";
 
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 jest.mock("../api", () => ({
   get: jest.fn(),
 }));

--- a/front-mobile/services/__tests__/userStatsService.test.ts
+++ b/front-mobile/services/__tests__/userStatsService.test.ts
@@ -1,8 +1,6 @@
 import { userStatsService } from "../userStatsService";
 import { get } from "../api";
 
-process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
-
 jest.mock("../api", () => ({
   get: jest.fn(),
 }));

--- a/front-mobile/services/userActivitiesService.ts
+++ b/front-mobile/services/userActivitiesService.ts
@@ -1,0 +1,10 @@
+import { get } from "./api";
+import { GetMyActivitiesResponse, UserActivity } from "@/types/userActivity";
+
+export const getMyActivities = async (
+  limit?: number,
+): Promise<UserActivity[]> => {
+  const query = limit !== undefined ? `?limit=${limit}` : "";
+  const data = await get<GetMyActivitiesResponse>(`/api/me/activities${query}`);
+  return data.activities;
+};

--- a/front-mobile/types/userActivity.ts
+++ b/front-mobile/types/userActivity.ts
@@ -1,0 +1,18 @@
+export type UserActivity =
+  | {
+      type: "game_session";
+      date: string;
+      gameTitle: string;
+      score: number;
+      maxScore: number;
+    }
+  | {
+      type: "liked_track";
+      date: string;
+      trackTitle: string | null;
+      artist: string | null;
+    };
+
+export interface GetMyActivitiesResponse {
+  activities: UserActivity[];
+}


### PR DESCRIPTION
This pull request introduces a new backend API and frontend integration to display a user's recent activities (completed game sessions and liked tracks) on their profile. It includes the full backend implementation with validation, service logic, routing, and comprehensive tests, as well as the frontend component to fetch and render these activities, replacing previous mock data.

**Backend: User Activities API**

* Added `MeActivitiesController` with an authenticated `index` endpoint to return recent activities, supporting an optional `limit` query parameter and proper error handling.
* Implemented `MeActivitiesService` to aggregate and sort completed game sessions and liked tracks for a user, returning a unified, date-sorted activity feed.
* Added `listActivitiesValidator` to validate the optional `limit` parameter (min 1, max 20).
* Registered the new route `/api/me/activities` in the router. [[1]](diffhunk://#diff-e72f182eae9caec3ef631c012ab133853f783154427bd6ef9cff6ccd21364d80R19) [[2]](diffhunk://#diff-e72f182eae9caec3ef631c012ab133853f783154427bd6ef9cff6ccd21364d80R87-R88)
* Added thorough functional and unit tests for the controller and service, covering validation, data aggregation, and edge cases. [[1]](diffhunk://#diff-93ecb589f2245d9543e0417fffa1ac687797226d6852661c60e1dccf032a4cf2R1-R93) [[2]](diffhunk://#diff-ca67a1eb4fa756e35ecfbc901d3b673e59d165128f39bac4a332e2b10fc5d93aR1-R149)

**Frontend: Profile Activities Integration**

* Created the `ProfileRecentActivities` component to fetch and display recent activities from the backend, with loading, error, and empty states.
* Integrated the new component into the profile screen, removing previous mock data and related styles. [[1]](diffhunk://#diff-01d721e53974a2c6f6bfe9089ae7d7d182a805d7f74777913e190943e33c67c5R9) [[2]](diffhunk://#diff-01d721e53974a2c6f6bfe9089ae7d7d182a805d7f74777913e190943e33c67c5L31-L58) [[3]](diffhunk://#diff-01d721e53974a2c6f6bfe9089ae7d7d182a805d7f74777913e190943e33c67c5L157-R130) [[4]](diffhunk://#diff-01d721e53974a2c6f6bfe9089ae7d7d182a805d7f74777913e190943e33c67c5L368-L402)

These changes provide a robust, tested, and user-friendly way to display recent user activities on the profile page.