### PR TITLE
HOTFIX-deezer-quota-cache-crash fix: prevent swipemix crash on deezer quota error body

### DIFF
--- a/front-mobile/hooks/__tests__/useSwipeMix.test.ts
+++ b/front-mobile/hooks/__tests__/useSwipeMix.test.ts
@@ -223,6 +223,27 @@ describe("useSwipeMix", () => {
         "Erreur lors du chargement des musiques",
       );
     });
+
+    it("should still render cards when Deezer genres/album enrichment fails", async () => {
+      // Régression : avant le fix, un échec sur getGenres (cas du quota Deezer
+      // dépassé) faisait crash genresResponse.data.forEach et bloquait tout le
+      // SwipeMix. Maintenant on dégrade gracieusement : cards sans tags.
+      mockDeezerAPI.getGenres.mockRejectedValueOnce(
+        new Error("Quota limit exceeded"),
+      );
+      mockDeezerAPI.getAlbum.mockRejectedValue(
+        new Error("Quota limit exceeded"),
+      );
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.isLoadingCards).toBe(false);
+      });
+
+      expect(result.current.error).toBeNull();
+      expect(result.current.cards).toHaveLength(10);
+    });
   });
 
   describe("swipe handlers", () => {

--- a/front-mobile/hooks/useSwipeMix.ts
+++ b/front-mobile/hooks/useSwipeMix.ts
@@ -10,6 +10,45 @@ import { MusicCardData } from "@/components/swipe";
 import { deezerTracksToCardData } from "@/utils/deezer-adapter";
 import { useAudioPlayer } from "./useAudioPlayer";
 
+const buildGenreMappings = async (
+  feedTracks: DeezerTrack[],
+): Promise<{
+  genreMapping: Record<number, string>;
+  albumGenresMapping: Record<number, string[]>;
+}> => {
+  const genreMapping: Record<number, string> = {};
+  const albumGenresMapping: Record<number, string[]> = {};
+
+  // L'enrichissement de genres est best-effort : si Deezer rate-limit (réponse
+  // 200 OK avec body { error: ... }), on affiche les cartes sans tags plutôt
+  // que de bloquer tout le SwipeMix.
+  const [genresResult, ...albumsResult] = await Promise.allSettled([
+    deezerAPI.getGenres(),
+    ...feedTracks.map((track) => deezerAPI.getAlbum(track.album.id)),
+  ]);
+
+  if (genresResult.status === "fulfilled" && genresResult.value?.data) {
+    genresResult.value.data.forEach((genre) => {
+      genreMapping[genre.id] = genre.name.toUpperCase();
+    });
+  }
+
+  albumsResult.forEach((result) => {
+    if (result.status !== "fulfilled") return;
+    const album = result.value;
+    if (!album) return;
+    if (album.genres && album.genres.data?.length > 0) {
+      albumGenresMapping[album.id] = album.genres.data.map((g) =>
+        g.name.toUpperCase(),
+      );
+    } else if (album.genre_id && genreMapping[album.genre_id]) {
+      albumGenresMapping[album.id] = [genreMapping[album.genre_id]];
+    }
+  });
+
+  return { genreMapping, albumGenresMapping };
+};
+
 interface UseSwipeMixOptions {
   initialLimit?: number;
   onInteractionAttempt?: (action: InteractionAction) => void;
@@ -65,33 +104,9 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
         // Récupérer les morceaux tendances
         const response = await deezerAPI.getTopTracks(initialLimit, indexToUse);
 
-        // Récupérer les genres et les détails des albums (pour avoir le genre_id) en parallèle
-        // Note: deezerAPI utilise déjà le cacheManager
-        const [genresResponse, ...albums] = await Promise.all([
-          deezerAPI.getGenres(),
-          ...response.data.map((track) => deezerAPI.getAlbum(track.album.id)),
-        ]);
-
-        // Créer les mappings pour l'adapter
-        const genreMapping: Record<number, string> = {};
-        genresResponse.data.forEach((genre) => {
-          genreMapping[genre.id] = genre.name.toUpperCase();
-        });
-
-        const albumGenresMapping: Record<number, string[]> = {};
-        albums.forEach((album) => {
-          if (album) {
-            // Si l'album a une liste de genres, on les récupère tous
-            if (album.genres && album.genres.data.length > 0) {
-              albumGenresMapping[album.id] = album.genres.data.map((g) =>
-                g.name.toUpperCase(),
-              );
-            } else if (album.genre_id && genreMapping[album.genre_id]) {
-              // Fallback sur le genre_id principal si la liste est absente
-              albumGenresMapping[album.id] = [genreMapping[album.genre_id]];
-            }
-          }
-        });
+        const { genreMapping, albumGenresMapping } = await buildGenreMappings(
+          response.data,
+        );
 
         // Convertir en cartes avec les informations de genre
         const newCards = deezerTracksToCardData(

--- a/front-mobile/services/__tests__/cache-manager.test.ts
+++ b/front-mobile/services/__tests__/cache-manager.test.ts
@@ -48,6 +48,21 @@ describe("CacheManager", () => {
       const result = await cacheManager.get("corrupted");
       expect(result).toBeNull();
     });
+
+    it("should auto-invalidate entries whose value contains a top-level error key", async () => {
+      // Reproduit le bug Deezer rate-limit : un body { error: { ... } } a été mis
+      // en cache. Sans auto-invalidation, on le sert pendant 24h.
+      const pollutedBody = {
+        error: { type: "Exception", message: "Quota limit exceeded", code: 4 },
+      };
+      await cacheManager.set("genres", pollutedBody, 60000);
+
+      const result = await cacheManager.get("genres");
+      expect(result).toBeNull();
+
+      const stored = await AsyncStorage.getItem("@rythmix_cache:genres");
+      expect(stored).toBeNull();
+    });
   });
 
   describe("set", () => {

--- a/front-mobile/services/__tests__/deezer-api.test.ts
+++ b/front-mobile/services/__tests__/deezer-api.test.ts
@@ -420,6 +420,29 @@ describe("DeezerAPI", () => {
       await expect(deezerAPI.searchTracks("test")).rejects.toThrow();
     });
 
+    it("should throw QUOTA error on 200 OK body with Deezer quota error", async () => {
+      // Régression : Deezer répond parfois 200 OK avec { error: { ... } } lors
+      // d'un quota dépassé. Sans ce garde, l'objet pollue le cache 24h et fait
+      // crash genresResponse.data.forEach.
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          error: {
+            type: "Exception",
+            message: "Quota limit exceeded",
+            code: 4,
+          },
+        }),
+      });
+
+      await expect(deezerAPI.getGenres()).rejects.toMatchObject({
+        statusCode: 429,
+        type: "QUOTA",
+        message: "Quota limit exceeded",
+      });
+    });
+
     it("should handle response without parseable error message", async () => {
       (global.fetch as jest.Mock).mockResolvedValueOnce({
         ok: false,

--- a/front-mobile/services/cache-manager.ts
+++ b/front-mobile/services/cache-manager.ts
@@ -54,6 +54,17 @@ class CacheManager {
         return null;
       }
 
+      // Auto-invalider les entrées polluées par un body d'erreur applicative
+      // (cas Deezer qui répond 200 OK avec { error: { ... } }).
+      if (
+        entry.data &&
+        typeof entry.data === "object" &&
+        "error" in (entry.data as object)
+      ) {
+        await this.remove(key);
+        return null;
+      }
+
       return entry.data;
     } catch (error) {
       console.error("Error getting cache entry:", error);

--- a/front-mobile/services/deezer-api.ts
+++ b/front-mobile/services/deezer-api.ts
@@ -181,7 +181,25 @@ class DeezerAPI {
             );
           }
 
-          return await response.json();
+          const body = await response.json();
+
+          // Deezer renvoie parfois 200 OK avec un body d'erreur applicative,
+          // par exemple { error: { type, message, code } } lors d'un quota dépassé.
+          // Sans ce garde, l'objet pollue le cache et fait planter les consommateurs.
+          if (body && typeof body === "object" && "error" in body) {
+            const errorBody = (
+              body as { error: { message?: string; code?: number } }
+            ).error;
+            const code = errorBody?.code;
+            const message = errorBody?.message ?? "Deezer application error";
+            // Codes Deezer 4 (quota global) et 200 (quota individuel) = rate limit
+            if (code === 4 || code === 200) {
+              throw DeezerAPIError.quota(message);
+            }
+            throw new DeezerAPIError(message, code);
+          }
+
+          return body;
         } catch (error) {
           // Si c'est déjà une DeezerAPIError, la relancer
           if (error instanceof DeezerAPIError) {


### PR DESCRIPTION
## Description

Deezer répond parfois `200 OK` avec un body `{ error: { code: 4, message: "Quota limit exceeded" } }` lors d'un rate-limit. Le client ne vérifiait que `response.ok`, stockait ce body en cache (TTL 24h pour les genres) et le `forEach` crashait sur `undefined` au prochain démarrage — bug persistant tant que le cache n'expirait pas.

Le fix : (1) `fetchWithRetry` détecte le shape `{ error: ... }` Deezer et throw avant la mise en cache, (2) `cacheManager.get()` auto-invalide les entrées polluées déjà présentes chez les utilisateurs, (3) `useSwipeMix` dégrade gracieusement via `Promise.allSettled` — si l'enrichissement genres/albums échoue, les cartes s'affichent sans tags au lieu de tout planter.

## Parcours utilisateur

1. Ouvrir l'app sur l'écran SwipeMix avec un device dont le cache contient déjà une entrée polluée (ou pendant un rate-limit Deezer actif).
2. Vérifier que les cartes s'affichent (avec ou sans tags de genre) — plus de bandeau rouge "Cannot read property 'forEach' of undefined".
3. Swipe gauche / droite : comportement nominal.
4. Au prochain démarrage, le cache pollué est purgé automatiquement → les genres reviennent dès que Deezer remarche.