### PR TITLE
MIX-314 feat: add achievements section in profile

### DIFF
--- a/backend/app/services/user_achievement_service.ts
+++ b/backend/app/services/user_achievement_service.ts
@@ -1,10 +1,62 @@
 import UserAchievement from '#models/user_achievement'
 import Achievement from '#models/achievement'
+import { AchievementProgressService } from '#services/achievement_progress_service'
 import db from '@adonisjs/lucid/services/db'
+import { DateTime } from 'luxon'
+
+export interface UserAchievementSummary {
+  id: string | null
+  userId: string
+  achievementId: number
+  currentProgress: number
+  requiredProgress: number
+  currentTier: number
+  progressData: Record<string, any>
+  unlockedAt: DateTime | null
+  achievement: Achievement
+}
 
 export class UserAchievementService {
-  async getUserAchievements(userId: string): Promise<UserAchievement[]> {
-    return UserAchievement.query().where('user_id', userId).preload('achievement')
+  private progressService = new AchievementProgressService()
+
+  async getUserAchievements(userId: string): Promise<UserAchievementSummary[]> {
+    const [achievements, tracked] = await Promise.all([
+      Achievement.query().orderBy('id', 'asc'),
+      UserAchievement.query().where('user_id', userId).preload('achievement'),
+    ])
+
+    const byAchievementId = new Map(tracked.map((ua) => [ua.achievementId, ua]))
+
+    const merged: UserAchievementSummary[] = []
+    for (const achievement of achievements) {
+      const requiredProgress = this.progressService.getRequiredProgress(achievement.type)
+      if (requiredProgress === undefined) continue
+      const existing = byAchievementId.get(achievement.id)
+      if (existing) {
+        merged.push(existing)
+        continue
+      }
+      merged.push({
+        id: null,
+        userId,
+        achievementId: achievement.id,
+        currentProgress: 0,
+        requiredProgress,
+        currentTier: 1,
+        progressData: {},
+        unlockedAt: null,
+        achievement,
+      })
+    }
+
+    return merged.sort((a, b) => {
+      if (a.unlockedAt && b.unlockedAt) {
+        return b.unlockedAt.toMillis() - a.unlockedAt.toMillis()
+      }
+      if (a.unlockedAt) return -1
+      if (b.unlockedAt) return 1
+      return a.achievementId - b.achievementId
+    })
   }
 
   async getAll(): Promise<UserAchievement[]> {

--- a/backend/tests/functional/user_achievements_controller.spec.ts
+++ b/backend/tests/functional/user_achievements_controller.spec.ts
@@ -22,7 +22,7 @@ test.group('UserAchievementsController', (group) => {
     adminToken = adminAuth.token
 
     achievement = await Achievement.create({
-      type: 'test_achievement' as AchievementType,
+      type: AchievementType.FirstGame,
       description: 'Test description',
     })
   })

--- a/backend/tests/unit/user_achievement_service.spec.ts
+++ b/backend/tests/unit/user_achievement_service.spec.ts
@@ -70,9 +70,7 @@ test.group('UserAchievementService', (group) => {
     assert.equal(result[1].achievementId, second.id)
   })
 
-  test('getUserAchievements sorts unlocked achievements by unlockedAt desc', async ({
-    assert,
-  }) => {
+  test('getUserAchievements sorts unlocked achievements by unlockedAt desc', async ({ assert }) => {
     const secondAchievement = await Achievement.create({
       type: AchievementType.FirstLike,
       description: 'Second',

--- a/backend/tests/unit/user_achievement_service.spec.ts
+++ b/backend/tests/unit/user_achievement_service.spec.ts
@@ -21,14 +21,14 @@ test.group('UserAchievementService', (group) => {
     })
 
     achievement = await Achievement.create({
-      type: 'test_achievement' as AchievementType,
+      type: AchievementType.FirstGame,
       description: 'Test description',
     })
   })
 
   deleteUserAchievement(group)
 
-  test('getUserAchievements returns user achievements with achievement preloaded', async ({
+  test('getUserAchievements returns existing user achievement with achievement preloaded', async ({
     assert,
   }) => {
     await UserAchievement.create({
@@ -46,7 +46,102 @@ test.group('UserAchievementService', (group) => {
     assert.equal(result[0].userId, user.id)
     assert.equal(result[0].achievementId, achievement.id)
     assert.exists(result[0].achievement)
-    assert.equal(result[0].achievement.type, 'test_achievement')
+    assert.equal(result[0].achievement.type, AchievementType.FirstGame)
+    assert.equal(result[0].currentProgress, 50)
+  })
+
+  test('getUserAchievements returns wired achievements with defaults when never tracked', async ({
+    assert,
+  }) => {
+    const second = await Achievement.create({
+      type: AchievementType.FirstLike,
+      description: 'Second wired',
+    })
+
+    const result = await service.getUserAchievements(user.id)
+
+    assert.lengthOf(result, 2)
+    assert.isNull(result[0].id)
+    assert.equal(result[0].achievementId, achievement.id)
+    assert.equal(result[0].currentProgress, 0)
+    assert.equal(result[0].requiredProgress, 1)
+    assert.isNull(result[0].unlockedAt)
+    assert.exists(result[0].achievement)
+    assert.equal(result[1].achievementId, second.id)
+  })
+
+  test('getUserAchievements sorts unlocked achievements by unlockedAt desc', async ({
+    assert,
+  }) => {
+    const secondAchievement = await Achievement.create({
+      type: AchievementType.FirstLike,
+      description: 'Second',
+    })
+    const older = DateTime.now().minus({ days: 2 })
+    const newer = DateTime.now().minus({ hours: 1 })
+    await UserAchievement.create({
+      userId: user.id,
+      achievementId: achievement.id,
+      currentProgress: 1,
+      requiredProgress: 1,
+      currentTier: 1,
+      progressData: {},
+      unlockedAt: older,
+    })
+    await UserAchievement.create({
+      userId: user.id,
+      achievementId: secondAchievement.id,
+      currentProgress: 1,
+      requiredProgress: 1,
+      currentTier: 1,
+      progressData: {},
+      unlockedAt: newer,
+    })
+
+    const result = await service.getUserAchievements(user.id)
+
+    assert.lengthOf(result, 2)
+    assert.equal(result[0].achievementId, secondAchievement.id)
+    assert.equal(result[1].achievementId, achievement.id)
+  })
+
+  test('getUserAchievements places unlocked before locked regardless of insertion order', async ({
+    assert,
+  }) => {
+    const secondAchievement = await Achievement.create({
+      type: AchievementType.FirstLike,
+      description: 'Higher id unlocked',
+    })
+    await UserAchievement.create({
+      userId: user.id,
+      achievementId: secondAchievement.id,
+      currentProgress: 1,
+      requiredProgress: 1,
+      currentTier: 1,
+      progressData: {},
+      unlockedAt: DateTime.now(),
+    })
+
+    const result = await service.getUserAchievements(user.id)
+
+    assert.lengthOf(result, 2)
+    assert.equal(result[0].achievementId, secondAchievement.id)
+    assert.exists(result[0].unlockedAt)
+    assert.isNull(result[1].unlockedAt)
+  })
+
+  test('getUserAchievements filters out achievements not wired to any event', async ({
+    assert,
+  }) => {
+    await Achievement.create({
+      type: 'unwired_type' as AchievementType,
+      description: 'Should not appear',
+    })
+
+    const result = await service.getUserAchievements(user.id)
+
+    assert.lengthOf(result, 1)
+    assert.equal(result[0].achievement.type, AchievementType.FirstGame)
   })
 
   test('getAll returns all user achievements with user and achievement preloaded', async ({
@@ -67,7 +162,7 @@ test.group('UserAchievementService', (group) => {
     assert.exists(result[0].user)
     assert.exists(result[0].achievement)
     assert.isNotNull(result[0].user.username)
-    assert.equal(result[0].achievement.type, 'test_achievement')
+    assert.equal(result[0].achievement.type, AchievementType.FirstGame)
   })
 
   test('startTracking creates user achievement with default values', async ({ assert }) => {

--- a/backend/tests/utils/user_achievement_helpers.ts
+++ b/backend/tests/utils/user_achievement_helpers.ts
@@ -13,10 +13,10 @@ export function deleteUserAchievement(group: Group) {
 
   group.each.teardown(async () => {
     await UserAchievement.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+    await Achievement.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
   })
 
   group.teardown(async () => {
-    await Achievement.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
     await User.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
   })
 }

--- a/front-mobile/app/(tabs)/profile/index.tsx
+++ b/front-mobile/app/(tabs)/profile/index.tsx
@@ -7,23 +7,11 @@ import { Colors } from "@/constants/Colors";
 import { useAuthStore } from "@/stores/authStore";
 import OnboardingBanner from "@/components/OnboardingBanner";
 import ProfileSpotifySection from "@/components/profile/ProfileSpotifySection";
+import ProfileAchievementsSection from "@/components/profile/ProfileAchievementsSection";
 import { ProfileRecentActivities } from "@/components/profile/ProfileRecentActivities";
 import { useOnboardingStatus } from "@/hooks/useOnboardingStatus";
 import { useMyStats } from "@/hooks/useMyStats";
 import { Skeleton } from "@/components/ui/Skeleton";
-
-// TODO: à modifier plus tard - remplacer par des données récupérées depuis l'API
-const MOCK_BADGES = [
-  { id: "1", name: "Bienvenue dans l'arène", icon: "🏟️", unlocked: true },
-  { id: "2", name: "Premier pas", icon: "👣", unlocked: true },
-  { id: "3", name: "Première victoire", icon: "🥇", unlocked: true },
-  { id: "4", name: "Oreille d'or", icon: "🎧", unlocked: true },
-  { id: "5", name: "Éclair", icon: "⚡", unlocked: true },
-  { id: "6", name: "Perfectionniste", icon: "💎", unlocked: false },
-  { id: "7", name: "Vétéran", icon: "🏆", unlocked: false },
-  { id: "8", name: "Légende", icon: "👑", unlocked: false },
-  { id: "9", name: "Mélomane absolu", icon: "🎵", unlocked: false },
-];
 
 function getMemberSince(createdAt?: string): string {
   if (!createdAt) return "membre récemment";
@@ -108,32 +96,7 @@ export default function ProfileScreen() {
         <ProfileSpotifySection />
 
         {/* ── Succès & Récompenses ── */}
-        <View style={styles.section}>
-          <Text style={styles.sectionTitleCentered}>Succès & Récompenses</Text>
-          <View style={styles.badgesGrid}>
-            {MOCK_BADGES.map((badge) => (
-              <View
-                key={badge.id}
-                style={[
-                  styles.badgeItem,
-                  !badge.unlocked && styles.badgeLocked,
-                ]}
-              >
-                <Text style={styles.badgeIcon}>
-                  {badge.unlocked ? badge.icon : "🔒"}
-                </Text>
-                <Text
-                  style={[
-                    styles.badgeName,
-                    !badge.unlocked && styles.badgeNameLocked,
-                  ]}
-                >
-                  {badge.name}
-                </Text>
-              </View>
-            ))}
-          </View>
-        </View>
+        <ProfileAchievementsSection />
 
         {/* ── Activités récentes ── */}
         <ProfileRecentActivities />
@@ -270,14 +233,6 @@ const styles = StyleSheet.create({
     borderLeftColor: Colors.primary.CTA,
     paddingLeft: 10,
   },
-  sectionTitleCentered: {
-    fontSize: 18,
-    fontWeight: "700",
-    color: Colors.dark.text,
-    marginBottom: 14,
-    textAlign: "center",
-  },
-
   // Stats
   statsRow: {
     flexDirection: "row",
@@ -314,39 +269,6 @@ const styles = StyleSheet.create({
   errorText: {
     color: "#FF4D4D",
     fontSize: 13,
-  },
-
-  // Badges
-  badgesGrid: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 12,
-  },
-  badgeItem: {
-    width: "31%",
-    backgroundColor: "#1A1A1A",
-    borderRadius: 12,
-    padding: 12,
-    alignItems: "center",
-    gap: 6,
-    borderWidth: 1,
-    borderColor: Colors.primary.CTA,
-  },
-  badgeLocked: {
-    borderColor: "#2A2A2A",
-    opacity: 0.5,
-  },
-  badgeIcon: {
-    fontSize: 28,
-  },
-  badgeName: {
-    fontSize: 11,
-    color: Colors.dark.text,
-    textAlign: "center",
-    fontWeight: "600",
-  },
-  badgeNameLocked: {
-    color: Colors.dark.icon,
   },
 
   // Favorite artists

--- a/front-mobile/components/profile/AchievementDetailModal.tsx
+++ b/front-mobile/components/profile/AchievementDetailModal.tsx
@@ -1,0 +1,242 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Dimensions,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Colors } from "@/constants/Colors";
+import { UserAchievementWithDetails } from "@/types/achievement";
+import { formatRelativeDate } from "@/utils/relative-date";
+
+const SCREEN_HEIGHT = Dimensions.get("window").height;
+const ANIMATION_DURATION = 400;
+const TIMING = {
+  duration: ANIMATION_DURATION,
+  easing: Easing.out(Easing.cubic),
+};
+
+interface AchievementDetailModalProps {
+  visible: boolean;
+  achievement: UserAchievementWithDetails | null;
+  onClose: () => void;
+}
+
+export default function AchievementDetailModal({
+  visible,
+  achievement,
+  onClose,
+}: AchievementDetailModalProps) {
+  const insets = useSafeAreaInsets();
+  const [isRendered, setIsRendered] = useState(visible);
+  const [lastAchievement, setLastAchievement] =
+    useState<UserAchievementWithDetails | null>(achievement);
+  const hasOpened = useRef(visible);
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    if (achievement) setLastAchievement(achievement);
+  }, [achievement]);
+
+  useEffect(() => {
+    if (visible) {
+      hasOpened.current = true;
+      setIsRendered(true);
+      progress.value = withTiming(1, TIMING);
+    } else if (hasOpened.current) {
+      progress.value = withTiming(0, TIMING, (finished) => {
+        if (finished) runOnJS(setIsRendered)(false);
+      });
+    }
+  }, [visible, progress]);
+
+  const backdropStyle = useAnimatedStyle(() => ({
+    opacity: progress.value,
+  }));
+
+  const sheetStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: (1 - progress.value) * SCREEN_HEIGHT }],
+  }));
+
+  if (!isRendered || !lastAchievement) return null;
+
+  const isUnlocked = lastAchievement.unlockedAt !== null;
+  const progressRatio =
+    lastAchievement.requiredProgress > 0
+      ? Math.min(
+          1,
+          Math.max(
+            0,
+            lastAchievement.currentProgress / lastAchievement.requiredProgress,
+          ),
+        )
+      : 0;
+
+  return (
+    <Modal
+      animationType="none"
+      transparent
+      visible={isRendered}
+      onRequestClose={onClose}
+    >
+      <View style={styles.container}>
+        <Animated.View style={[styles.backdrop, backdropStyle]}>
+          <Pressable
+            style={StyleSheet.absoluteFill}
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Fermer la modal"
+            testID="achievement-modal-backdrop"
+          />
+        </Animated.View>
+
+        <Animated.View
+          style={[
+            styles.sheet,
+            { paddingBottom: 24 + insets.bottom },
+            sheetStyle,
+          ]}
+        >
+          <View style={styles.handle} />
+
+          <Text style={styles.icon}>
+            {isUnlocked ? (lastAchievement.icon ?? "🏅") : "🔒"}
+          </Text>
+          <Text style={styles.name}>{lastAchievement.name}</Text>
+          {lastAchievement.description ? (
+            <Text style={styles.description}>
+              {lastAchievement.description}
+            </Text>
+          ) : null}
+
+          {isUnlocked ? (
+            <Text style={styles.statusUnlocked}>
+              Débloqué {formatRelativeDate(lastAchievement.unlockedAt!)}
+            </Text>
+          ) : (
+            <View style={styles.lockedBlock}>
+              <Text style={styles.statusLocked}>
+                Verrouillé — {lastAchievement.currentProgress}/
+                {lastAchievement.requiredProgress}
+              </Text>
+              <View style={styles.progressTrack}>
+                <View
+                  style={[
+                    styles.progressFill,
+                    { width: `${progressRatio * 100}%` },
+                  ]}
+                />
+              </View>
+            </View>
+          )}
+
+          <TouchableOpacity
+            style={styles.closeButton}
+            onPress={onClose}
+            accessibilityRole="button"
+          >
+            <Text style={styles.closeButtonText}>Fermer</Text>
+          </TouchableOpacity>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  sheet: {
+    width: "100%",
+    backgroundColor: Colors.primary.fondPremier,
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: 28,
+    paddingTop: 12,
+    alignItems: "center",
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: Colors.dark.icon,
+    marginBottom: 20,
+    opacity: 0.4,
+  },
+  icon: {
+    fontSize: 60,
+    marginBottom: 12,
+  },
+  name: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: Colors.dark.text,
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  description: {
+    fontSize: 14,
+    color: Colors.dark.icon,
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  statusUnlocked: {
+    fontSize: 14,
+    color: Colors.primary.survol,
+    fontWeight: "600",
+    marginBottom: 20,
+    textAlign: "center",
+  },
+  lockedBlock: {
+    width: "100%",
+    marginBottom: 20,
+    alignItems: "center",
+    gap: 8,
+  },
+  statusLocked: {
+    fontSize: 14,
+    color: Colors.game.textMuted,
+    textAlign: "center",
+  },
+  progressTrack: {
+    width: "100%",
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: "#2A2A2A",
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: Colors.primary.CTA,
+  },
+  closeButton: {
+    width: "100%",
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: Colors.primary.CTA,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  closeButtonText: {
+    color: Colors.dark.text,
+    fontSize: 15,
+    fontWeight: "700",
+  },
+});

--- a/front-mobile/components/profile/ProfileAchievementsSection.tsx
+++ b/front-mobile/components/profile/ProfileAchievementsSection.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Colors } from "@/constants/Colors";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useMyAchievements } from "@/hooks/useMyAchievements";
+import { UserAchievementWithDetails } from "@/types/achievement";
+import AchievementDetailModal from "@/components/profile/AchievementDetailModal";
+
+const SKELETON_COUNT = 9;
+
+function AchievementSkeletons() {
+  return (
+    <>
+      {Array.from({ length: SKELETON_COUNT }).map((_, idx) => (
+        <Skeleton
+          key={`achievement-skeleton-${idx}`}
+          width="31%"
+          height={80}
+          borderRadius={12}
+          style={styles.skeletonCard}
+        />
+      ))}
+    </>
+  );
+}
+
+function AchievementCard({
+  achievement,
+  onPress,
+}: {
+  achievement: UserAchievementWithDetails;
+  onPress: (a: UserAchievementWithDetails) => void;
+}) {
+  const isUnlocked = achievement.unlockedAt !== null;
+  return (
+    <Pressable
+      style={[styles.card, !isUnlocked && styles.cardLocked]}
+      onPress={() => onPress(achievement)}
+      accessibilityRole="button"
+      accessibilityLabel={`${achievement.name}, ${isUnlocked ? "débloqué" : "verrouillé"}`}
+    >
+      <Text style={styles.icon}>
+        {isUnlocked ? (achievement.icon ?? "🏅") : "🔒"}
+      </Text>
+      <Text style={[styles.name, !isUnlocked && styles.nameLocked]}>
+        {achievement.name}
+      </Text>
+    </Pressable>
+  );
+}
+
+function renderBody(
+  isLoading: boolean,
+  error: string | null,
+  achievements: UserAchievementWithDetails[],
+  onPress: (a: UserAchievementWithDetails) => void,
+) {
+  if (isLoading) return <AchievementSkeletons />;
+  if (error) {
+    return (
+      <Text style={styles.feedbackText}>
+        Impossible de charger tes succès, réessaie plus tard.
+      </Text>
+    );
+  }
+  if (achievements.length === 0) {
+    return (
+      <Text style={styles.feedbackText}>
+        Aucun succès disponible pour le moment.
+      </Text>
+    );
+  }
+  return achievements.map((achievement) => (
+    <AchievementCard
+      key={achievement.id}
+      achievement={achievement}
+      onPress={onPress}
+    />
+  ));
+}
+
+export default function ProfileAchievementsSection() {
+  const { achievements, isLoading, error } = useMyAchievements();
+  const [selected, setSelected] = useState<UserAchievementWithDetails | null>(
+    null,
+  );
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>Succès & Récompenses</Text>
+      <View style={styles.grid}>
+        {renderBody(isLoading, error, achievements, setSelected)}
+      </View>
+      <AchievementDetailModal
+        visible={selected !== null}
+        achievement={selected}
+        onClose={() => setSelected(null)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: 28,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: Colors.dark.text,
+    marginBottom: 14,
+    borderLeftWidth: 3,
+    borderLeftColor: Colors.primary.CTA,
+    paddingLeft: 10,
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  card: {
+    width: "31%",
+    backgroundColor: "#1A1A1A",
+    borderRadius: 12,
+    padding: 12,
+    alignItems: "center",
+    gap: 6,
+    borderWidth: 1,
+    borderColor: Colors.primary.CTA,
+  },
+  cardLocked: {
+    borderColor: "#2A2A2A",
+    opacity: 0.5,
+  },
+  icon: {
+    fontSize: 28,
+  },
+  name: {
+    fontSize: 11,
+    color: Colors.dark.text,
+    textAlign: "center",
+    fontWeight: "600",
+  },
+  nameLocked: {
+    color: Colors.dark.icon,
+  },
+  skeletonCard: {
+    marginBottom: 0,
+  },
+  feedbackText: {
+    fontSize: 13,
+    color: Colors.dark.icon,
+    fontStyle: "italic",
+    paddingVertical: 8,
+    width: "100%",
+    textAlign: "center",
+  },
+});

--- a/front-mobile/components/profile/ProfileRecentActivities.tsx
+++ b/front-mobile/components/profile/ProfileRecentActivities.tsx
@@ -4,33 +4,10 @@ import { Colors } from "@/constants/Colors";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { useMyActivities } from "@/hooks/useMyActivities";
 import { UserActivity } from "@/types/userActivity";
+import { formatRelativeDate } from "@/utils/relative-date";
 
 const ACTIVITY_LIMIT = 5;
 const SKELETON_COUNT = 3;
-
-function formatRelativeDate(date: string): string {
-  const target = new Date(date).getTime();
-  const now = Date.now();
-  const diffMs = Math.max(0, now - target);
-  const diffMinutes = Math.floor(diffMs / 60_000);
-  if (diffMinutes < 1) return "À l'instant";
-  if (diffMinutes < 60) return `Il y a ${diffMinutes} min`;
-  const diffHours = Math.floor(diffMinutes / 60);
-  if (diffHours < 24) return `Il y a ${diffHours}h`;
-  const diffDays = Math.floor(diffHours / 24);
-  if (diffDays === 1) return "Hier";
-  if (diffDays < 7) return `Il y a ${diffDays} jours`;
-  if (diffDays < 30) {
-    const diffWeeks = Math.floor(diffDays / 7);
-    return `Il y a ${diffWeeks} sem.`;
-  }
-  if (diffDays < 365) {
-    const diffMonths = Math.floor(diffDays / 30);
-    return `Il y a ${diffMonths} mois`;
-  }
-  const diffYears = Math.floor(diffDays / 365);
-  return diffYears === 1 ? "Il y a 1 an" : `Il y a ${diffYears} ans`;
-}
 
 function activityBaseKey(activity: UserActivity): string {
   if (activity.type === "game_session") {

--- a/front-mobile/components/profile/__tests__/AchievementDetailModal.test.tsx
+++ b/front-mobile/components/profile/__tests__/AchievementDetailModal.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import AchievementDetailModal from "../AchievementDetailModal";
+import { UserAchievementWithDetails } from "@/types/achievement";
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const unlocked: UserAchievementWithDetails = {
+  id: 1,
+  name: "Première victoire",
+  description: "Gagner sa toute première partie multijoueur",
+  icon: "🥇",
+  type: "FirstWin",
+  currentProgress: 1,
+  requiredProgress: 1,
+  unlockedAt: "2026-05-13T12:00:00Z",
+};
+
+const locked: UserAchievementWithDetails = {
+  id: 2,
+  name: "Vétéran",
+  description: "Jouer 10 parties",
+  icon: "🏆",
+  type: "GamesPlayed",
+  currentProgress: 3,
+  requiredProgress: 10,
+  unlockedAt: null,
+};
+
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2026-05-14T12:00:00Z"));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+describe("AchievementDetailModal", () => {
+  it("returns null when no achievement is provided", () => {
+    const { toJSON } = render(
+      <AchievementDetailModal visible achievement={null} onClose={jest.fn()} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders unlocked achievement with icon and relative date", () => {
+    const { getByText } = render(
+      <AchievementDetailModal
+        visible
+        achievement={unlocked}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(getByText("🥇")).toBeTruthy();
+    expect(getByText("Première victoire")).toBeTruthy();
+    expect(getByText(/Débloqué/)).toBeTruthy();
+    expect(getByText(/Hier/)).toBeTruthy();
+  });
+
+  it("renders locked achievement with progress text", () => {
+    const { getByText } = render(
+      <AchievementDetailModal
+        visible
+        achievement={locked}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(getByText("🔒")).toBeTruthy();
+    expect(getByText(/Verrouillé — 3\/10/)).toBeTruthy();
+  });
+
+  it("calls onClose when the Fermer button is pressed", () => {
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <AchievementDetailModal
+        visible
+        achievement={unlocked}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.press(getByText("Fermer"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the backdrop is pressed", () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <AchievementDetailModal
+        visible
+        achievement={unlocked}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.press(getByTestId("achievement-modal-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front-mobile/components/profile/__tests__/ProfileAchievementsSection.test.tsx
+++ b/front-mobile/components/profile/__tests__/ProfileAchievementsSection.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import ProfileAchievementsSection from "../ProfileAchievementsSection";
+import { useMyAchievements } from "@/hooks/useMyAchievements";
+import { UserAchievementWithDetails } from "@/types/achievement";
+
+jest.mock("@/hooks/useMyAchievements", () => ({
+  useMyAchievements: jest.fn(),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const mockUseMyAchievements = useMyAchievements as jest.MockedFunction<
+  typeof useMyAchievements
+>;
+
+const unlocked: UserAchievementWithDetails = {
+  id: 1,
+  name: "Première victoire",
+  description: "Gagner sa toute première partie",
+  icon: "🥇",
+  type: "FirstWin",
+  currentProgress: 1,
+  requiredProgress: 1,
+  unlockedAt: "2026-05-13T12:00:00Z",
+};
+
+const locked: UserAchievementWithDetails = {
+  id: 2,
+  name: "Vétéran",
+  description: "Jouer 10 parties",
+  icon: "🏆",
+  type: "GamesPlayed",
+  currentProgress: 3,
+  requiredProgress: 10,
+  unlockedAt: null,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ProfileAchievementsSection", () => {
+  it("renders the section title", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByText } = render(<ProfileAchievementsSection />);
+    expect(getByText("Succès & Récompenses")).toBeTruthy();
+  });
+
+  it("renders empty state when no achievements", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByText } = render(<ProfileAchievementsSection />);
+    expect(getByText(/Aucun succès disponible/i)).toBeTruthy();
+  });
+
+  it("renders error feedback when the hook reports an error", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [],
+      isLoading: false,
+      error: "network",
+      refresh: jest.fn(),
+    });
+    const { getByText } = render(<ProfileAchievementsSection />);
+    expect(getByText(/Impossible de charger tes succès/i)).toBeTruthy();
+  });
+
+  it("renders unlocked and locked cards with the right icons", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [unlocked, locked],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByText } = render(<ProfileAchievementsSection />);
+    expect(getByText("🥇")).toBeTruthy();
+    expect(getByText("🔒")).toBeTruthy();
+    expect(getByText("Première victoire")).toBeTruthy();
+    expect(getByText("Vétéran")).toBeTruthy();
+  });
+
+  it("opens the detail modal when a card is pressed", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [unlocked, locked],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByLabelText, queryByText, getByText } = render(
+      <ProfileAchievementsSection />,
+    );
+
+    expect(queryByText(/Verrouillé/)).toBeNull();
+    fireEvent.press(getByLabelText("Vétéran, verrouillé"));
+    expect(getByText(/Verrouillé — 3\/10/)).toBeTruthy();
+  });
+});

--- a/front-mobile/hooks/__tests__/useMyAchievements.test.ts
+++ b/front-mobile/hooks/__tests__/useMyAchievements.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, waitFor, act } from "@testing-library/react-native";
+import { useMyAchievements } from "../useMyAchievements";
+import { getMyAchievements } from "@/services/achievementsService";
+import { UserAchievementWithDetails } from "@/types/achievement";
+
+jest.mock("@/services/achievementsService", () => ({
+  getMyAchievements: jest.fn(),
+}));
+
+jest.mock("expo-router", () => ({
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const React = require("react");
+    React.useEffect(() => {
+      const cleanup = callback();
+      return typeof cleanup === "function" ? cleanup : undefined;
+    }, [callback]);
+  },
+}));
+
+const mockGetMyAchievements = getMyAchievements as jest.MockedFunction<
+  typeof getMyAchievements
+>;
+
+const buildAchievement = (
+  override: Partial<UserAchievementWithDetails> = {},
+): UserAchievementWithDetails => ({
+  id: 1,
+  name: "Première victoire",
+  description: "Gagner sa toute première partie",
+  icon: "🥇",
+  type: "FirstWin",
+  currentProgress: 1,
+  requiredProgress: 1,
+  unlockedAt: "2026-05-10T08:00:00Z",
+  ...override,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useMyAchievements", () => {
+  it("fetches achievements on mount and exposes them", async () => {
+    const data = [buildAchievement()];
+    mockGetMyAchievements.mockResolvedValueOnce(data);
+
+    const { result } = renderHook(() => useMyAchievements());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetMyAchievements).toHaveBeenCalledTimes(1);
+    expect(result.current.achievements).toEqual(data);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("captures error message on failure", async () => {
+    mockGetMyAchievements.mockRejectedValueOnce(new Error("network down"));
+
+    const { result } = renderHook(() => useMyAchievements());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("network down");
+    expect(result.current.achievements).toEqual([]);
+  });
+
+  it("falls back to 'Unknown error' when thrown value is not an Error", async () => {
+    mockGetMyAchievements.mockRejectedValueOnce("plain string");
+
+    const { result } = renderHook(() => useMyAchievements());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("Unknown error");
+  });
+
+  it("refresh re-triggers the fetch", async () => {
+    mockGetMyAchievements.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useMyAchievements());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetMyAchievements).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(mockGetMyAchievements).toHaveBeenCalledTimes(2);
+  });
+});

--- a/front-mobile/hooks/useMyAchievements.ts
+++ b/front-mobile/hooks/useMyAchievements.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useFocusEffect } from "expo-router";
+import { getMyAchievements } from "@/services/achievementsService";
+import { UserAchievementWithDetails } from "@/types/achievement";
+
+export interface UseMyAchievementsResult {
+  achievements: UserAchievementWithDetails[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useMyAchievements(): UseMyAchievementsResult {
+  const [achievements, setAchievements] = useState<
+    UserAchievementWithDetails[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isMountedRef = useRef(true);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    if (isMountedRef.current) {
+      setIsLoading(true);
+      setError(null);
+    }
+
+    try {
+      const data = await getMyAchievements();
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setAchievements(data);
+      }
+    } catch (err) {
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    } finally {
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      void refresh();
+    }, [refresh]),
+  );
+
+  return { achievements, isLoading, error, refresh };
+}

--- a/front-mobile/services/__tests__/achievementsService.test.ts
+++ b/front-mobile/services/__tests__/achievementsService.test.ts
@@ -1,0 +1,98 @@
+import { getMyAchievements } from "../achievementsService";
+import { get } from "../api";
+import { UserAchievement } from "@/types/achievement";
+
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
+
+jest.mock("../api", () => ({
+  get: jest.fn(),
+}));
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const baseUserAchievement = (
+  override: Partial<UserAchievement> = {},
+): UserAchievement => ({
+  id: "ua-1",
+  userId: "user-1",
+  achievementId: 1,
+  currentProgress: 1,
+  requiredProgress: 1,
+  currentTier: 1,
+  unlockedAt: "2026-05-10T08:00:00Z",
+  achievement: {
+    id: 1,
+    name: "Première victoire",
+    description: "Gagner sa toute première partie multijoueur",
+    icon: "🥇",
+    type: "FirstWin",
+  },
+  ...override,
+});
+
+describe("achievementsService", () => {
+  it("GETs the user achievements endpoint", async () => {
+    mockGet.mockResolvedValueOnce({ userAchievements: [] });
+    await getMyAchievements();
+    expect(mockGet).toHaveBeenCalledWith("/api/user-achievements/me");
+  });
+
+  it("flattens the nested achievement relation into a single object", async () => {
+    const unlocked = baseUserAchievement();
+    const locked = baseUserAchievement({
+      id: "ua-2",
+      achievementId: 2,
+      currentProgress: 3,
+      requiredProgress: 10,
+      unlockedAt: null,
+      achievement: {
+        id: 2,
+        name: "Vétéran",
+        description: "Jouer 10 parties",
+        icon: "🏆",
+        type: "GamesPlayed",
+      },
+    });
+
+    mockGet.mockResolvedValueOnce({ userAchievements: [unlocked, locked] });
+
+    const result = await getMyAchievements();
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: "Première victoire",
+        description: "Gagner sa toute première partie multijoueur",
+        icon: "🥇",
+        type: "FirstWin",
+        currentProgress: 1,
+        requiredProgress: 1,
+        unlockedAt: "2026-05-10T08:00:00Z",
+      },
+      {
+        id: 2,
+        name: "Vétéran",
+        description: "Jouer 10 parties",
+        icon: "🏆",
+        type: "GamesPlayed",
+        currentProgress: 3,
+        requiredProgress: 10,
+        unlockedAt: null,
+      },
+    ]);
+  });
+
+  it("returns an empty array when no achievements are returned", async () => {
+    mockGet.mockResolvedValueOnce({ userAchievements: [] });
+    expect(await getMyAchievements()).toEqual([]);
+  });
+
+  it("propagates API errors", async () => {
+    mockGet.mockRejectedValueOnce(new Error("network down"));
+    await expect(getMyAchievements()).rejects.toThrow("network down");
+  });
+});

--- a/front-mobile/services/achievementsService.ts
+++ b/front-mobile/services/achievementsService.ts
@@ -1,0 +1,28 @@
+import { get } from "./api";
+import {
+  GetMyAchievementsResponse,
+  UserAchievement,
+  UserAchievementWithDetails,
+} from "@/types/achievement";
+
+function flatten(item: UserAchievement): UserAchievementWithDetails {
+  return {
+    id: item.achievement.id,
+    name: item.achievement.name,
+    description: item.achievement.description,
+    icon: item.achievement.icon,
+    type: item.achievement.type,
+    currentProgress: item.currentProgress,
+    requiredProgress: item.requiredProgress,
+    unlockedAt: item.unlockedAt,
+  };
+}
+
+export const getMyAchievements = async (): Promise<
+  UserAchievementWithDetails[]
+> => {
+  const data = await get<GetMyAchievementsResponse>(
+    "/api/user-achievements/me",
+  );
+  return data.userAchievements.map(flatten);
+};

--- a/front-mobile/types/achievement.ts
+++ b/front-mobile/types/achievement.ts
@@ -7,7 +7,7 @@ export interface Achievement {
 }
 
 export interface UserAchievement {
-  id: string;
+  id: string | null;
   userId: string;
   achievementId: number;
   currentProgress: number;

--- a/front-mobile/types/achievement.ts
+++ b/front-mobile/types/achievement.ts
@@ -1,0 +1,33 @@
+export interface Achievement {
+  id: number;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  type: string;
+}
+
+export interface UserAchievement {
+  id: string;
+  userId: string;
+  achievementId: number;
+  currentProgress: number;
+  requiredProgress: number;
+  currentTier: number;
+  unlockedAt: string | null;
+  achievement: Achievement;
+}
+
+export interface UserAchievementWithDetails {
+  id: number;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  type: string;
+  currentProgress: number;
+  requiredProgress: number;
+  unlockedAt: string | null;
+}
+
+export interface GetMyAchievementsResponse {
+  userAchievements: UserAchievement[];
+}

--- a/front-mobile/utils/__tests__/relative-date.test.ts
+++ b/front-mobile/utils/__tests__/relative-date.test.ts
@@ -1,0 +1,67 @@
+import { formatRelativeDate } from "../relative-date";
+
+describe("formatRelativeDate", () => {
+  const NOW = new Date("2026-05-14T12:00:00.000Z").getTime();
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const offset = (ms: number) => new Date(NOW - ms).toISOString();
+
+  it("returns 'À l'instant' for under one minute", () => {
+    expect(formatRelativeDate(offset(30 * 1000))).toBe("À l'instant");
+  });
+
+  it("returns minutes for under one hour", () => {
+    expect(formatRelativeDate(offset(5 * 60_000))).toBe("Il y a 5 min");
+  });
+
+  it("returns hours for under one day", () => {
+    expect(formatRelativeDate(offset(3 * 60 * 60_000))).toBe("Il y a 3h");
+  });
+
+  it("returns 'Hier' for exactly one day", () => {
+    expect(formatRelativeDate(offset(24 * 60 * 60_000))).toBe("Hier");
+  });
+
+  it("returns days for between 2 and 6 days", () => {
+    expect(formatRelativeDate(offset(3 * 24 * 60 * 60_000))).toBe(
+      "Il y a 3 jours",
+    );
+  });
+
+  it("returns weeks for between 7 and 29 days", () => {
+    expect(formatRelativeDate(offset(14 * 24 * 60 * 60_000))).toBe(
+      "Il y a 2 sem.",
+    );
+  });
+
+  it("returns months for between 30 and 364 days", () => {
+    expect(formatRelativeDate(offset(90 * 24 * 60 * 60_000))).toBe(
+      "Il y a 3 mois",
+    );
+  });
+
+  it("returns 'Il y a 1 an' for one year", () => {
+    expect(formatRelativeDate(offset(365 * 24 * 60 * 60_000))).toBe(
+      "Il y a 1 an",
+    );
+  });
+
+  it("returns years for more than one year", () => {
+    expect(formatRelativeDate(offset(3 * 365 * 24 * 60 * 60_000))).toBe(
+      "Il y a 3 ans",
+    );
+  });
+
+  it("clamps future dates to 'À l'instant'", () => {
+    const future = new Date(NOW + 10 * 60_000).toISOString();
+    expect(formatRelativeDate(future)).toBe("À l'instant");
+  });
+});

--- a/front-mobile/utils/relative-date.ts
+++ b/front-mobile/utils/relative-date.ts
@@ -1,0 +1,23 @@
+export function formatRelativeDate(date: string): string {
+  const target = new Date(date).getTime();
+  const now = Date.now();
+  const diffMs = Math.max(0, now - target);
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  if (diffMinutes < 1) return "À l'instant";
+  if (diffMinutes < 60) return `Il y a ${diffMinutes} min`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `Il y a ${diffHours}h`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays === 1) return "Hier";
+  if (diffDays < 7) return `Il y a ${diffDays} jours`;
+  if (diffDays < 30) {
+    const diffWeeks = Math.floor(diffDays / 7);
+    return `Il y a ${diffWeeks} sem.`;
+  }
+  if (diffDays < 365) {
+    const diffMonths = Math.floor(diffDays / 30);
+    return `Il y a ${diffMonths} mois`;
+  }
+  const diffYears = Math.floor(diffDays / 365);
+  return diffYears === 1 ? "Il y a 1 an" : `Il y a ${diffYears} ans`;
+}


### PR DESCRIPTION
## Summary

- **Front-mobile** : nouvelle section "Succès & Récompenses" dans le Profil avec grille 3 colonnes, bottom sheet de détail (fade-in overlay + slide-in sheet, easing out cubic 400ms, animation propre à l'ouverture **et** à la fermeture) et helper `formatRelativeDate` extrait dans `utils/relative-date.ts` (réutilisé par `ProfileRecentActivities` et la modal).
- **Backend** : `getUserAchievements` retourne maintenant tous les achievements câblés à un listener (11 types via `REQUIRED_PROGRESS_BY_TYPE`) avec valeurs par défaut pour ceux jamais déclenchés, et un tri unlocked-first puis par id. Les achievements seedés mais sans listener (BlindTestCorrect, etc.) sont filtrés pour éviter d'afficher des cartes impossibles à débloquer.
- **MOCK_BADGES retiré** : le profil ne contient plus de données mockées, branché sur `GET /api/user-achievements/me`.

## User journey

- [ ] Ouvrir l'onglet Profil → la section "Succès & Récompenses" s'affiche entre Spotify et Activités récentes
- [ ] Pour un nouvel utilisateur sans aucune action : 11 cards verrouillées (🔒) avec 0/X
- [ ] Jouer une partie → certains achievements (FirstGame, GamesPlayed, TotalGamesPlayed, TotalCorrectAnswers) montrent une progression > 0 au retour sur le Profil
- [ ] Liker un titre → FirstLike + TotalLikes se peuplent
- [ ] Atteindre `requiredProgress` → la carte passe en mode débloqué (couleur CTA, icône emoji), remonte en haut de la grille
- [ ] Tap sur une carte → bottom sheet s'ouvre (overlay fade-in + sheet slide-up depuis le bas) avec icône XL, nom, description et état (date relative si débloqué, barre de progression si verrouillé)
- [ ] Tap sur le backdrop OU sur le bouton Fermer → bottom sheet redescend proprement avec fade-out
- [ ] Quitter le Profil puis revenir → `useFocusEffect` rafraîchit la liste

## Tests

- Backend : 710/710 verts, coverage 100% (4 nouveaux tests sur `getUserAchievements`)
- Front-mobile : 18/18 verts sur les nouveaux fichiers (service, hook, modal, section, util)