### PR TITLE
HOTFIX-auth-refresh-deadlock-splash fix: prevent splash hang from refresh token 401 deadlock

### DIFF
--- a/front-mobile/services/__tests__/authService.test.ts
+++ b/front-mobile/services/__tests__/authService.test.ts
@@ -45,8 +45,8 @@ describe("authService.resendVerificationEmail", () => {
 });
 
 describe("authService.refreshAccessToken", () => {
-  it("POSTs to /api/auth/refresh with _isRetry to short-circuit the 401 refresh loop", async () => {
-    // Regression guard: without _isRetry: true on the refresh call itself,
+  it("POSTs to /api/auth/refresh with skipRefresh to short-circuit the 401 refresh loop", async () => {
+    // Regression guard: without skipRefresh: true on the refresh call itself,
     // a 401 on /api/auth/refresh re-enters handleTokenRefresh and awaits the
     // same in-flight refreshPromise → deadlock → splash stuck on launch.
     mockPost.mockResolvedValueOnce({ accessToken: "new-token" });
@@ -56,7 +56,7 @@ describe("authService.refreshAccessToken", () => {
     expect(mockPost).toHaveBeenCalledWith(
       "/api/auth/refresh",
       { refreshToken: "refresh-token" },
-      { skipAuth: true, _isRetry: true },
+      { skipAuth: true, skipRefresh: true },
     );
   });
 });

--- a/front-mobile/services/__tests__/authService.test.ts
+++ b/front-mobile/services/__tests__/authService.test.ts
@@ -1,6 +1,6 @@
 process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
 
-import { resendVerificationEmail } from "../authService";
+import { refreshAccessToken, resendVerificationEmail } from "../authService";
 import { post } from "../api";
 
 jest.mock("../api", () => ({
@@ -40,6 +40,23 @@ describe("authService.resendVerificationEmail", () => {
 
     await expect(resendVerificationEmail("user@example.com")).rejects.toEqual(
       apiError,
+    );
+  });
+});
+
+describe("authService.refreshAccessToken", () => {
+  it("POSTs to /api/auth/refresh with _isRetry to short-circuit the 401 refresh loop", async () => {
+    // Regression guard: without _isRetry: true on the refresh call itself,
+    // a 401 on /api/auth/refresh re-enters handleTokenRefresh and awaits the
+    // same in-flight refreshPromise → deadlock → splash stuck on launch.
+    mockPost.mockResolvedValueOnce({ accessToken: "new-token" });
+
+    await refreshAccessToken("refresh-token");
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/api/auth/refresh",
+      { refreshToken: "refresh-token" },
+      { skipAuth: true, _isRetry: true },
     );
   });
 });

--- a/front-mobile/services/api.ts
+++ b/front-mobile/services/api.ts
@@ -2,6 +2,7 @@ import { getToken, getRefreshToken } from "./storage";
 import { ApiError } from "@/types/auth";
 
 export const BASE_URL = process.env.EXPO_PUBLIC_API_URL;
+const REQUEST_TIMEOUT_MS = 15000;
 
 // Gestion du refresh en cours
 let isRefreshing = false;
@@ -196,10 +197,19 @@ export const apiClient = async <T>(
 
   const url = `${BASE_URL}${endpoint}`;
 
-  const response = await fetch(url, {
-    ...fetchOptions,
-    headers,
-  });
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      ...fetchOptions,
+      headers,
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeoutId);
+  }
 
   return handleResponse<T>(response, endpoint, options);
 };

--- a/front-mobile/services/api.ts
+++ b/front-mobile/services/api.ts
@@ -33,7 +33,7 @@ let pendingRequests: PendingRequest[] = [];
 
 interface RequestOptions extends RequestInit {
   skipAuth?: boolean;
-  _isRetry?: boolean; // Flag interne pour éviter les boucles infinies
+  skipRefresh?: boolean; // Skip the 401→refresh→retry loop (used internally after retry, and externally by /api/auth/refresh itself to avoid recursion)
 }
 
 // Fonction pour gérer le refresh du token
@@ -125,8 +125,9 @@ const handleResponse = async <T>(
   options: RequestOptions,
 ): Promise<T> => {
   if (response.status === 401) {
-    // Si c'est un retry, ne pas réessayer le refresh (éviter boucles infinies)
-    if (options._isRetry) {
+    // Skip the refresh loop on requests already retried or on the refresh
+    // endpoint itself — otherwise handleTokenRefresh awaits its own promise.
+    if (options.skipRefresh) {
       if (onUnauthorized) onUnauthorized();
       const error: ApiError = {
         message: "Non autorisé",
@@ -139,7 +140,7 @@ const handleResponse = async <T>(
     const refreshToken = await getRefreshToken();
     if (refreshToken) {
       // Tenter le refresh
-      return handleTokenRefresh(endpoint, { ...options, _isRetry: true });
+      return handleTokenRefresh(endpoint, { ...options, skipRefresh: true });
     } else {
       // Pas de refreshToken: déconnecter
       if (onUnauthorized) onUnauthorized();

--- a/front-mobile/services/authService.ts
+++ b/front-mobile/services/authService.ts
@@ -74,7 +74,7 @@ export const refreshAccessToken = async (
   const response = await post<RefreshTokenResponse>(
     "/api/auth/refresh",
     { refreshToken },
-    { skipAuth: true, _isRetry: true },
+    { skipAuth: true, skipRefresh: true },
   );
 
   if (!response.accessToken) {

--- a/front-mobile/services/authService.ts
+++ b/front-mobile/services/authService.ts
@@ -74,7 +74,7 @@ export const refreshAccessToken = async (
   const response = await post<RefreshTokenResponse>(
     "/api/auth/refresh",
     { refreshToken },
-    { skipAuth: true },
+    { skipAuth: true, _isRetry: true },
   );
 
   if (!response.accessToken) {

--- a/front-mobile/stores/authStore.ts
+++ b/front-mobile/stores/authStore.ts
@@ -30,11 +30,14 @@ export const useAuthStore = create<AuthState>((set, get) => {
   // Handler pour déconnexion (401 sans refresh ou échec du refresh)
   setUnauthorizedHandler(() => {
     const wasAuthenticated = get().isAuthenticated;
+    // isInitializing: false unblocks the splash if 401 fires during the
+    // initial checkAuth, before its own catch block resets the flag.
     set({
       user: null,
       token: null,
       refreshToken: null,
       isAuthenticated: false,
+      isInitializing: false,
     });
     storage.clearAll().catch((error) => {
       console.error("Failed to clear storage on unauthorized:", error);


### PR DESCRIPTION
## Description

Quand l'access token ET le refresh token étaient tous les deux expirés, l'app restait bloquée sur le splash screen à vie. Cause : `handleTokenRefresh` dans `services/api.ts` se rappelait récursivement quand `/api/auth/refresh` retournait 401, et la deuxième invocation faisait `await refreshPromise` sur la promesse même en cours d'exécution → deadlock infini → `checkAuth()` jamais résolu → `isInitializing: true` à vie.

Le fix marque la requête de refresh elle-même avec `_isRetry: true` pour court-circuiter la logique de refresh récursive, garantit que `setUnauthorizedHandler` reset aussi `isInitializing: false` comme filet de sécurité, et ajoute un timeout de 15 s via `AbortController` sur tous les `fetch()` pour qu'aucune hang réseau ne puisse plus jamais bloquer le splash.

## Parcours utilisateur

1. Lancer l'app avec un compte dont l'access token ET le refresh token sont expirés (ou modifier manuellement les tokens stockés via SecureStore)
2. Vérifier que le splash disparaît en ≤ 2 s au lieu de rester bloqué indéfiniment
3. Vérifier que l'app redirige automatiquement vers `/auth/login` avec le toast "Session expirée, reconnecte-toi"
4. Bonus : couper le wifi pendant le démarrage de l'app — le splash doit se libérer après ≤ 15 s (timeout fetch) au lieu de hang à vie