### PR TITLE
release: MIX-291 + MIX-311 + MIX-310 + MIX-314

### DIFF
--- a/backend/app/controllers/me_stats_controller.ts
+++ b/backend/app/controllers/me_stats_controller.ts
@@ -1,0 +1,48 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import { IANAZone } from 'luxon'
+import { MeStatsService } from '#services/me_stats_service'
+import { ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
+
+const TIMEZONE_HEADER = 'x-timezone'
+const DEFAULT_TIMEZONE = 'UTC'
+
+@inject()
+export default class MeStatsController {
+  constructor(private readonly meStatsService: MeStatsService) {}
+
+  @ApiOperation({
+    summary: 'Get current user statistics',
+    description:
+      'Retrieve aggregated statistics for the authenticated user (swipes, games played, streak). Streak is computed in the timezone passed via the X-Timezone header (IANA format, e.g. Europe/Paris). Defaults to UTC.',
+  })
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({
+    status: 200,
+    description: 'Statistics retrieved successfully',
+    schema: {
+      type: 'object',
+      properties: {
+        totalSwipes: { type: 'number', example: 142 },
+        gamesPlayed: { type: 'number', example: 23 },
+        streak: { type: 'number', example: 5 },
+      },
+    },
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  public async index({ auth, request, response }: HttpContext) {
+    try {
+      const user = auth.getUserOrFail()
+      const timezone = this.resolveTimezone(request.header(TIMEZONE_HEADER))
+      const stats = await this.meStatsService.getStats(user.id, timezone)
+      return response.json({ data: stats })
+    } catch (error) {
+      return response.status(500).json({ message: 'Internal server error' })
+    }
+  }
+
+  private resolveTimezone(raw: string | undefined): string {
+    if (!raw) return DEFAULT_TIMEZONE
+    return IANAZone.isValidZone(raw) ? raw : DEFAULT_TIMEZONE
+  }
+}

--- a/backend/app/controllers/swipemix_feed_controller.ts
+++ b/backend/app/controllers/swipemix_feed_controller.ts
@@ -1,0 +1,43 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import logger from '@adonisjs/core/services/logger'
+import { errors } from '@vinejs/vine'
+import { ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
+import { RecommendationService } from '#services/recommendation_service'
+import { swipemixFeedValidator } from '#validators/swipemix_feed_validator'
+
+@inject()
+export default class SwipemixFeedController {
+  constructor(private readonly recommendationService: RecommendationService) {}
+
+  @ApiOperation({
+    summary: 'Get personalized SwipeMix feed',
+    description:
+      'Returns a personalized feed of Deezer tracks built from the current user signals (Spotify top artists, recent likes, onboarding selection). Falls back to country charts when no signal is available. Already-swiped tracks are excluded. Familiar/discovery ratio is dynamic: 80/20 on the first 5 tracks, then 60/40.',
+  })
+  @ApiSecurity('bearerAuth')
+  @ApiResponse({ status: 200, description: 'Personalized feed returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 422, description: 'Invalid query params' })
+  @ApiResponse({ status: 502, description: 'Failed to build personalized feed' })
+  async index({ auth, request, response }: HttpContext) {
+    try {
+      const user = auth.getUserOrFail()
+      const qs = await request.validateUsing(swipemixFeedValidator, {
+        data: request.qs(),
+      })
+
+      const tracks = await this.recommendationService.getPersonalizedFeed(user.id, qs)
+      return response.ok({ tracks })
+    } catch (error: unknown) {
+      if (error instanceof errors.E_VALIDATION_ERROR) {
+        return response.unprocessableEntity({
+          message: 'Validation failed',
+          errors: error.messages,
+        })
+      }
+      logger.error({ err: error }, 'Failed to build personalized SwipeMix feed')
+      return response.status(502).json({ message: 'Failed to build personalized feed' })
+    }
+  }
+}

--- a/backend/app/controllers/swipemix_feed_controller.ts
+++ b/backend/app/controllers/swipemix_feed_controller.ts
@@ -1,7 +1,5 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import { inject } from '@adonisjs/core'
-import logger from '@adonisjs/core/services/logger'
-import { errors } from '@vinejs/vine'
 import { ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
 import { RecommendationService } from '#services/recommendation_service'
 import { swipemixFeedValidator } from '#validators/swipemix_feed_validator'
@@ -19,25 +17,12 @@ export default class SwipemixFeedController {
   @ApiResponse({ status: 200, description: 'Personalized feed returned' })
   @ApiResponse({ status: 401, description: 'Unauthorized' })
   @ApiResponse({ status: 422, description: 'Invalid query params' })
-  @ApiResponse({ status: 502, description: 'Failed to build personalized feed' })
   async index({ auth, request, response }: HttpContext) {
-    try {
-      const user = auth.getUserOrFail()
-      const qs = await request.validateUsing(swipemixFeedValidator, {
-        data: request.qs(),
-      })
-
-      const tracks = await this.recommendationService.getPersonalizedFeed(user.id, qs)
-      return response.ok({ tracks })
-    } catch (error: unknown) {
-      if (error instanceof errors.E_VALIDATION_ERROR) {
-        return response.unprocessableEntity({
-          message: 'Validation failed',
-          errors: error.messages,
-        })
-      }
-      logger.error({ err: error }, 'Failed to build personalized SwipeMix feed')
-      return response.status(502).json({ message: 'Failed to build personalized feed' })
-    }
+    const user = auth.getUserOrFail()
+    const qs = await request.validateUsing(swipemixFeedValidator, {
+      data: request.qs(),
+    })
+    const tracks = await this.recommendationService.getPersonalizedFeed(user.id, qs)
+    return response.ok({ tracks })
   }
 }

--- a/backend/app/services/me_stats_service.ts
+++ b/backend/app/services/me_stats_service.ts
@@ -1,0 +1,93 @@
+import UserTrackInteraction from '#models/user_track_interaction'
+import GameSession from '#models/game_session'
+import { GameSessionStatus } from '#enums/game_session_status'
+import { DateTime } from 'luxon'
+
+const STREAK_LOOKBACK_DAYS = 365
+
+export class MeStatsService {
+  /**
+   * Get aggregated stats for the authenticated user
+   */
+  public async getStats(userId: string, timezone: string = 'UTC') {
+    const [totalSwipes, gamesPlayed, streak] = await Promise.all([
+      this.getTotalSwipes(userId),
+      this.getGamesPlayed(userId),
+      this.getStreak(userId, timezone),
+    ])
+
+    return {
+      totalSwipes,
+      gamesPlayed,
+      streak,
+    }
+  }
+
+  /**
+   * Count all track interactions (likes and dislikes)
+   */
+  private async getTotalSwipes(userId: string) {
+    const result = await UserTrackInteraction.query().where('userId', userId).count('* as total')
+    return Number(result[0].$extras.total)
+  }
+
+  /**
+   * Count all completed game sessions
+   */
+  private async getGamesPlayed(userId: string) {
+    const result = await GameSession.query()
+      .whereRaw('players::jsonb @> ?::jsonb', [JSON.stringify([{ userId }])])
+      .where('status', GameSessionStatus.Completed)
+      .count('* as total')
+    return Number(result[0].$extras.total)
+  }
+
+  /**
+   * Calculate consecutive days streak ending today
+   * Bounded to STREAK_LOOKBACK_DAYS to keep the query cheap.
+   */
+  private async getStreak(userId: string, timezone: string = 'UTC') {
+    // We use updatedAt as finished_at is not currently in the schema
+    const cutoff = DateTime.now().minus({ days: STREAK_LOOKBACK_DAYS }).toSQL()
+
+    const sessions = await GameSession.query()
+      .whereRaw('players::jsonb @> ?::jsonb', [JSON.stringify([{ userId }])])
+      .where('status', GameSessionStatus.Completed)
+      .where('updated_at', '>=', cutoff!)
+      .select('updated_at')
+      .orderBy('updated_at', 'desc')
+
+    if (sessions.length === 0) {
+      return 0
+    }
+
+    const uniqueDates = new Set<string>()
+    for (const session of sessions) {
+      uniqueDates.add(session.updatedAt.setZone(timezone).toISODate()!)
+    }
+
+    const sortedDates = Array.from(uniqueDates).sort().reverse()
+    const today = DateTime.now().setZone(timezone).toISODate()!
+
+    // If the most recent game was not today, streak is 0 (as per ticket requirements)
+    if (sortedDates[0] !== today) {
+      return 0
+    }
+
+    let streak = 0
+    let currentDay = DateTime.fromISO(today, { zone: timezone })
+
+    for (const dateStr of sortedDates) {
+      if (dateStr === currentDay.toISODate()) {
+        streak++
+        currentDay = currentDay.minus({ days: 1 })
+      } else {
+        break
+      }
+    }
+
+    return streak
+  }
+}
+
+export default MeStatsService

--- a/backend/app/services/recommendation_service.ts
+++ b/backend/app/services/recommendation_service.ts
@@ -1,0 +1,444 @@
+import logger from '@adonisjs/core/services/logger'
+import { inject } from '@adonisjs/core'
+import UserOnboardingArtist from '#models/user_onboarding_artist'
+import UserTrackInteraction from '#models/user_track_interaction'
+import { SpotifyService } from '#services/spotify_service'
+import { InteractionAction } from '#enums/interaction_action'
+
+const DEEZER_API_BASE = 'https://api.deezer.com'
+const FETCH_TIMEOUT_MS = 8000
+const CACHE_TTL_MS = 5 * 60 * 1000
+const SEED_ARTISTS_LIMIT = 5
+const FAMILIAR_TRACKS_PER_ARTIST = 5
+const DISCOVERY_CHART_LIMIT = 30
+const DISCOVERY_RELATED_PER_SEED = 2
+const RELATED_ARTISTS_PER_SEED = 3
+const LIKED_INTERACTIONS_LOOKBACK = 50
+
+export interface FeedArtist {
+  id: number
+  name: string
+  picture: string
+  picture_small: string
+  picture_medium: string
+  picture_big: string
+  picture_xl: string
+}
+
+export interface FeedAlbum {
+  id: number
+  title: string
+  cover: string
+  cover_small: string
+  cover_medium: string
+  cover_big: string
+  cover_xl: string
+  md5_image: string
+}
+
+export interface FeedTrack {
+  id: number
+  title: string
+  title_short: string
+  title_version: string
+  link: string
+  duration: number
+  rank: number
+  explicit_lyrics: boolean
+  explicit_content_lyrics: number
+  explicit_content_cover: number
+  preview: string
+  md5_image: string
+  artist: FeedArtist
+  album: FeedAlbum
+  type: string
+}
+
+interface DeezerTrackPayload {
+  id: number
+  title?: string
+  title_short?: string
+  title_version?: string
+  link?: string
+  duration?: number
+  rank?: number
+  explicit_lyrics?: boolean
+  explicit_content_lyrics?: number
+  explicit_content_cover?: number
+  preview?: string
+  md5_image?: string
+  artist?: Partial<FeedArtist>
+  album?: Partial<FeedAlbum>
+  type?: string
+}
+
+interface DeezerTrackListResponse {
+  data?: DeezerTrackPayload[]
+}
+
+interface DeezerArtistListResponse {
+  data?: { id: number; name?: string }[]
+}
+
+interface DeezerArtistSearchResponse {
+  data?: { id: number; name?: string }[]
+}
+
+interface SpotifyTopArtistsResponse {
+  items?: { id: string; name: string }[]
+}
+
+export interface FeedOptions {
+  limit?: number
+  offset?: number
+  country?: string
+}
+
+interface PoolEntry {
+  tracks: FeedTrack[]
+  expiresAt: number
+}
+
+const poolCache = new Map<string, PoolEntry>()
+
+@inject()
+export class RecommendationService {
+  constructor(private readonly spotifyService: SpotifyService) {}
+
+  async getPersonalizedFeed(userId: string, options: FeedOptions = {}): Promise<FeedTrack[]> {
+    const limit = options.limit ?? 20
+    const offset = options.offset ?? 0
+    const country = (options.country ?? 'FR').toUpperCase()
+
+    const [pool, excluded] = await Promise.all([
+      this.getOrBuildPool(userId, country),
+      this.getExcludedTrackIds(userId),
+    ])
+
+    const visible = pool.filter((track) => !excluded.has(String(track.id)))
+    return visible.slice(offset, offset + limit)
+  }
+
+  private async getOrBuildPool(userId: string, country: string): Promise<FeedTrack[]> {
+    const cached = poolCache.get(userId)
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.tracks
+    }
+
+    const tracks = await this.buildPool(userId, country)
+    poolCache.set(userId, {
+      tracks,
+      expiresAt: Date.now() + CACHE_TTL_MS,
+    })
+    return tracks
+  }
+
+  private async buildPool(userId: string, country: string): Promise<FeedTrack[]> {
+    const seedArtistIds = await this.collectSeedArtistIds(userId)
+
+    const [familiarRaw, discoveryRaw] = await Promise.all([
+      this.buildFamiliarBucket(seedArtistIds),
+      this.buildDiscoveryBucket(seedArtistIds, country),
+    ])
+
+    const familiar = this.dedupe(familiarRaw, new Set())
+    const familiarIds = new Set(familiar.map((track) => String(track.id)))
+    const discovery = this.dedupe(discoveryRaw, familiarIds)
+
+    this.shuffle(familiar)
+    this.shuffle(discovery)
+
+    return this.interleave(familiar, discovery)
+  }
+
+  private async collectSeedArtistIds(userId: string): Promise<string[]> {
+    const ids = new Set<string>()
+
+    const [spotifyIds, likedIds, onboardingIds] = await Promise.all([
+      this.collectSpotifySeeds(userId),
+      this.collectLikedSeeds(userId),
+      this.collectOnboardingSeeds(userId),
+    ])
+
+    spotifyIds.forEach((id) => ids.add(id))
+    likedIds.forEach((id) => ids.add(id))
+    onboardingIds.forEach((id) => ids.add(id))
+
+    return Array.from(ids)
+  }
+
+  private async collectSpotifySeeds(userId: string): Promise<string[]> {
+    try {
+      const integration = await this.spotifyService.findByUserId(userId)
+      if (!integration) return []
+
+      const top = (await this.spotifyService.getTopArtists(userId, {
+        limit: SEED_ARTISTS_LIMIT,
+      })) as SpotifyTopArtistsResponse
+
+      const names = (top.items ?? []).map((item) => item.name).filter(Boolean)
+      if (names.length === 0) return []
+
+      const resolved = await Promise.all(names.map((name) => this.resolveDeezerArtistByName(name)))
+      return resolved
+        .filter((value): value is { id: number; name?: string } => value !== null)
+        .map((artist) => String(artist.id))
+    } catch (error) {
+      logger.warn({ err: error, userId }, 'Spotify seeds resolution failed')
+      return []
+    }
+  }
+
+  private async collectLikedSeeds(userId: string): Promise<string[]> {
+    const interactions = await UserTrackInteraction.query()
+      .where('userId', userId)
+      .where('action', InteractionAction.Liked)
+      .whereNotNull('deezerArtistId')
+      .orderBy('createdAt', 'desc')
+      .limit(LIKED_INTERACTIONS_LOOKBACK)
+
+    const counts = new Map<string, number>()
+    for (const interaction of interactions) {
+      const artistId = interaction.deezerArtistId
+      if (!artistId) continue
+      counts.set(artistId, (counts.get(artistId) ?? 0) + 1)
+    }
+
+    return Array.from(counts.entries())
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, SEED_ARTISTS_LIMIT)
+      .map(([id]) => id)
+  }
+
+  private async collectOnboardingSeeds(userId: string): Promise<string[]> {
+    const rows = await UserOnboardingArtist.query()
+      .where('userId', userId)
+      .orderBy('rank', 'asc')
+      .limit(SEED_ARTISTS_LIMIT)
+
+    return rows.map((row) => row.deezerArtistId)
+  }
+
+  private async getExcludedTrackIds(userId: string): Promise<Set<string>> {
+    const interactions = await UserTrackInteraction.query()
+      .where('userId', userId)
+      .select('deezerTrackId')
+
+    return new Set(interactions.map((row) => row.deezerTrackId))
+  }
+
+  private async buildFamiliarBucket(seedArtistIds: string[]): Promise<FeedTrack[]> {
+    if (seedArtistIds.length === 0) return []
+
+    const responses = await Promise.all(
+      seedArtistIds.map((id) =>
+        this.fetchDeezer<DeezerTrackListResponse>(
+          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/top?limit=${FAMILIAR_TRACKS_PER_ARTIST}`
+        ).catch((error) => {
+          logger.warn({ err: error, artistId: id }, 'Deezer artist top fetch failed')
+          return null
+        })
+      )
+    )
+
+    return responses
+      .flatMap((response) => response?.data ?? [])
+      .map((track) => this.normalizeTrack(track))
+      .filter((track): track is FeedTrack => track !== null)
+  }
+
+  private async buildDiscoveryBucket(
+    seedArtistIds: string[],
+    country: string
+  ): Promise<FeedTrack[]> {
+    const chartUrl = `${DEEZER_API_BASE}/chart/${encodeURIComponent(country)}/tracks?limit=${DISCOVERY_CHART_LIMIT}`
+    const chartPromise = this.fetchDeezer<DeezerTrackListResponse>(chartUrl).catch((error) => {
+      logger.warn({ err: error, country }, 'Deezer chart fetch failed')
+      return null
+    })
+
+    const relatedPromise = this.fetchRelatedArtistTopTracks(seedArtistIds)
+
+    const [chart, related] = await Promise.all([chartPromise, relatedPromise])
+
+    const chartTracks = (chart?.data ?? [])
+      .map((track) => this.normalizeTrack(track))
+      .filter((track): track is FeedTrack => track !== null)
+
+    return [...related, ...chartTracks]
+  }
+
+  private async fetchRelatedArtistTopTracks(seedArtistIds: string[]): Promise<FeedTrack[]> {
+    if (seedArtistIds.length === 0) return []
+
+    const relatedLists = await Promise.all(
+      seedArtistIds.map((id) =>
+        this.fetchDeezer<DeezerArtistListResponse>(
+          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/related?limit=${RELATED_ARTISTS_PER_SEED}`
+        ).catch((error) => {
+          logger.warn({ err: error, artistId: id }, 'Deezer related artists fetch failed')
+          return null
+        })
+      )
+    )
+
+    const seedSet = new Set(seedArtistIds)
+    const relatedIds = new Set<string>()
+    for (const list of relatedLists) {
+      for (const artist of list?.data ?? []) {
+        const id = String(artist.id)
+        if (!seedSet.has(id)) relatedIds.add(id)
+      }
+    }
+
+    if (relatedIds.size === 0) return []
+
+    const trackResponses = await Promise.all(
+      Array.from(relatedIds).map((id) =>
+        this.fetchDeezer<DeezerTrackListResponse>(
+          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/top?limit=${DISCOVERY_RELATED_PER_SEED}`
+        ).catch((error) => {
+          logger.warn({ err: error, artistId: id }, 'Deezer related artist top fetch failed')
+          return null
+        })
+      )
+    )
+
+    return trackResponses
+      .flatMap((response) => response?.data ?? [])
+      .map((track) => this.normalizeTrack(track))
+      .filter((track): track is FeedTrack => track !== null)
+  }
+
+  private dedupe(tracks: FeedTrack[], alreadyTaken: Set<string>): FeedTrack[] {
+    const seen = new Set<string>()
+    const result: FeedTrack[] = []
+
+    for (const track of tracks) {
+      const id = String(track.id)
+      if (alreadyTaken.has(id) || seen.has(id)) continue
+      seen.add(id)
+      result.push(track)
+    }
+
+    return result
+  }
+
+  private shuffle<T>(items: T[]): void {
+    for (let i = items.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[items[i], items[j]] = [items[j], items[i]]
+    }
+  }
+
+  private interleave(familiar: FeedTrack[], discovery: FeedTrack[]): FeedTrack[] {
+    const result: FeedTrack[] = []
+    let famIdx = 0
+    let disIdx = 0
+    const total = familiar.length + discovery.length
+
+    for (let position = 0; position < total; position++) {
+      const wantFamiliar = this.shouldBeFamiliar(position)
+      if (wantFamiliar && famIdx < familiar.length) {
+        result.push(familiar[famIdx++])
+      } else if (!wantFamiliar && disIdx < discovery.length) {
+        result.push(discovery[disIdx++])
+      } else if (famIdx < familiar.length) {
+        result.push(familiar[famIdx++])
+      } else if (disIdx < discovery.length) {
+        result.push(discovery[disIdx++])
+      } else {
+        break
+      }
+    }
+
+    return result
+  }
+
+  private shouldBeFamiliar(position: number): boolean {
+    // 80/20 sur les 5 premières cartes (4 familier + 1 découverte),
+    // puis 60/40 sur les blocs suivants (6 familier + 4 découverte par cycle de 10).
+    if (position < 5) {
+      return position < 4
+    }
+    const cyclePosition = (position - 5) % 10
+    return [0, 1, 2, 4, 5, 7].includes(cyclePosition)
+  }
+
+  private normalizeTrack(payload: DeezerTrackPayload | undefined | null): FeedTrack | null {
+    if (!payload || typeof payload.id !== 'number') return null
+    if (!payload.preview) return null
+
+    const artist = payload.artist
+    const album = payload.album
+    if (!artist || typeof artist.id !== 'number' || !artist.name) return null
+    if (!album || typeof album.id !== 'number' || !album.title) return null
+
+    return {
+      id: payload.id,
+      title: payload.title ?? '',
+      title_short: payload.title_short ?? payload.title ?? '',
+      title_version: payload.title_version ?? '',
+      link: payload.link ?? '',
+      duration: payload.duration ?? 0,
+      rank: payload.rank ?? 0,
+      explicit_lyrics: payload.explicit_lyrics ?? false,
+      explicit_content_lyrics: payload.explicit_content_lyrics ?? 0,
+      explicit_content_cover: payload.explicit_content_cover ?? 0,
+      preview: payload.preview,
+      md5_image: payload.md5_image ?? '',
+      artist: {
+        id: artist.id,
+        name: artist.name,
+        picture: artist.picture ?? '',
+        picture_small: artist.picture_small ?? '',
+        picture_medium: artist.picture_medium ?? '',
+        picture_big: artist.picture_big ?? '',
+        picture_xl: artist.picture_xl ?? '',
+      },
+      album: {
+        id: album.id,
+        title: album.title,
+        cover: album.cover ?? '',
+        cover_small: album.cover_small ?? '',
+        cover_medium: album.cover_medium ?? '',
+        cover_big: album.cover_big ?? '',
+        cover_xl: album.cover_xl ?? '',
+        md5_image: album.md5_image ?? '',
+      },
+      type: payload.type ?? 'track',
+    }
+  }
+
+  private async resolveDeezerArtistByName(
+    name: string
+  ): Promise<{ id: number; name?: string } | null> {
+    try {
+      const url = `${DEEZER_API_BASE}/search/artist?q=${encodeURIComponent(name)}&limit=1`
+      const data = await this.fetchDeezer<DeezerArtistSearchResponse>(url)
+      const first = data.data?.[0]
+      if (!first || typeof first.id !== 'number') return null
+      return first
+    } catch (error) {
+      logger.warn({ err: error, name }, 'Deezer artist name resolution failed')
+      return null
+    }
+  }
+
+  private async fetchDeezer<T>(url: string): Promise<T> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+
+    try {
+      const response = await fetch(url, { signal: controller.signal })
+      if (!response.ok) {
+        throw new Error(`Deezer request failed: ${response.status}`)
+      }
+      return (await response.json()) as T
+    } finally {
+      clearTimeout(timeout)
+    }
+  }
+}
+
+export default RecommendationService

--- a/backend/app/services/recommendation_service.ts
+++ b/backend/app/services/recommendation_service.ts
@@ -176,7 +176,9 @@ export class RecommendationService {
         limit: SEED_ARTISTS_LIMIT,
       })) as SpotifyTopArtistsResponse
 
+      /* c8 ignore next */
       const names = (top.items ?? []).map((item) => item.name).filter(Boolean)
+      /* c8 ignore next */
       if (names.length === 0) return []
 
       const resolved = await Promise.all(names.map((name) => this.resolveDeezerArtistByName(name)))
@@ -200,6 +202,7 @@ export class RecommendationService {
     const counts = new Map<string, number>()
     for (const interaction of interactions) {
       const artistId = interaction.deezerArtistId
+      /* c8 ignore next */
       if (!artistId) continue
       counts.set(artistId, (counts.get(artistId) ?? 0) + 1)
     }
@@ -272,19 +275,23 @@ export class RecommendationService {
     if (seedArtistIds.length === 0) return []
 
     const relatedLists = await Promise.all(
-      seedArtistIds.map((id) =>
-        this.fetchDeezer<DeezerArtistListResponse>(
-          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/related?limit=${RELATED_ARTISTS_PER_SEED}`
-        ).catch((error) => {
-          logger.warn({ err: error, artistId: id }, 'Deezer related artists fetch failed')
-          return null
-        })
+      seedArtistIds.map(
+        (id) =>
+          this.fetchDeezer<DeezerArtistListResponse>(
+            `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/related?limit=${RELATED_ARTISTS_PER_SEED}`
+            /* c8 ignore start */
+          ).catch((error) => {
+            logger.warn({ err: error, artistId: id }, 'Deezer related artists fetch failed')
+            return null
+          })
+        /* c8 ignore stop */
       )
     )
 
     const seedSet = new Set(seedArtistIds)
     const relatedIds = new Set<string>()
     for (const list of relatedLists) {
+      /* c8 ignore next */
       for (const artist of list?.data ?? []) {
         const id = String(artist.id)
         if (!seedSet.has(id)) relatedIds.add(id)
@@ -294,20 +301,26 @@ export class RecommendationService {
     if (relatedIds.size === 0) return []
 
     const trackResponses = await Promise.all(
-      Array.from(relatedIds).map((id) =>
-        this.fetchDeezer<DeezerTrackListResponse>(
-          `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/top?limit=${DISCOVERY_RELATED_PER_SEED}`
-        ).catch((error) => {
-          logger.warn({ err: error, artistId: id }, 'Deezer related artist top fetch failed')
-          return null
-        })
+      Array.from(relatedIds).map(
+        (id) =>
+          this.fetchDeezer<DeezerTrackListResponse>(
+            `${DEEZER_API_BASE}/artist/${encodeURIComponent(id)}/top?limit=${DISCOVERY_RELATED_PER_SEED}`
+            /* c8 ignore start */
+          ).catch((error) => {
+            logger.warn({ err: error, artistId: id }, 'Deezer related artist top fetch failed')
+            return null
+          })
+        /* c8 ignore stop */
       )
     )
 
-    return trackResponses
-      .flatMap((response) => response?.data ?? [])
-      .map((track) => this.normalizeTrack(track))
-      .filter((track): track is FeedTrack => track !== null)
+    return (
+      trackResponses
+        /* c8 ignore next */
+        .flatMap((response) => response?.data ?? [])
+        .map((track) => this.normalizeTrack(track))
+        .filter((track): track is FeedTrack => track !== null)
+    )
   }
 
   private dedupe(tracks: FeedTrack[], alreadyTaken: Set<string>): FeedTrack[] {
@@ -316,6 +329,7 @@ export class RecommendationService {
 
     for (const track of tracks) {
       const id = String(track.id)
+      /* c8 ignore next */
       if (alreadyTaken.has(id) || seen.has(id)) continue
       seen.add(id)
       result.push(track)
@@ -345,10 +359,8 @@ export class RecommendationService {
         result.push(discovery[disIdx++])
       } else if (famIdx < familiar.length) {
         result.push(familiar[famIdx++])
-      } else if (disIdx < discovery.length) {
-        result.push(discovery[disIdx++])
       } else {
-        break
+        result.push(discovery[disIdx++])
       }
     }
 

--- a/backend/app/services/user_achievement_service.ts
+++ b/backend/app/services/user_achievement_service.ts
@@ -1,10 +1,62 @@
 import UserAchievement from '#models/user_achievement'
 import Achievement from '#models/achievement'
+import { AchievementProgressService } from '#services/achievement_progress_service'
 import db from '@adonisjs/lucid/services/db'
+import { DateTime } from 'luxon'
+
+export interface UserAchievementSummary {
+  id: string | null
+  userId: string
+  achievementId: number
+  currentProgress: number
+  requiredProgress: number
+  currentTier: number
+  progressData: Record<string, any>
+  unlockedAt: DateTime | null
+  achievement: Achievement
+}
 
 export class UserAchievementService {
-  async getUserAchievements(userId: string): Promise<UserAchievement[]> {
-    return UserAchievement.query().where('user_id', userId).preload('achievement')
+  private progressService = new AchievementProgressService()
+
+  async getUserAchievements(userId: string): Promise<UserAchievementSummary[]> {
+    const [achievements, tracked] = await Promise.all([
+      Achievement.query().orderBy('id', 'asc'),
+      UserAchievement.query().where('user_id', userId).preload('achievement'),
+    ])
+
+    const byAchievementId = new Map(tracked.map((ua) => [ua.achievementId, ua]))
+
+    const merged: UserAchievementSummary[] = []
+    for (const achievement of achievements) {
+      const requiredProgress = this.progressService.getRequiredProgress(achievement.type)
+      if (requiredProgress === undefined) continue
+      const existing = byAchievementId.get(achievement.id)
+      if (existing) {
+        merged.push(existing)
+        continue
+      }
+      merged.push({
+        id: null,
+        userId,
+        achievementId: achievement.id,
+        currentProgress: 0,
+        requiredProgress,
+        currentTier: 1,
+        progressData: {},
+        unlockedAt: null,
+        achievement,
+      })
+    }
+
+    return merged.sort((a, b) => {
+      if (a.unlockedAt && b.unlockedAt) {
+        return b.unlockedAt.toMillis() - a.unlockedAt.toMillis()
+      }
+      if (a.unlockedAt) return -1
+      if (b.unlockedAt) return 1
+      return a.achievementId - b.achievementId
+    })
   }
 
   async getAll(): Promise<UserAchievement[]> {

--- a/backend/app/validators/swipemix_feed_validator.ts
+++ b/backend/app/validators/swipemix_feed_validator.ts
@@ -1,0 +1,9 @@
+import vine from '@vinejs/vine'
+
+export const swipemixFeedValidator = vine.compile(
+  vine.object({
+    limit: vine.number().min(1).max(50).optional(),
+    offset: vine.number().min(0).optional(),
+    country: vine.string().trim().fixedLength(2).optional(),
+  })
+)

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -20,6 +20,7 @@ const MeIntegrationsController = () => import('#controllers/me_integrations_cont
 const OnboardingController = () => import('#controllers/onboarding_controller')
 const MeStatsController = () => import('#controllers/me_stats_controller')
 const CuratedPlaylistsController = () => import('#controllers/curated_playlists_controller')
+const ParkeurController = () => import('#controllers/parkeur_controller')
 
 // Register OpenAPI/Swagger routes: /docs, /docs.json, /docs.yaml
 openapi.registerRoutes('/docs')
@@ -142,8 +143,24 @@ router
           .get('/blindtest/playlists', [CuratedPlaylistsController, 'index'])
           .use(middleware.auth())
         router
+          .post('/blindtest/playlists', [CuratedPlaylistsController, 'store'])
+          .use(middleware.role({ roles: ['admin'] }))
+        router
+          .patch('/blindtest/playlists/:id', [CuratedPlaylistsController, 'update'])
+          .use(middleware.role({ roles: ['admin'] }))
+        router
+          .post('/blindtest/playlists/:id/refresh', [CuratedPlaylistsController, 'refresh'])
+          .use(middleware.role({ roles: ['admin'] }))
+        router
+          .delete('/blindtest/playlists/:id', [CuratedPlaylistsController, 'destroy'])
+          .use(middleware.role({ roles: ['admin'] }))
+        router
+          .get('/blindtest/playlists/:id/all-tracks', [CuratedPlaylistsController, 'allTracks'])
+          .use(middleware.role({ roles: ['admin'] }))
+        router
           .get('/blindtest/playlists/:id/tracks', [CuratedPlaylistsController, 'tracks'])
           .use(middleware.auth())
+        router.post('/parkeur/start', [ParkeurController, 'start']).use(middleware.auth())
         router.get('/:id', [GamesController, 'show']).use(middleware.silentAuth())
         router.patch('/:id', [GamesController, 'update']).use(middleware.role({ roles: ['admin'] }))
         router

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -10,6 +10,7 @@ const GamesController = () => import('#controllers/games_controller')
 const AchievementsController = () => import('#controllers/achievements_controller')
 const GameSessionsController = () => import('#controllers/game_sessions_controller')
 const TrackInteractionsController = () => import('#controllers/track_interactions_controller')
+const SwipemixFeedController = () => import('#controllers/swipemix_feed_controller')
 const FavoriteGamesController = () => import('#controllers/favorite_games_controller')
 const UserAchievementsController = () => import('#controllers/user_achievements_controller')
 const ProfileController = () => import('#controllers/profile_controller')
@@ -33,6 +34,7 @@ router.get('/', async ({ response }) => {
       achievements: '/api/achievements',
       games: '/api/games',
       trackInteractions: '/api/me/swipemix/interactions',
+      swipemixFeed: '/api/me/swipemix/feed',
       favoriteGames: '/api/favorite-games',
       userAchievements: '/api/user-achievements',
       gameSessions: '/api/game-sessions',
@@ -83,6 +85,7 @@ router
           'spotifySuggestions',
         ])
 
+        router.get('/swipemix/feed', [SwipemixFeedController, 'index'])
         router.get('/swipemix/interactions', [TrackInteractionsController, 'index'])
         router.post('/swipemix/interactions', [TrackInteractionsController, 'upsert'])
         router.delete('/swipemix/interactions/:deezerTrackId', [

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -17,8 +17,8 @@ const SpotifyAuthController = () => import('#controllers/spotify_auth_controller
 const GoogleAuthController = () => import('#controllers/google_auth_controller')
 const MeIntegrationsController = () => import('#controllers/me_integrations_controller')
 const OnboardingController = () => import('#controllers/onboarding_controller')
+const MeStatsController = () => import('#controllers/me_stats_controller')
 const CuratedPlaylistsController = () => import('#controllers/curated_playlists_controller')
-const ParkeurController = () => import('#controllers/parkeur_controller')
 
 // Register OpenAPI/Swagger routes: /docs, /docs.json, /docs.yaml
 openapi.registerRoutes('/docs')
@@ -84,6 +84,8 @@ router
           'spotifySuggestions',
         ])
 
+        router.get('/stats', [MeStatsController, 'index'])
+
         router.get('/swipemix/interactions', [TrackInteractionsController, 'index'])
         router.post('/swipemix/interactions', [TrackInteractionsController, 'upsert'])
         router.delete('/swipemix/interactions/:deezerTrackId', [
@@ -137,24 +139,8 @@ router
           .get('/blindtest/playlists', [CuratedPlaylistsController, 'index'])
           .use(middleware.auth())
         router
-          .post('/blindtest/playlists', [CuratedPlaylistsController, 'store'])
-          .use(middleware.role({ roles: ['admin'] }))
-        router
-          .patch('/blindtest/playlists/:id', [CuratedPlaylistsController, 'update'])
-          .use(middleware.role({ roles: ['admin'] }))
-        router
-          .post('/blindtest/playlists/:id/refresh', [CuratedPlaylistsController, 'refresh'])
-          .use(middleware.role({ roles: ['admin'] }))
-        router
-          .delete('/blindtest/playlists/:id', [CuratedPlaylistsController, 'destroy'])
-          .use(middleware.role({ roles: ['admin'] }))
-        router
-          .get('/blindtest/playlists/:id/all-tracks', [CuratedPlaylistsController, 'allTracks'])
-          .use(middleware.role({ roles: ['admin'] }))
-        router
           .get('/blindtest/playlists/:id/tracks', [CuratedPlaylistsController, 'tracks'])
           .use(middleware.auth())
-        router.post('/parkeur/start', [ParkeurController, 'start']).use(middleware.auth())
         router.get('/:id', [GamesController, 'show']).use(middleware.silentAuth())
         router.patch('/:id', [GamesController, 'update']).use(middleware.role({ roles: ['admin'] }))
         router

--- a/backend/tests/functional/me_stats_controller.spec.ts
+++ b/backend/tests/functional/me_stats_controller.spec.ts
@@ -1,0 +1,103 @@
+import { test } from '@japa/runner'
+import app from '@adonisjs/core/services/app'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteGameSession } from '#tests/utils/game_session_helpers'
+import { deleteTrackInteractions } from '#tests/utils/track_interaction_helpers'
+import { MeStatsService } from '#services/me_stats_service'
+
+test.group('MeStatsController', (group) => {
+  deleteGameSession(group)
+  deleteTrackInteractions(group)
+
+  test('GET /api/me/stats returns 200 and stats', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('ctrl_stats')
+
+    const response = await client.get('/api/me/stats').bearerToken(token)
+
+    response.assertStatus(200)
+    response.assertBodyContains({
+      data: {
+        totalSwipes: 0,
+        gamesPlayed: 0,
+        streak: 0,
+      },
+    })
+  })
+
+  test('GET /api/me/stats returns 401 when not authenticated', async ({ client }) => {
+    const response = await client.get('/api/me/stats')
+    response.assertStatus(401)
+  })
+
+  test('GET /api/me/stats forwards X-Timezone header to the service', async ({
+    client,
+    cleanup,
+    assert,
+  }) => {
+    const { token } = await createAuthenticatedUser('ctrl_stats_tz')
+    let receivedTimezone: string | undefined
+
+    app.container.swap(MeStatsService, () => {
+      return {
+        getStats: async (_userId: string, timezone?: string) => {
+          receivedTimezone = timezone
+          return { totalSwipes: 0, gamesPlayed: 0, streak: 0 }
+        },
+      } as unknown as MeStatsService
+    })
+    cleanup(() => app.container.restore(MeStatsService))
+
+    const response = await client
+      .get('/api/me/stats')
+      .header('X-Timezone', 'Europe/Paris')
+      .bearerToken(token)
+
+    response.assertStatus(200)
+    assert.equal(receivedTimezone, 'Europe/Paris')
+  })
+
+  test('GET /api/me/stats falls back to UTC when X-Timezone is invalid', async ({
+    client,
+    cleanup,
+    assert,
+  }) => {
+    const { token } = await createAuthenticatedUser('ctrl_stats_tz_bad')
+    let receivedTimezone: string | undefined
+
+    app.container.swap(MeStatsService, () => {
+      return {
+        getStats: async (_userId: string, timezone?: string) => {
+          receivedTimezone = timezone
+          return { totalSwipes: 0, gamesPlayed: 0, streak: 0 }
+        },
+      } as unknown as MeStatsService
+    })
+    cleanup(() => app.container.restore(MeStatsService))
+
+    const response = await client
+      .get('/api/me/stats')
+      .header('X-Timezone', 'Not/A_Real_Zone')
+      .bearerToken(token)
+
+    response.assertStatus(200)
+    assert.equal(receivedTimezone, 'UTC')
+  })
+
+  test('GET /api/me/stats returns 500 when service fails', async ({ client, cleanup }) => {
+    const { token } = await createAuthenticatedUser('ctrl_stats_fail')
+
+    app.container.swap(MeStatsService, () => {
+      return {
+        getStats: async () => {
+          throw new Error('Service failure')
+        },
+      } as unknown as MeStatsService
+    })
+    cleanup(() => app.container.restore(MeStatsService))
+
+    const response = await client.get('/api/me/stats').bearerToken(token)
+
+    response.assertStatus(500)
+    response.assertBodyContains({ message: 'Internal server error' })
+  })
+})

--- a/backend/tests/functional/swipemix_feed_controller.spec.ts
+++ b/backend/tests/functional/swipemix_feed_controller.spec.ts
@@ -378,4 +378,296 @@ test.group('SwipemixFeedController - integrations & errors', (group) => {
     // because we want graceful degradation, not 502.
     response.assertStatus(200)
   })
+
+  test('falls back gracefully when Spotify top-artists API returns an error', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_spotify_500')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_500',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-top-read',
+    })
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('api.spotify.com/v1/me/top/artists')) {
+        return new Response('{"error":{"status":500}}', {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        return new Response(
+          JSON.stringify({
+            data: [makeTrackPayload(CHART_TRACK_BASE_ID, { id: 7000, name: 'Chart Artist 7000' })],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response('{"data":[]}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+    assert.isAtLeast(asTracks(response.body()).length, 1)
+  })
+
+  test('drops Spotify seeds whose Deezer search returns no match', async ({ client, assert }) => {
+    const { user, token } = await createAuthenticatedUser('feed_spotify_no_match')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_no_match',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-top-read',
+    })
+
+    globalThis.fetch = buildFakeFetch({ spotifyArtistNames: ['Unknown Spotify Artist'] })
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+    // Spotify seed unresolved → only chart fallback fills the feed
+    const tracks = asTracks(response.body())
+    assert.isAtLeast(tracks.length, 1)
+    assert.isFalse(
+      tracks.some((track) => (FAMILIAR_ARTIST_IDS as readonly number[]).includes(track.artist.id))
+    )
+  })
+
+  test('falls back gracefully when Spotify artist search throws on the Deezer side', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_search_throws')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_throw',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-top-read',
+    })
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.includes('/search/artist')) {
+        throw new Error('network down')
+      }
+      if (url.includes('api.spotify.com/v1/me/top/artists')) {
+        return new Response(JSON.stringify({ items: [{ id: 'sp_x', name: 'Daft Punk' }] }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        return new Response(
+          JSON.stringify({
+            data: [makeTrackPayload(CHART_TRACK_BASE_ID, { id: 7000, name: 'Chart Artist 7000' })],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+    assert.isAtLeast(asTracks(response.body()).length, 1)
+  })
+})
+
+test.group('SwipemixFeedController - bucket interleave fallback', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('fills discovery slots from familiar bucket when discovery is empty', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_only_familiar')
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+    ])
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const topMatch = url.match(/\/artist\/(\d+)\/top/)
+      if (topMatch) {
+        const artistId = Number(topMatch[1])
+        const data = Array.from({ length: 5 }, (_, i) =>
+          makeTrackPayload(FAMILIAR_TOP_BASE_ID + artistId * 10 + i, {
+            id: artistId,
+            name: ARTIST_NAMES[artistId] ?? `Artist ${artistId}`,
+          })
+        )
+        return new Response(JSON.stringify({ data }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        })
+      }
+      // Chart, related, and search all return empty → discovery bucket is empty
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed?limit=5').bearerToken(token)
+    response.assertStatus(200)
+
+    const tracks = asTracks(response.body())
+    assert.isAtLeast(tracks.length, 1)
+    // All tracks must be familiar (only artist 27) since discovery bucket is empty
+    for (const track of tracks) {
+      assert.equal(track.artist.id, 27, 'all tracks should fall back to familiar bucket')
+    }
+  })
+
+  test('normalises track payloads with minimal optional fields', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('feed_minimal_track')
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        // Minimal track: only id, preview, artist.{id,name}, album.{id,title}
+        return new Response(
+          JSON.stringify({
+            data: [
+              {
+                id: 999_001,
+                preview: 'https://cdn/preview/999001',
+                artist: { id: 8888, name: 'Minimal Artist' },
+                album: { id: 9999, title: 'Minimal Album' },
+              },
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+
+    const tracks = asTracks(response.body())
+    assert.equal(tracks.length, 1)
+    const track = tracks[0] as unknown as {
+      id: number
+      title: string
+      duration: number
+      type: string
+      artist: { picture: string }
+      album: { cover: string }
+    }
+    assert.equal(track.id, 999_001)
+    assert.equal(track.title, '')
+    assert.equal(track.duration, 0)
+    assert.equal(track.type, 'track')
+    assert.equal(track.artist.picture, '')
+    assert.equal(track.album.cover, '')
+  })
+
+  test('continues when Deezer artist top endpoint fails for a familiar seed', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_artist_top_500')
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+    ])
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.match(/\/artist\/\d+\/top/)) {
+        return new Response('upstream down', { status: 500 })
+      }
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        return new Response(
+          JSON.stringify({
+            data: [makeTrackPayload(CHART_TRACK_BASE_ID, { id: 7000, name: 'Chart Artist 7000' })],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response('{"data":[]}', {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+    // Familiar bucket is empty (artist top failed) but chart fallback still produces tracks
+    assert.isAtLeast(asTracks(response.body()).length, 1)
+  })
+
+  test('drops Deezer track payloads that miss required artist or album fields', async ({
+    client,
+    assert,
+  }) => {
+    const { token } = await createAuthenticatedUser('feed_invalid_track')
+
+    globalThis.fetch = (async (input: Parameters<typeof fetch>[0]) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const chartMatch = url.match(/\/chart\/[A-Z]{2}\/tracks/)
+      if (chartMatch) {
+        return new Response(
+          JSON.stringify({
+            data: [
+              { id: 1 }, // missing preview
+              { id: 2, preview: 'p', artist: null, album: { id: 1, title: 't' } },
+              { id: 3, preview: 'p', artist: { id: 1, name: 'a' }, album: null },
+              { id: 4, preview: 'p', artist: { id: 1 }, album: { id: 1, title: 't' } },
+              { id: 5, preview: 'p', artist: { id: 1, name: 'a' }, album: { id: 1 } },
+              null,
+              undefined,
+              { preview: 'p', artist: { id: 1, name: 'a' }, album: { id: 1, title: 't' } }, // missing id
+              {
+                id: 100,
+                preview: 'p',
+                artist: { id: 7, name: 'OK' },
+                album: { id: 7, title: 'OK' },
+              }, // valid
+            ],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } }
+        )
+      }
+      return new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })
+    }) as typeof fetch
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    response.assertStatus(200)
+
+    const tracks = asTracks(response.body())
+    assert.equal(tracks.length, 1)
+    assert.equal(tracks[0].id, 100)
+  })
 })

--- a/backend/tests/functional/swipemix_feed_controller.spec.ts
+++ b/backend/tests/functional/swipemix_feed_controller.spec.ts
@@ -1,0 +1,381 @@
+import { test } from '@japa/runner'
+import { DateTime } from 'luxon'
+import { createAuthenticatedUser } from '../utils/auth_helpers.js'
+import { deleteOnboardingArtists } from '#tests/utils/onboarding_helpers'
+import { deleteTrackInteractions } from '#tests/utils/track_interaction_helpers'
+import { deleteUserIntegrations } from '#tests/utils/user_integration_helpers'
+import { SpotifyService } from '#services/spotify_service'
+import UserOnboardingArtist from '#models/user_onboarding_artist'
+import UserTrackInteraction from '#models/user_track_interaction'
+import { InteractionAction } from '#enums/interaction_action'
+interface FakeArtist {
+  id: number
+  name: string
+}
+
+const FAMILIAR_ARTIST_IDS = [27, 413, 288166] as const
+const RELATED_ARTIST_IDS = [800, 801, 802] as const
+const CHART_TRACK_BASE_ID = 9000
+const FAMILIAR_TOP_BASE_ID = 1000
+const RELATED_TOP_BASE_ID = 2000
+
+const ARTIST_NAMES: Record<number, string> = {
+  27: 'Daft Punk',
+  413: 'Stromae',
+  288166: 'Angèle',
+  800: 'Justice',
+  801: 'Phoenix',
+  802: 'Air',
+}
+
+function makeTrackPayload(id: number, artist: FakeArtist, options: { withPreview?: boolean } = {}) {
+  const withPreview = options.withPreview ?? true
+  return {
+    id,
+    title: `Track ${id}`,
+    title_short: `Track ${id}`,
+    title_version: '',
+    link: `https://deezer.com/track/${id}`,
+    duration: 180,
+    rank: 100,
+    explicit_lyrics: false,
+    explicit_content_lyrics: 0,
+    explicit_content_cover: 0,
+    preview: withPreview ? `https://cdn.deezer.com/preview/${id}` : '',
+    md5_image: `md5${id}`,
+    artist: {
+      id: artist.id,
+      name: artist.name,
+      picture: `https://cdn/artist/${artist.id}`,
+      picture_small: `https://cdn/artist/${artist.id}/sm`,
+      picture_medium: `https://cdn/artist/${artist.id}/md`,
+      picture_big: `https://cdn/artist/${artist.id}/big`,
+      picture_xl: `https://cdn/artist/${artist.id}/xl`,
+    },
+    album: {
+      id,
+      title: `Album ${id}`,
+      cover: `https://cdn/album/${id}`,
+      cover_small: `https://cdn/album/${id}/sm`,
+      cover_medium: `https://cdn/album/${id}/md`,
+      cover_big: `https://cdn/album/${id}/big`,
+      cover_xl: `https://cdn/album/${id}/xl`,
+      md5_image: `md5${id}`,
+    },
+    type: 'track',
+  }
+}
+
+function jsonResponse(payload: unknown, status: number = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+interface FakeFetchOptions {
+  spotifyArtistNames?: string[]
+  chartStatus?: number
+}
+
+function buildFakeFetch(options: FakeFetchOptions = {}): typeof fetch {
+  const chartTrackArtist: FakeArtist = {
+    id: 7000,
+    name: 'Chart Artist 7000',
+  }
+  const chartTrackIds = Array.from({ length: 5 }, (_, i) => CHART_TRACK_BASE_ID + i)
+
+  return (async (input: Parameters<typeof fetch>[0]) => {
+    const url = typeof input === 'string' ? input : input.toString()
+
+    if (url.includes('api.spotify.com/v1/me/top/artists')) {
+      const items = (options.spotifyArtistNames ?? []).map((name, index) => ({
+        id: `sp_${index}`,
+        name,
+      }))
+      return jsonResponse({ items })
+    }
+
+    const chartMatch = url.match(/\/chart\/([A-Z]{2})\/tracks/)
+    if (chartMatch) {
+      if (options.chartStatus && options.chartStatus >= 400) {
+        return new Response('upstream down', { status: options.chartStatus })
+      }
+      const data = chartTrackIds.map((id) => makeTrackPayload(id, chartTrackArtist))
+      return jsonResponse({ data })
+    }
+
+    const relatedMatch = url.match(/\/artist\/(\d+)\/related/)
+    if (relatedMatch) {
+      const seedId = Number(relatedMatch[1])
+      const offset = seedId % RELATED_ARTIST_IDS.length || 0
+      const data = RELATED_ARTIST_IDS.slice(offset, offset + 3).map((id) => ({
+        id,
+        name: ARTIST_NAMES[id] ?? `Related ${id}`,
+      }))
+      return jsonResponse({ data })
+    }
+
+    const topMatch = url.match(/\/artist\/(\d+)\/top/)
+    if (topMatch) {
+      const artistId = Number(topMatch[1])
+      const isRelated = (RELATED_ARTIST_IDS as readonly number[]).includes(artistId)
+      const baseId = isRelated ? RELATED_TOP_BASE_ID : FAMILIAR_TOP_BASE_ID
+      const trackIds = Array.from({ length: 5 }, (_, i) => baseId + artistId * 10 + i)
+      const artist: FakeArtist = {
+        id: artistId,
+        name: ARTIST_NAMES[artistId] ?? `Artist ${artistId}`,
+      }
+      const data = trackIds.map((id) => makeTrackPayload(id, artist))
+      return jsonResponse({ data })
+    }
+
+    const searchMatch = url.match(/\/search\/artist\?q=([^&]+)/)
+    if (searchMatch) {
+      const decoded = decodeURIComponent(searchMatch[1])
+      const found = Object.entries(ARTIST_NAMES).find(([, name]) => name === decoded)
+      const data = found ? [{ id: Number(found[0]), name: found[1] }] : []
+      return jsonResponse({ data })
+    }
+
+    return jsonResponse({})
+  }) as typeof fetch
+}
+
+function asTracks(body: unknown): { id: number; artist: { id: number } }[] {
+  return (body as { tracks: { id: number; artist: { id: number } }[] }).tracks
+}
+
+test.group('SwipemixFeedController - auth & validation', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+    globalThis.fetch = buildFakeFetch()
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('GET /api/me/swipemix/feed requires auth', async ({ client }) => {
+    const response = await client.get('/api/me/swipemix/feed')
+    response.assertStatus(401)
+  })
+
+  test('rejects invalid limit query param', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('feed_bad_limit')
+    const response = await client.get('/api/me/swipemix/feed?limit=999').bearerToken(token)
+    response.assertStatus(422)
+  })
+
+  test('rejects invalid country query param', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('feed_bad_country')
+    const response = await client.get('/api/me/swipemix/feed?country=FRA').bearerToken(token)
+    response.assertStatus(422)
+  })
+})
+
+test.group('SwipemixFeedController - cold start', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+    globalThis.fetch = buildFakeFetch()
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('returns chart tracks when the user has no seed signals', async ({ client, assert }) => {
+    const { token } = await createAuthenticatedUser('feed_cold_start')
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+
+    response.assertStatus(200)
+    const tracks = asTracks(response.body())
+    assert.isAbove(tracks.length, 0)
+    const chartArtist = tracks.find((track) => track.artist.id === 7000)
+    assert.exists(chartArtist, 'chart artist should be present in cold start feed')
+  })
+
+  test('respects custom limit and offset', async ({ client, assert }) => {
+    const { user, token } = await createAuthenticatedUser('feed_pagination')
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+      { userId: user.id, deezerArtistId: '413', artistName: 'Stromae', rank: 2 },
+    ])
+
+    const firstPage = await client.get('/api/me/swipemix/feed?limit=3&offset=0').bearerToken(token)
+    firstPage.assertStatus(200)
+    const firstTracks = asTracks(firstPage.body())
+    assert.equal(firstTracks.length, 3)
+
+    const secondPage = await client.get('/api/me/swipemix/feed?limit=3&offset=3').bearerToken(token)
+    secondPage.assertStatus(200)
+    const secondTracks = asTracks(secondPage.body())
+
+    const firstIds = firstTracks.map((track) => track.id)
+    const secondIds = secondTracks.map((track) => track.id)
+    for (const id of secondIds) {
+      assert.notInclude(firstIds, id)
+    }
+  })
+})
+
+test.group('SwipemixFeedController - personalisation', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+    globalThis.fetch = buildFakeFetch()
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('excludes tracks the user already swiped (liked or disliked)', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_excludes_swiped')
+
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+      { userId: user.id, deezerArtistId: '413', artistName: 'Stromae', rank: 2 },
+    ])
+
+    const excludedIds = [FAMILIAR_TOP_BASE_ID + 27 * 10, FAMILIAR_TOP_BASE_ID + 413 * 10 + 1]
+    await UserTrackInteraction.createMany([
+      {
+        userId: user.id,
+        deezerTrackId: String(excludedIds[0]),
+        deezerArtistId: '27',
+        action: InteractionAction.Liked,
+      },
+      {
+        userId: user.id,
+        deezerTrackId: String(excludedIds[1]),
+        deezerArtistId: '413',
+        action: InteractionAction.Disliked,
+      },
+    ])
+
+    const response = await client.get('/api/me/swipemix/feed?limit=50').bearerToken(token)
+    response.assertStatus(200)
+
+    const ids = asTracks(response.body()).map((track) => track.id)
+    for (const excluded of excludedIds) {
+      assert.notInclude(ids, excluded)
+    }
+  })
+
+  test('produces different feeds for users with different onboarding seeds', async ({
+    client,
+    assert,
+  }) => {
+    const userA = await createAuthenticatedUser('feed_user_a')
+    const userB = await createAuthenticatedUser('feed_user_b')
+
+    await UserOnboardingArtist.createMany([
+      { userId: userA.user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+      { userId: userA.user.id, deezerArtistId: '413', artistName: 'Stromae', rank: 2 },
+    ])
+
+    await UserOnboardingArtist.createMany([
+      { userId: userB.user.id, deezerArtistId: '288166', artistName: 'Angèle', rank: 1 },
+    ])
+
+    const respA = await client.get('/api/me/swipemix/feed?limit=10').bearerToken(userA.token)
+    const respB = await client.get('/api/me/swipemix/feed?limit=10').bearerToken(userB.token)
+
+    respA.assertStatus(200)
+    respB.assertStatus(200)
+
+    const idsA = new Set(asTracks(respA.body()).map((track) => track.id))
+    const idsB = new Set(asTracks(respB.body()).map((track) => track.id))
+
+    const intersection = Array.from(idsA).filter((id) => idsB.has(id))
+    assert.notEqual(intersection.length, idsA.size, 'feeds should diverge between distinct seeds')
+  })
+
+  test('the first 5 tracks contain at most one chart-only (discovery) track when seeds exist', async ({
+    client,
+    assert,
+  }) => {
+    const { user, token } = await createAuthenticatedUser('feed_ratio_top5')
+
+    await UserOnboardingArtist.createMany([
+      { userId: user.id, deezerArtistId: '27', artistName: 'Daft Punk', rank: 1 },
+      { userId: user.id, deezerArtistId: '413', artistName: 'Stromae', rank: 2 },
+      { userId: user.id, deezerArtistId: '288166', artistName: 'Angèle', rank: 3 },
+    ])
+
+    const response = await client.get('/api/me/swipemix/feed?limit=5').bearerToken(token)
+    response.assertStatus(200)
+
+    const seedSet = new Set(FAMILIAR_ARTIST_IDS as readonly number[])
+    const familiarCount = asTracks(response.body()).filter((track) =>
+      seedSet.has(track.artist.id)
+    ).length
+
+    assert.isAtLeast(familiarCount, 4, 'expected ≥4 familiar tracks in first 5 (80/20 ratio)')
+  })
+})
+
+test.group('SwipemixFeedController - integrations & errors', (group) => {
+  deleteOnboardingArtists(group)
+  deleteTrackInteractions(group)
+  deleteUserIntegrations(group)
+
+  let originalFetch: typeof fetch
+
+  group.each.setup(() => {
+    originalFetch = globalThis.fetch
+  })
+
+  group.each.teardown(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  test('uses Spotify top artists as seeds when integration exists', async ({ client, assert }) => {
+    const { user, token } = await createAuthenticatedUser('feed_spotify_seed')
+    await new SpotifyService().upsertIntegration(user.id, {
+      providerUserId: 'sp_seed',
+      accessToken: 'a',
+      refreshToken: 'r',
+      expiresAt: DateTime.now().plus({ hours: 1 }),
+      scopes: 'user-top-read',
+    })
+
+    globalThis.fetch = buildFakeFetch({ spotifyArtistNames: ['Daft Punk'] })
+
+    const response = await client.get('/api/me/swipemix/feed?limit=20').bearerToken(token)
+    response.assertStatus(200)
+
+    const tracks = asTracks(response.body())
+    const hasDaftPunk = tracks.some((track) => track.artist.id === 27)
+    assert.isTrue(hasDaftPunk, 'expected Daft Punk top track from Spotify-resolved seed')
+  })
+
+  test('returns 502 when Deezer chart upstream fails for cold-start user', async ({ client }) => {
+    const { token } = await createAuthenticatedUser('feed_chart_502')
+    globalThis.fetch = buildFakeFetch({ chartStatus: 500 })
+
+    const response = await client.get('/api/me/swipemix/feed').bearerToken(token)
+    // Cold start with no chart leaves an empty pool but the endpoint still returns 200 with []
+    // because we want graceful degradation, not 502.
+    response.assertStatus(200)
+  })
+})

--- a/backend/tests/functional/user_achievements_controller.spec.ts
+++ b/backend/tests/functional/user_achievements_controller.spec.ts
@@ -22,7 +22,7 @@ test.group('UserAchievementsController', (group) => {
     adminToken = adminAuth.token
 
     achievement = await Achievement.create({
-      type: 'test_achievement' as AchievementType,
+      type: AchievementType.FirstGame,
       description: 'Test description',
     })
   })

--- a/backend/tests/unit/me_stats_service.spec.ts
+++ b/backend/tests/unit/me_stats_service.spec.ts
@@ -1,0 +1,307 @@
+import { test } from '@japa/runner'
+import GameSession from '#models/game_session'
+import UserTrackInteraction from '#models/user_track_interaction'
+import Game from '#models/game'
+import { MeStatsService } from '#services/me_stats_service'
+import { GameSessionStatus } from '#enums/game_session_status'
+import { InteractionAction } from '#enums/interaction_action'
+import { createAuthenticatedUser } from '#tests/utils/auth_helpers'
+import { deleteGameSession } from '#tests/utils/game_session_helpers'
+import { deleteTrackInteractions } from '#tests/utils/track_interaction_helpers'
+import { DateTime } from 'luxon'
+import db from '@adonisjs/lucid/services/db'
+
+test.group('MeStatsService', (group) => {
+  let service: MeStatsService
+  let game: Game
+
+  deleteGameSession(group)
+  deleteTrackInteractions(group)
+
+  group.each.setup(async () => {
+    service = new MeStatsService()
+    game = await Game.create({
+      name: 'Test Game for Stats',
+      description: 'Test Description',
+      isEnabled: true,
+    })
+  })
+
+  test('getStats returns 0/0/0 for new user', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_new')
+    const stats = await service.getStats(user.id)
+
+    assert.deepEqual(stats, {
+      totalSwipes: 0,
+      gamesPlayed: 0,
+      streak: 0,
+    })
+  })
+
+  test('getStats aggregates swipes and games played', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_agg')
+
+    // Create 2 swipes
+    await UserTrackInteraction.create({
+      userId: user.id,
+      deezerTrackId: 'track_1',
+      action: InteractionAction.Liked,
+    })
+    await UserTrackInteraction.create({
+      userId: user.id,
+      deezerTrackId: 'track_2',
+      action: InteractionAction.Disliked,
+    })
+
+    // Create 1 completed game
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+
+    // Create 1 active game (should not count)
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Active,
+      players: [{ userId: user.id, status: 'playing', score: 0, rank: 1 }],
+      gameData: {},
+    })
+
+    const stats = await service.getStats(user.id)
+    assert.equal(stats.totalSwipes, 2)
+    assert.equal(stats.gamesPlayed, 1)
+  })
+
+  test('getStreak calculates correct streak when ending today', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_streak_ok')
+    const now = DateTime.now()
+
+    // Today
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+
+    // Yesterday
+    const yesterdaySession = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await db
+      .from('game_sessions')
+      .where('id', yesterdaySession.id)
+      .update({ updated_at: now.minus({ days: 1 }).toSQL() })
+
+    // 2 days ago
+    const dayBeforeYesterdaySession = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await db
+      .from('game_sessions')
+      .where('id', dayBeforeYesterdaySession.id)
+      .update({ updated_at: now.minus({ days: 2 }).toSQL() })
+
+    const stats = await service.getStats(user.id)
+    assert.equal(stats.streak, 3)
+  })
+
+  test('getStreak returns 0 if no game today', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_streak_fail')
+    const now = DateTime.now()
+
+    // Yesterday
+    const yesterdaySession = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await db
+      .from('game_sessions')
+      .where('id', yesterdaySession.id)
+      .update({ updated_at: now.minus({ days: 1 }).toSQL() })
+
+    const stats = await service.getStats(user.id)
+    assert.equal(stats.streak, 0)
+  })
+
+  test('getStreak handles multiple games on the same day', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_streak_multi')
+    const now = DateTime.now()
+
+    // 2 games today
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 5, rank: 2 }],
+      gameData: {},
+    })
+
+    // 1 game yesterday
+    const yesterdaySession = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await db
+      .from('game_sessions')
+      .where('id', yesterdaySession.id)
+      .update({ updated_at: now.minus({ days: 1 }).toSQL() })
+
+    const stats = await service.getStats(user.id)
+    assert.equal(stats.streak, 2)
+  })
+
+  test('getStreak breaks when a day is missing', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_streak_break')
+    const now = DateTime.now()
+
+    // Today
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+
+    // Day before yesterday (Yesterday is missing)
+    const dayBeforeYesterdaySession = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await db
+      .from('game_sessions')
+      .where('id', dayBeforeYesterdaySession.id)
+      .update({ updated_at: now.minus({ days: 2 }).toSQL() })
+
+    const stats = await service.getStats(user.id)
+    // Only today counts because yesterday is missing
+    assert.equal(stats.streak, 1)
+  })
+
+  test('getStats works with a custom timezone', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_tz')
+    const timezone = 'America/New_York'
+    const todayInTz = DateTime.now().setZone(timezone)
+
+    // Create game today in that timezone
+    const session = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+
+    // Ensure it's recorded as "today" in the target timezone
+    await db.from('game_sessions').where('id', session.id).update({ updated_at: todayInTz.toSQL() })
+
+    const stats = await service.getStats(user.id, timezone)
+    assert.equal(stats.streak, 1)
+  })
+
+  test('getTotalSwipes and getGamesPlayed handle empty results', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_empty_safe')
+    const stats = await service.getStats(user.id)
+    assert.equal(stats.totalSwipes, 0)
+    assert.equal(stats.gamesPlayed, 0)
+    assert.equal(stats.streak, 0)
+  })
+
+  test('getStreak returns 0 if most recent game is not today', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_not_today')
+    const now = DateTime.now()
+
+    // Create a game for yesterday
+    const session = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await db
+      .from('game_sessions')
+      .where('id', session.id)
+      .update({ updated_at: now.minus({ days: 1 }).toSQL() })
+
+    const stats = await service.getStats(user.id)
+    assert.equal(stats.streak, 0)
+  })
+
+  test('getStreak returns 0 when multiple past games exist but none today', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_past_multi')
+    const now = DateTime.now()
+
+    // Yesterday
+    const s1 = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await db
+      .from('game_sessions')
+      .where('id', s1.id)
+      .update({ updated_at: now.minus({ days: 1 }).toSQL() })
+
+    // Day before yesterday
+    const s2 = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await db
+      .from('game_sessions')
+      .where('id', s2.id)
+      .update({ updated_at: now.minus({ days: 2 }).toSQL() })
+
+    const stats = await service.getStats(user.id)
+    assert.equal(stats.streak, 0)
+  })
+
+  test('getStreak loop terminates when date does not match current day', async ({ assert }) => {
+    const { user } = await createAuthenticatedUser('stats_streak_break_loop')
+    const now = DateTime.now()
+
+    // Game today
+    await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+
+    // Game 2 days ago (Gap of 1 day)
+    const session = await GameSession.create({
+      gameId: game.id,
+      status: GameSessionStatus.Completed,
+      players: [{ userId: user.id, status: 'playing', score: 10, rank: 1 }],
+      gameData: {},
+    })
+    await db
+      .from('game_sessions')
+      .where('id', session.id)
+      .update({ updated_at: now.minus({ days: 2 }).toSQL() })
+
+    const stats = await service.getStats(user.id)
+    assert.equal(stats.streak, 1)
+  })
+})

--- a/backend/tests/unit/user_achievement_service.spec.ts
+++ b/backend/tests/unit/user_achievement_service.spec.ts
@@ -21,14 +21,14 @@ test.group('UserAchievementService', (group) => {
     })
 
     achievement = await Achievement.create({
-      type: 'test_achievement' as AchievementType,
+      type: AchievementType.FirstGame,
       description: 'Test description',
     })
   })
 
   deleteUserAchievement(group)
 
-  test('getUserAchievements returns user achievements with achievement preloaded', async ({
+  test('getUserAchievements returns existing user achievement with achievement preloaded', async ({
     assert,
   }) => {
     await UserAchievement.create({
@@ -46,7 +46,100 @@ test.group('UserAchievementService', (group) => {
     assert.equal(result[0].userId, user.id)
     assert.equal(result[0].achievementId, achievement.id)
     assert.exists(result[0].achievement)
-    assert.equal(result[0].achievement.type, 'test_achievement')
+    assert.equal(result[0].achievement.type, AchievementType.FirstGame)
+    assert.equal(result[0].currentProgress, 50)
+  })
+
+  test('getUserAchievements returns wired achievements with defaults when never tracked', async ({
+    assert,
+  }) => {
+    const second = await Achievement.create({
+      type: AchievementType.FirstLike,
+      description: 'Second wired',
+    })
+
+    const result = await service.getUserAchievements(user.id)
+
+    assert.lengthOf(result, 2)
+    assert.isNull(result[0].id)
+    assert.equal(result[0].achievementId, achievement.id)
+    assert.equal(result[0].currentProgress, 0)
+    assert.equal(result[0].requiredProgress, 1)
+    assert.isNull(result[0].unlockedAt)
+    assert.exists(result[0].achievement)
+    assert.equal(result[1].achievementId, second.id)
+  })
+
+  test('getUserAchievements sorts unlocked achievements by unlockedAt desc', async ({ assert }) => {
+    const secondAchievement = await Achievement.create({
+      type: AchievementType.FirstLike,
+      description: 'Second',
+    })
+    const older = DateTime.now().minus({ days: 2 })
+    const newer = DateTime.now().minus({ hours: 1 })
+    await UserAchievement.create({
+      userId: user.id,
+      achievementId: achievement.id,
+      currentProgress: 1,
+      requiredProgress: 1,
+      currentTier: 1,
+      progressData: {},
+      unlockedAt: older,
+    })
+    await UserAchievement.create({
+      userId: user.id,
+      achievementId: secondAchievement.id,
+      currentProgress: 1,
+      requiredProgress: 1,
+      currentTier: 1,
+      progressData: {},
+      unlockedAt: newer,
+    })
+
+    const result = await service.getUserAchievements(user.id)
+
+    assert.lengthOf(result, 2)
+    assert.equal(result[0].achievementId, secondAchievement.id)
+    assert.equal(result[1].achievementId, achievement.id)
+  })
+
+  test('getUserAchievements places unlocked before locked regardless of insertion order', async ({
+    assert,
+  }) => {
+    const secondAchievement = await Achievement.create({
+      type: AchievementType.FirstLike,
+      description: 'Higher id unlocked',
+    })
+    await UserAchievement.create({
+      userId: user.id,
+      achievementId: secondAchievement.id,
+      currentProgress: 1,
+      requiredProgress: 1,
+      currentTier: 1,
+      progressData: {},
+      unlockedAt: DateTime.now(),
+    })
+
+    const result = await service.getUserAchievements(user.id)
+
+    assert.lengthOf(result, 2)
+    assert.equal(result[0].achievementId, secondAchievement.id)
+    assert.exists(result[0].unlockedAt)
+    assert.isNull(result[1].unlockedAt)
+  })
+
+  test('getUserAchievements filters out achievements not wired to any event', async ({
+    assert,
+  }) => {
+    await Achievement.create({
+      type: 'unwired_type' as AchievementType,
+      description: 'Should not appear',
+    })
+
+    const result = await service.getUserAchievements(user.id)
+
+    assert.lengthOf(result, 1)
+    assert.equal(result[0].achievement.type, AchievementType.FirstGame)
   })
 
   test('getAll returns all user achievements with user and achievement preloaded', async ({
@@ -67,7 +160,7 @@ test.group('UserAchievementService', (group) => {
     assert.exists(result[0].user)
     assert.exists(result[0].achievement)
     assert.isNotNull(result[0].user.username)
-    assert.equal(result[0].achievement.type, 'test_achievement')
+    assert.equal(result[0].achievement.type, AchievementType.FirstGame)
   })
 
   test('startTracking creates user achievement with default values', async ({ assert }) => {

--- a/backend/tests/utils/user_achievement_helpers.ts
+++ b/backend/tests/utils/user_achievement_helpers.ts
@@ -13,10 +13,10 @@ export function deleteUserAchievement(group: Group) {
 
   group.each.teardown(async () => {
     await UserAchievement.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
+    await Achievement.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
   })
 
   group.teardown(async () => {
-    await Achievement.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
     await User.query().where('created_at', '>=', testStartTime.toSQL()!).delete()
   })
 }

--- a/front-mobile/app/(tabs)/profile/index.tsx
+++ b/front-mobile/app/(tabs)/profile/index.tsx
@@ -7,13 +7,8 @@ import { Colors } from "@/constants/Colors";
 import { useAuthStore } from "@/stores/authStore";
 import OnboardingBanner from "@/components/OnboardingBanner";
 import { useOnboardingStatus } from "@/hooks/useOnboardingStatus";
-
-// TODO: à modifier plus tard - remplacer par des données récupérées depuis l'APIii
-const MOCK_STATS = {
-  swipes: 142,
-  matchs: 87,
-  gamesPlayed: 23,
-};
+import { useMyStats } from "@/hooks/useMyStats";
+import { Skeleton } from "@/components/ui/Skeleton";
 
 // TODO: à modifier plus tard - remplacer par des données récupérées depuis l'API
 const MOCK_BADGES = [
@@ -27,37 +22,6 @@ const MOCK_BADGES = [
   { id: "8", name: "Légende", icon: "👑", unlocked: false },
   { id: "9", name: "Mélomane absolu", icon: "🎵", unlocked: false },
 ];
-
-// TODO: à modifier plus tard - remplacer par des données récupérées depuis l'API
-const MOCK_RECENT_ACTIVITIES = [
-  {
-    id: "1",
-    name: "Partie Blurchette",
-    detail: "Score : 8/10",
-    relativeDate: "Il y a 2h",
-  },
-  {
-    id: "2",
-    name: "Titre mis en favori",
-    detail: "One More Time - Daft Punk",
-    relativeDate: "Il y a 5h",
-  },
-  {
-    id: "3",
-    name: "Partie Tracklist",
-    detail: "Score : 6/10",
-    relativeDate: "Hier",
-  },
-  {
-    id: "4",
-    name: "Titre mis en favori",
-    detail: "Papaoutai - Stromae",
-    relativeDate: "Il y a 2 jours",
-  },
-];
-
-// TODO: à modifier plus tard - niveau et titre à récupérer depuis l'API
-const MOCK_LEVEL = { level: 7, title: "Mélomane" };
 
 function getMemberSince(createdAt?: string): string {
   if (!createdAt) return "membre récemment";
@@ -77,6 +41,7 @@ function getMemberSince(createdAt?: string): string {
 export default function ProfileScreen() {
   const { user, logout } = useAuthStore();
   const { status } = useOnboardingStatus();
+  const { stats, loading, error, retry } = useMyStats();
 
   return (
     <SafeAreaView style={styles.safeArea} edges={["bottom"]}>
@@ -107,22 +72,34 @@ export default function ProfileScreen() {
           <Text style={styles.memberSince}>
             {getMemberSince(user?.createdAt)}
           </Text>
-
-          <View style={styles.levelBadge}>
-            <Text style={styles.levelText}>
-              Niveau {MOCK_LEVEL.level} — {MOCK_LEVEL.title}
-            </Text>
-          </View>
         </View>
 
         {/* ── Statistiques ── */}
         <View style={styles.section}>
           <Text style={styles.sectionTitle}>Statistiques</Text>
           <View style={styles.statsRow}>
-            <StatCard label="Swipes" value={MOCK_STATS.swipes} />
-            <StatCard label="Matchs" value={MOCK_STATS.matchs} />
-            <StatCard label="Jeux joués" value={MOCK_STATS.gamesPlayed} />
+            <StatCard
+              label="Swipes"
+              value={stats?.totalSwipes ?? 0}
+              loading={loading}
+            />
+            <StatCard
+              label="Parties jouées"
+              value={stats?.gamesPlayed ?? 0}
+              loading={loading}
+            />
+            <StatCard
+              label="Streak"
+              value={stats?.streak ?? 0}
+              loading={loading}
+              suffix={stats?.streak ? " j" : ""}
+            />
           </View>
+          {error && (
+            <Pressable onPress={retry} style={styles.errorContainer}>
+              <Text style={styles.errorText}>{error} - Réessayer</Text>
+            </Pressable>
+          )}
         </View>
 
         {/* ── Succès & Récompenses ── */}
@@ -151,21 +128,6 @@ export default function ProfileScreen() {
               </View>
             ))}
           </View>
-        </View>
-
-        {/* ── Activités récentes ── */}
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Activités récentes</Text>
-          {MOCK_RECENT_ACTIVITIES.map((activity) => (
-            <View key={activity.id} style={styles.activityItem}>
-              <View style={styles.activityDot} />
-              <View style={styles.activityContent}>
-                <Text style={styles.activityName}>{activity.name}</Text>
-                <Text style={styles.activityDetail}>{activity.detail}</Text>
-              </View>
-              <Text style={styles.activityDate}>{activity.relativeDate}</Text>
-            </View>
-          ))}
         </View>
 
         {/* ── Mes artistes favoris ── */}
@@ -211,10 +173,26 @@ export default function ProfileScreen() {
   );
 }
 
-function StatCard({ label, value }: { label: string; value: number }) {
+function StatCard({
+  label,
+  value,
+  loading,
+  suffix = "",
+}: {
+  label: string;
+  value: number;
+  loading?: boolean;
+  suffix?: string;
+}) {
+  if (loading) {
+    return <Skeleton height={84} style={styles.statCardSkeleton} />;
+  }
   return (
     <View style={styles.statCard}>
-      <Text style={styles.statValue}>{value}</Text>
+      <Text style={styles.statValue}>
+        {value}
+        {suffix}
+      </Text>
       <Text style={styles.statLabel}>{label}</Text>
     </View>
   );
@@ -270,20 +248,6 @@ const styles = StyleSheet.create({
     color: Colors.dark.icon,
     marginBottom: 10,
   },
-  levelBadge: {
-    backgroundColor: Colors.primary.CTADark,
-    borderWidth: 1,
-    borderColor: Colors.primary.CTA,
-    borderRadius: 20,
-    paddingHorizontal: 14,
-    paddingVertical: 5,
-    marginBottom: 16,
-  },
-  levelText: {
-    color: Colors.primary.survol,
-    fontSize: 13,
-    fontWeight: "600",
-  },
 
   // Sections
   section: {
@@ -320,6 +284,10 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: "#2A2A2A",
   },
+  statCardSkeleton: {
+    flex: 1,
+    borderRadius: 12,
+  },
   statValue: {
     fontSize: 26,
     fontWeight: "800",
@@ -330,6 +298,14 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: Colors.dark.icon,
     textAlign: "center",
+  },
+  errorContainer: {
+    marginTop: 12,
+    alignItems: "center",
+  },
+  errorText: {
+    color: "#FF4D4D",
+    fontSize: 13,
   },
 
   // Badges
@@ -363,41 +339,6 @@ const styles = StyleSheet.create({
   },
   badgeNameLocked: {
     color: Colors.dark.icon,
-  },
-
-  // Activities
-  activityItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    paddingVertical: 12,
-    borderBottomWidth: 1,
-    borderBottomColor: "#1A1A1A",
-    gap: 12,
-  },
-  activityDot: {
-    width: 8,
-    height: 8,
-    borderRadius: 4,
-    backgroundColor: Colors.primary.CTA,
-    flexShrink: 0,
-  },
-  activityContent: {
-    flex: 1,
-  },
-  activityName: {
-    fontSize: 14,
-    color: Colors.dark.text,
-    fontWeight: "600",
-    marginBottom: 2,
-  },
-  activityDetail: {
-    fontSize: 12,
-    color: Colors.dark.icon,
-  },
-  activityDate: {
-    fontSize: 11,
-    color: Colors.game.textMuted,
-    flexShrink: 0,
   },
 
   // Favorite artists

--- a/front-mobile/app/(tabs)/profile/index.tsx
+++ b/front-mobile/app/(tabs)/profile/index.tsx
@@ -6,6 +6,7 @@ import { router } from "expo-router";
 import { Colors } from "@/constants/Colors";
 import { useAuthStore } from "@/stores/authStore";
 import OnboardingBanner from "@/components/OnboardingBanner";
+import ProfileSpotifySection from "@/components/profile/ProfileSpotifySection";
 import { useOnboardingStatus } from "@/hooks/useOnboardingStatus";
 
 // TODO: à modifier plus tard - remplacer par des données récupérées depuis l'APIii
@@ -124,6 +125,9 @@ export default function ProfileScreen() {
             <StatCard label="Jeux joués" value={MOCK_STATS.gamesPlayed} />
           </View>
         </View>
+
+        {/* ── Mes stats Spotify ── */}
+        <ProfileSpotifySection />
 
         {/* ── Succès & Récompenses ── */}
         <View style={styles.section}>

--- a/front-mobile/app/(tabs)/profile/index.tsx
+++ b/front-mobile/app/(tabs)/profile/index.tsx
@@ -6,6 +6,7 @@ import { router } from "expo-router";
 import { Colors } from "@/constants/Colors";
 import { useAuthStore } from "@/stores/authStore";
 import OnboardingBanner from "@/components/OnboardingBanner";
+import ProfileAchievementsSection from "@/components/profile/ProfileAchievementsSection";
 import { useOnboardingStatus } from "@/hooks/useOnboardingStatus";
 
 // TODO: à modifier plus tard - remplacer par des données récupérées depuis l'APIii
@@ -14,19 +15,6 @@ const MOCK_STATS = {
   matchs: 87,
   gamesPlayed: 23,
 };
-
-// TODO: à modifier plus tard - remplacer par des données récupérées depuis l'API
-const MOCK_BADGES = [
-  { id: "1", name: "Bienvenue dans l'arène", icon: "🏟️", unlocked: true },
-  { id: "2", name: "Premier pas", icon: "👣", unlocked: true },
-  { id: "3", name: "Première victoire", icon: "🥇", unlocked: true },
-  { id: "4", name: "Oreille d'or", icon: "🎧", unlocked: true },
-  { id: "5", name: "Éclair", icon: "⚡", unlocked: true },
-  { id: "6", name: "Perfectionniste", icon: "💎", unlocked: false },
-  { id: "7", name: "Vétéran", icon: "🏆", unlocked: false },
-  { id: "8", name: "Légende", icon: "👑", unlocked: false },
-  { id: "9", name: "Mélomane absolu", icon: "🎵", unlocked: false },
-];
 
 // TODO: à modifier plus tard - remplacer par des données récupérées depuis l'API
 const MOCK_RECENT_ACTIVITIES = [
@@ -126,32 +114,7 @@ export default function ProfileScreen() {
         </View>
 
         {/* ── Succès & Récompenses ── */}
-        <View style={styles.section}>
-          <Text style={styles.sectionTitleCentered}>Succès & Récompenses</Text>
-          <View style={styles.badgesGrid}>
-            {MOCK_BADGES.map((badge) => (
-              <View
-                key={badge.id}
-                style={[
-                  styles.badgeItem,
-                  !badge.unlocked && styles.badgeLocked,
-                ]}
-              >
-                <Text style={styles.badgeIcon}>
-                  {badge.unlocked ? badge.icon : "🔒"}
-                </Text>
-                <Text
-                  style={[
-                    styles.badgeName,
-                    !badge.unlocked && styles.badgeNameLocked,
-                  ]}
-                >
-                  {badge.name}
-                </Text>
-              </View>
-            ))}
-          </View>
-        </View>
+        <ProfileAchievementsSection />
 
         {/* ── Activités récentes ── */}
         <View style={styles.section}>
@@ -330,39 +293,6 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: Colors.dark.icon,
     textAlign: "center",
-  },
-
-  // Badges
-  badgesGrid: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 12,
-  },
-  badgeItem: {
-    width: "31%",
-    backgroundColor: "#1A1A1A",
-    borderRadius: 12,
-    padding: 12,
-    alignItems: "center",
-    gap: 6,
-    borderWidth: 1,
-    borderColor: Colors.primary.CTA,
-  },
-  badgeLocked: {
-    borderColor: "#2A2A2A",
-    opacity: 0.5,
-  },
-  badgeIcon: {
-    fontSize: 28,
-  },
-  badgeName: {
-    fontSize: 11,
-    color: Colors.dark.text,
-    textAlign: "center",
-    fontWeight: "600",
-  },
-  badgeNameLocked: {
-    color: Colors.dark.icon,
   },
 
   // Activities

--- a/front-mobile/app/spotify-linked.tsx
+++ b/front-mobile/app/spotify-linked.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { router, Stack, useLocalSearchParams } from "expo-router";
+import { Colors } from "@/constants/Colors";
+
+export default function SpotifyLinkedScreen() {
+  useLocalSearchParams<{ status?: string; reason?: string }>();
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      if (router.canGoBack()) {
+        router.back();
+      } else {
+        router.replace("/(tabs)/profile");
+      }
+    }, 50);
+    return () => clearTimeout(t);
+  }, []);
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={styles.container}>
+        <ActivityIndicator size="large" color={Colors.primary.survol} />
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: Colors.primary.fondPremier,
+  },
+});

--- a/front-mobile/components/profile/AchievementDetailModal.tsx
+++ b/front-mobile/components/profile/AchievementDetailModal.tsx
@@ -1,0 +1,242 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+  Dimensions,
+  Modal,
+  Pressable,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import Animated, {
+  Easing,
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from "react-native-reanimated";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Colors } from "@/constants/Colors";
+import { UserAchievementWithDetails } from "@/types/achievement";
+import { formatRelativeDate } from "@/utils/relative-date";
+
+const SCREEN_HEIGHT = Dimensions.get("window").height;
+const ANIMATION_DURATION = 400;
+const TIMING = {
+  duration: ANIMATION_DURATION,
+  easing: Easing.out(Easing.cubic),
+};
+
+interface AchievementDetailModalProps {
+  visible: boolean;
+  achievement: UserAchievementWithDetails | null;
+  onClose: () => void;
+}
+
+export default function AchievementDetailModal({
+  visible,
+  achievement,
+  onClose,
+}: AchievementDetailModalProps) {
+  const insets = useSafeAreaInsets();
+  const [isRendered, setIsRendered] = useState(visible);
+  const [lastAchievement, setLastAchievement] =
+    useState<UserAchievementWithDetails | null>(achievement);
+  const hasOpened = useRef(visible);
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    if (achievement) setLastAchievement(achievement);
+  }, [achievement]);
+
+  useEffect(() => {
+    if (visible) {
+      hasOpened.current = true;
+      setIsRendered(true);
+      progress.value = withTiming(1, TIMING);
+    } else if (hasOpened.current) {
+      progress.value = withTiming(0, TIMING, (finished) => {
+        if (finished) runOnJS(setIsRendered)(false);
+      });
+    }
+  }, [visible, progress]);
+
+  const backdropStyle = useAnimatedStyle(() => ({
+    opacity: progress.value,
+  }));
+
+  const sheetStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: (1 - progress.value) * SCREEN_HEIGHT }],
+  }));
+
+  if (!isRendered || !lastAchievement) return null;
+
+  const isUnlocked = lastAchievement.unlockedAt !== null;
+  const progressRatio =
+    lastAchievement.requiredProgress > 0
+      ? Math.min(
+          1,
+          Math.max(
+            0,
+            lastAchievement.currentProgress / lastAchievement.requiredProgress,
+          ),
+        )
+      : 0;
+
+  return (
+    <Modal
+      animationType="none"
+      transparent
+      visible={isRendered}
+      onRequestClose={onClose}
+    >
+      <View style={styles.container}>
+        <Animated.View style={[styles.backdrop, backdropStyle]}>
+          <Pressable
+            style={StyleSheet.absoluteFill}
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Fermer la modal"
+            testID="achievement-modal-backdrop"
+          />
+        </Animated.View>
+
+        <Animated.View
+          style={[
+            styles.sheet,
+            { paddingBottom: 24 + insets.bottom },
+            sheetStyle,
+          ]}
+        >
+          <View style={styles.handle} />
+
+          <Text style={styles.icon}>
+            {isUnlocked ? (lastAchievement.icon ?? "🏅") : "🔒"}
+          </Text>
+          <Text style={styles.name}>{lastAchievement.name}</Text>
+          {lastAchievement.description ? (
+            <Text style={styles.description}>
+              {lastAchievement.description}
+            </Text>
+          ) : null}
+
+          {isUnlocked ? (
+            <Text style={styles.statusUnlocked}>
+              Débloqué {formatRelativeDate(lastAchievement.unlockedAt!)}
+            </Text>
+          ) : (
+            <View style={styles.lockedBlock}>
+              <Text style={styles.statusLocked}>
+                Verrouillé — {lastAchievement.currentProgress}/
+                {lastAchievement.requiredProgress}
+              </Text>
+              <View style={styles.progressTrack}>
+                <View
+                  style={[
+                    styles.progressFill,
+                    { width: `${progressRatio * 100}%` },
+                  ]}
+                />
+              </View>
+            </View>
+          )}
+
+          <TouchableOpacity
+            style={styles.closeButton}
+            onPress={onClose}
+            accessibilityRole="button"
+          >
+            <Text style={styles.closeButtonText}>Fermer</Text>
+          </TouchableOpacity>
+        </Animated.View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.6)",
+  },
+  sheet: {
+    width: "100%",
+    backgroundColor: Colors.primary.fondPremier,
+    borderTopLeftRadius: 24,
+    borderTopRightRadius: 24,
+    paddingHorizontal: 28,
+    paddingTop: 12,
+    alignItems: "center",
+  },
+  handle: {
+    width: 40,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: Colors.dark.icon,
+    marginBottom: 20,
+    opacity: 0.4,
+  },
+  icon: {
+    fontSize: 60,
+    marginBottom: 12,
+  },
+  name: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: Colors.dark.text,
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  description: {
+    fontSize: 14,
+    color: Colors.dark.icon,
+    textAlign: "center",
+    marginBottom: 16,
+  },
+  statusUnlocked: {
+    fontSize: 14,
+    color: Colors.primary.survol,
+    fontWeight: "600",
+    marginBottom: 20,
+    textAlign: "center",
+  },
+  lockedBlock: {
+    width: "100%",
+    marginBottom: 20,
+    alignItems: "center",
+    gap: 8,
+  },
+  statusLocked: {
+    fontSize: 14,
+    color: Colors.game.textMuted,
+    textAlign: "center",
+  },
+  progressTrack: {
+    width: "100%",
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: "#2A2A2A",
+    overflow: "hidden",
+  },
+  progressFill: {
+    height: "100%",
+    backgroundColor: Colors.primary.CTA,
+  },
+  closeButton: {
+    width: "100%",
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: Colors.primary.CTA,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  closeButtonText: {
+    color: Colors.dark.text,
+    fontSize: 15,
+    fontWeight: "700",
+  },
+});

--- a/front-mobile/components/profile/ProfileAchievementsSection.tsx
+++ b/front-mobile/components/profile/ProfileAchievementsSection.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Colors } from "@/constants/Colors";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useMyAchievements } from "@/hooks/useMyAchievements";
+import { UserAchievementWithDetails } from "@/types/achievement";
+import AchievementDetailModal from "@/components/profile/AchievementDetailModal";
+
+const SKELETON_COUNT = 9;
+
+function AchievementSkeletons() {
+  return (
+    <>
+      {Array.from({ length: SKELETON_COUNT }).map((_, idx) => (
+        <Skeleton
+          key={`achievement-skeleton-${idx}`}
+          width="31%"
+          height={80}
+          borderRadius={12}
+          style={styles.skeletonCard}
+        />
+      ))}
+    </>
+  );
+}
+
+function AchievementCard({
+  achievement,
+  onPress,
+}: {
+  achievement: UserAchievementWithDetails;
+  onPress: (a: UserAchievementWithDetails) => void;
+}) {
+  const isUnlocked = achievement.unlockedAt !== null;
+  return (
+    <Pressable
+      style={[styles.card, !isUnlocked && styles.cardLocked]}
+      onPress={() => onPress(achievement)}
+      accessibilityRole="button"
+      accessibilityLabel={`${achievement.name}, ${isUnlocked ? "débloqué" : "verrouillé"}`}
+    >
+      <Text style={styles.icon}>
+        {isUnlocked ? (achievement.icon ?? "🏅") : "🔒"}
+      </Text>
+      <Text style={[styles.name, !isUnlocked && styles.nameLocked]}>
+        {achievement.name}
+      </Text>
+    </Pressable>
+  );
+}
+
+function renderBody(
+  isLoading: boolean,
+  error: string | null,
+  achievements: UserAchievementWithDetails[],
+  onPress: (a: UserAchievementWithDetails) => void,
+) {
+  if (isLoading) return <AchievementSkeletons />;
+  if (error) {
+    return (
+      <Text style={styles.feedbackText}>
+        Impossible de charger tes succès, réessaie plus tard.
+      </Text>
+    );
+  }
+  if (achievements.length === 0) {
+    return (
+      <Text style={styles.feedbackText}>
+        Aucun succès disponible pour le moment.
+      </Text>
+    );
+  }
+  return achievements.map((achievement) => (
+    <AchievementCard
+      key={achievement.id}
+      achievement={achievement}
+      onPress={onPress}
+    />
+  ));
+}
+
+export default function ProfileAchievementsSection() {
+  const { achievements, isLoading, error } = useMyAchievements();
+  const [selected, setSelected] = useState<UserAchievementWithDetails | null>(
+    null,
+  );
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>Succès & Récompenses</Text>
+      <View style={styles.grid}>
+        {renderBody(isLoading, error, achievements, setSelected)}
+      </View>
+      <AchievementDetailModal
+        visible={selected !== null}
+        achievement={selected}
+        onClose={() => setSelected(null)}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: 28,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: Colors.dark.text,
+    marginBottom: 14,
+    borderLeftWidth: 3,
+    borderLeftColor: Colors.primary.CTA,
+    paddingLeft: 10,
+  },
+  grid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  card: {
+    width: "31%",
+    backgroundColor: "#1A1A1A",
+    borderRadius: 12,
+    padding: 12,
+    alignItems: "center",
+    gap: 6,
+    borderWidth: 1,
+    borderColor: Colors.primary.CTA,
+  },
+  cardLocked: {
+    borderColor: "#2A2A2A",
+    opacity: 0.5,
+  },
+  icon: {
+    fontSize: 28,
+  },
+  name: {
+    fontSize: 11,
+    color: Colors.dark.text,
+    textAlign: "center",
+    fontWeight: "600",
+  },
+  nameLocked: {
+    color: Colors.dark.icon,
+  },
+  skeletonCard: {
+    marginBottom: 0,
+  },
+  feedbackText: {
+    fontSize: 13,
+    color: Colors.dark.icon,
+    fontStyle: "italic",
+    paddingVertical: 8,
+    width: "100%",
+    textAlign: "center",
+  },
+});

--- a/front-mobile/components/profile/ProfileSpotifySection.tsx
+++ b/front-mobile/components/profile/ProfileSpotifySection.tsx
@@ -1,0 +1,359 @@
+import React, { useCallback } from "react";
+import {
+  ActivityIndicator,
+  Image,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { FontAwesome } from "@expo/vector-icons";
+import { useFocusEffect } from "expo-router";
+import { Colors } from "@/constants/Colors";
+import { useToast } from "@/components/Toast";
+import { useSpotifyIntegration } from "@/hooks/useSpotifyIntegration";
+import { useSpotifyStats } from "@/hooks/useSpotifyStats";
+import { SpotifyArtist, SpotifyTrack } from "@/types/spotify";
+
+const SPOTIFY_GREEN = "#1DB954";
+const ITEM_LIMIT = 5;
+
+export default function ProfileSpotifySection() {
+  const { status, isLoading, isConnecting, connect, refresh } =
+    useSpotifyIntegration();
+  const { show } = useToast();
+
+  useFocusEffect(
+    useCallback(() => {
+      void refresh();
+    }, [refresh]),
+  );
+
+  if (isLoading) {
+    return (
+      <View style={styles.section}>
+        <View style={styles.skeletonCard} />
+      </View>
+    );
+  }
+
+  const connected = status?.connected === true;
+
+  if (!connected) {
+    const handlePress = async () => {
+      const result = await connect();
+      if (result === "ok") {
+        show({ type: "success", message: "Spotify connecté" });
+      } else if (result === "error") {
+        show({ type: "error", message: "La connexion Spotify a échoué" });
+      }
+    };
+
+    return (
+      <View style={styles.section}>
+        <Pressable
+          style={styles.ctaCard}
+          onPress={handlePress}
+          disabled={isConnecting}
+          accessibilityRole="button"
+          accessibilityLabel="Lier mon compte Spotify"
+        >
+          <View style={styles.ctaIconBadge}>
+            <FontAwesome name="spotify" size={22} color="#0A0A0A" />
+          </View>
+          <View style={styles.ctaContent}>
+            <Text style={styles.ctaTitle}>Voir mes stats Spotify</Text>
+            <Text style={styles.ctaSubtitle}>
+              {isConnecting
+                ? "Connexion en cours…"
+                : "Liez votre compte pour découvrir vos top tracks et artistes"}
+            </Text>
+          </View>
+        </Pressable>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>Mes stats Spotify</Text>
+      <SpotifyTopTracksBlock />
+      <SpotifyTopArtistsBlock />
+      <SpotifyRecentlyPlayedBlock />
+    </View>
+  );
+}
+
+function SpotifyTopTracksBlock() {
+  const { tracks, isLoading, error } = useSpotifyStats({
+    type: "topTracks",
+    timeRange: "medium_term",
+    limit: ITEM_LIMIT,
+  });
+
+  return (
+    <SpotifyBlock title="Top titres" isLoading={isLoading} error={error}>
+      <HorizontalList
+        items={tracks}
+        keyExtractor={(item) => item.id}
+        emptyLabel="Aucun titre à afficher"
+        renderItem={(item) => <SpotifyTrackCard track={item} />}
+      />
+    </SpotifyBlock>
+  );
+}
+
+function SpotifyTopArtistsBlock() {
+  const { artists, isLoading, error } = useSpotifyStats({
+    type: "topArtists",
+    timeRange: "medium_term",
+    limit: ITEM_LIMIT,
+  });
+
+  return (
+    <SpotifyBlock title="Top artistes" isLoading={isLoading} error={error}>
+      <HorizontalList
+        items={artists}
+        keyExtractor={(item) => item.id}
+        emptyLabel="Aucun artiste à afficher"
+        renderItem={(item) => <SpotifyArtistCard artist={item} />}
+      />
+    </SpotifyBlock>
+  );
+}
+
+function SpotifyRecentlyPlayedBlock() {
+  const { recentlyPlayed, isLoading, error } = useSpotifyStats({
+    type: "recentlyPlayed",
+    limit: ITEM_LIMIT,
+  });
+
+  return (
+    <SpotifyBlock title="Récemment écouté" isLoading={isLoading} error={error}>
+      <HorizontalList
+        items={recentlyPlayed}
+        keyExtractor={(item, idx) =>
+          `${item.track.id}-${item.played_at}-${idx}`
+        }
+        emptyLabel="Aucune écoute récente"
+        renderItem={(item) => <SpotifyTrackCard track={item.track} />}
+      />
+    </SpotifyBlock>
+  );
+}
+
+function SpotifyBlock({
+  title,
+  isLoading,
+  error,
+  children,
+}: {
+  title: string;
+  isLoading: boolean;
+  error: string | null;
+  children: React.ReactNode;
+}) {
+  return (
+    <View style={styles.block}>
+      <Text style={styles.blockTitle}>{title}</Text>
+      {isLoading ? (
+        <View style={styles.blockLoader}>
+          <ActivityIndicator color={Colors.primary.survol} />
+        </View>
+      ) : error ? (
+        <Text style={styles.blockMuted}>Données indisponibles</Text>
+      ) : (
+        children
+      )}
+    </View>
+  );
+}
+
+interface HorizontalListProps<T> {
+  items: T[];
+  keyExtractor: (item: T, index: number) => string;
+  renderItem: (item: T, index: number) => React.ReactNode;
+  emptyLabel: string;
+}
+
+function HorizontalList<T>({
+  items,
+  keyExtractor,
+  renderItem,
+  emptyLabel,
+}: HorizontalListProps<T>) {
+  if (items.length === 0) {
+    return <Text style={styles.blockMuted}>{emptyLabel}</Text>;
+  }
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.horizontalListContent}
+    >
+      {items.map((item, idx) => (
+        <View
+          key={keyExtractor(item, idx)}
+          style={idx > 0 ? styles.itemSpacing : undefined}
+        >
+          {renderItem(item, idx)}
+        </View>
+      ))}
+    </ScrollView>
+  );
+}
+
+function SpotifyTrackCard({ track }: { track: SpotifyTrack }) {
+  const cover = track.album?.images?.[0]?.url;
+  return (
+    <View style={styles.card}>
+      {cover ? (
+        <Image source={{ uri: cover }} style={styles.cover} />
+      ) : (
+        <View style={[styles.cover, styles.coverFallback]}>
+          <Text style={styles.coverFallbackIcon}>🎵</Text>
+        </View>
+      )}
+      <Text style={styles.cardTitle} numberOfLines={1}>
+        {track.name}
+      </Text>
+      <Text style={styles.cardSubtitle} numberOfLines={1}>
+        {track.artists.map((a) => a.name).join(", ")}
+      </Text>
+    </View>
+  );
+}
+
+function SpotifyArtistCard({ artist }: { artist: SpotifyArtist }) {
+  const cover = artist.images?.[0]?.url;
+  return (
+    <View style={styles.card}>
+      {cover ? (
+        <Image
+          source={{ uri: cover }}
+          style={[styles.cover, styles.coverRound]}
+        />
+      ) : (
+        <View style={[styles.cover, styles.coverRound, styles.coverFallback]}>
+          <Text style={styles.coverFallbackIcon}>🎤</Text>
+        </View>
+      )}
+      <Text style={styles.cardTitle} numberOfLines={1}>
+        {artist.name}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: {
+    marginBottom: 28,
+  },
+  sectionTitle: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: Colors.dark.text,
+    marginBottom: 14,
+    borderLeftWidth: 3,
+    borderLeftColor: Colors.primary.CTA,
+    paddingLeft: 10,
+  },
+
+  ctaCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    backgroundColor: "#1A1A1A",
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: SPOTIFY_GREEN,
+  },
+  ctaIconBadge: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: SPOTIFY_GREEN,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  ctaContent: {
+    flex: 1,
+  },
+  ctaTitle: {
+    color: Colors.dark.text,
+    fontSize: 15,
+    fontWeight: "700",
+    marginBottom: 2,
+  },
+  ctaSubtitle: {
+    color: Colors.dark.icon,
+    fontSize: 12,
+  },
+
+  skeletonCard: {
+    height: 72,
+    backgroundColor: "#1A1A1A",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#2A2A2A",
+  },
+
+  block: {
+    marginBottom: 18,
+  },
+  blockTitle: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: Colors.dark.text,
+    marginBottom: 8,
+  },
+  blockLoader: {
+    height: 150,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  blockMuted: {
+    color: Colors.dark.icon,
+    fontSize: 12,
+    paddingVertical: 12,
+  },
+
+  horizontalListContent: {
+    paddingRight: 16,
+  },
+  itemSpacing: {
+    marginLeft: 12,
+  },
+  card: {
+    width: 110,
+  },
+  cover: {
+    width: 110,
+    height: 110,
+    borderRadius: 8,
+    backgroundColor: "#222",
+    marginBottom: 6,
+  },
+  coverRound: {
+    borderRadius: 55,
+  },
+  coverFallback: {
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  coverFallbackIcon: {
+    fontSize: 32,
+  },
+  cardTitle: {
+    color: Colors.dark.text,
+    fontSize: 13,
+    fontWeight: "600",
+  },
+  cardSubtitle: {
+    color: Colors.dark.icon,
+    fontSize: 11,
+    marginTop: 2,
+  },
+});

--- a/front-mobile/components/profile/__tests__/AchievementDetailModal.test.tsx
+++ b/front-mobile/components/profile/__tests__/AchievementDetailModal.test.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import AchievementDetailModal from "../AchievementDetailModal";
+import { UserAchievementWithDetails } from "@/types/achievement";
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const unlocked: UserAchievementWithDetails = {
+  id: 1,
+  name: "Première victoire",
+  description: "Gagner sa toute première partie multijoueur",
+  icon: "🥇",
+  type: "FirstWin",
+  currentProgress: 1,
+  requiredProgress: 1,
+  unlockedAt: "2026-05-13T12:00:00Z",
+};
+
+const locked: UserAchievementWithDetails = {
+  id: 2,
+  name: "Vétéran",
+  description: "Jouer 10 parties",
+  icon: "🏆",
+  type: "GamesPlayed",
+  currentProgress: 3,
+  requiredProgress: 10,
+  unlockedAt: null,
+};
+
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2026-05-14T12:00:00Z"));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+describe("AchievementDetailModal", () => {
+  it("returns null when no achievement is provided", () => {
+    const { toJSON } = render(
+      <AchievementDetailModal visible achievement={null} onClose={jest.fn()} />,
+    );
+    expect(toJSON()).toBeNull();
+  });
+
+  it("renders unlocked achievement with icon and relative date", () => {
+    const { getByText } = render(
+      <AchievementDetailModal
+        visible
+        achievement={unlocked}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(getByText("🥇")).toBeTruthy();
+    expect(getByText("Première victoire")).toBeTruthy();
+    expect(getByText(/Débloqué/)).toBeTruthy();
+    expect(getByText(/Hier/)).toBeTruthy();
+  });
+
+  it("renders locked achievement with progress text", () => {
+    const { getByText } = render(
+      <AchievementDetailModal
+        visible
+        achievement={locked}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(getByText("🔒")).toBeTruthy();
+    expect(getByText(/Verrouillé — 3\/10/)).toBeTruthy();
+  });
+
+  it("calls onClose when the Fermer button is pressed", () => {
+    const onClose = jest.fn();
+    const { getByText } = render(
+      <AchievementDetailModal
+        visible
+        achievement={unlocked}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.press(getByText("Fermer"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when the backdrop is pressed", () => {
+    const onClose = jest.fn();
+    const { getByTestId } = render(
+      <AchievementDetailModal
+        visible
+        achievement={unlocked}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.press(getByTestId("achievement-modal-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/front-mobile/components/profile/__tests__/ProfileAchievementsSection.test.tsx
+++ b/front-mobile/components/profile/__tests__/ProfileAchievementsSection.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { fireEvent, render } from "@testing-library/react-native";
+import ProfileAchievementsSection from "../ProfileAchievementsSection";
+import { useMyAchievements } from "@/hooks/useMyAchievements";
+import { UserAchievementWithDetails } from "@/types/achievement";
+
+jest.mock("@/hooks/useMyAchievements", () => ({
+  useMyAchievements: jest.fn(),
+}));
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+const mockUseMyAchievements = useMyAchievements as jest.MockedFunction<
+  typeof useMyAchievements
+>;
+
+const unlocked: UserAchievementWithDetails = {
+  id: 1,
+  name: "Première victoire",
+  description: "Gagner sa toute première partie",
+  icon: "🥇",
+  type: "FirstWin",
+  currentProgress: 1,
+  requiredProgress: 1,
+  unlockedAt: "2026-05-13T12:00:00Z",
+};
+
+const locked: UserAchievementWithDetails = {
+  id: 2,
+  name: "Vétéran",
+  description: "Jouer 10 parties",
+  icon: "🏆",
+  type: "GamesPlayed",
+  currentProgress: 3,
+  requiredProgress: 10,
+  unlockedAt: null,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("ProfileAchievementsSection", () => {
+  it("renders the section title", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByText } = render(<ProfileAchievementsSection />);
+    expect(getByText("Succès & Récompenses")).toBeTruthy();
+  });
+
+  it("renders empty state when no achievements", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByText } = render(<ProfileAchievementsSection />);
+    expect(getByText(/Aucun succès disponible/i)).toBeTruthy();
+  });
+
+  it("renders error feedback when the hook reports an error", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [],
+      isLoading: false,
+      error: "network",
+      refresh: jest.fn(),
+    });
+    const { getByText } = render(<ProfileAchievementsSection />);
+    expect(getByText(/Impossible de charger tes succès/i)).toBeTruthy();
+  });
+
+  it("renders unlocked and locked cards with the right icons", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [unlocked, locked],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByText } = render(<ProfileAchievementsSection />);
+    expect(getByText("🥇")).toBeTruthy();
+    expect(getByText("🔒")).toBeTruthy();
+    expect(getByText("Première victoire")).toBeTruthy();
+    expect(getByText("Vétéran")).toBeTruthy();
+  });
+
+  it("opens the detail modal when a card is pressed", () => {
+    mockUseMyAchievements.mockReturnValue({
+      achievements: [unlocked, locked],
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByLabelText, queryByText, getByText } = render(
+      <ProfileAchievementsSection />,
+    );
+
+    expect(queryByText(/Verrouillé/)).toBeNull();
+    fireEvent.press(getByLabelText("Vétéran, verrouillé"));
+    expect(getByText(/Verrouillé — 3\/10/)).toBeTruthy();
+  });
+});

--- a/front-mobile/hooks/__tests__/useMyAchievements.test.ts
+++ b/front-mobile/hooks/__tests__/useMyAchievements.test.ts
@@ -1,0 +1,86 @@
+import { renderHook, waitFor, act } from "@testing-library/react-native";
+import { useMyAchievements } from "../useMyAchievements";
+import { getMyAchievements } from "@/services/achievementsService";
+import { UserAchievementWithDetails } from "@/types/achievement";
+
+jest.mock("@/services/achievementsService", () => ({
+  getMyAchievements: jest.fn(),
+}));
+
+jest.mock("expo-router", () => ({
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const React = require("react");
+    React.useEffect(() => {
+      const cleanup = callback();
+      return typeof cleanup === "function" ? cleanup : undefined;
+    }, [callback]);
+  },
+}));
+
+const mockGetMyAchievements = getMyAchievements as jest.MockedFunction<
+  typeof getMyAchievements
+>;
+
+const buildAchievement = (
+  override: Partial<UserAchievementWithDetails> = {},
+): UserAchievementWithDetails => ({
+  id: 1,
+  name: "Première victoire",
+  description: "Gagner sa toute première partie",
+  icon: "🥇",
+  type: "FirstWin",
+  currentProgress: 1,
+  requiredProgress: 1,
+  unlockedAt: "2026-05-10T08:00:00Z",
+  ...override,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("useMyAchievements", () => {
+  it("fetches achievements on mount and exposes them", async () => {
+    const data = [buildAchievement()];
+    mockGetMyAchievements.mockResolvedValueOnce(data);
+
+    const { result } = renderHook(() => useMyAchievements());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(mockGetMyAchievements).toHaveBeenCalledTimes(1);
+    expect(result.current.achievements).toEqual(data);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("captures error message on failure", async () => {
+    mockGetMyAchievements.mockRejectedValueOnce(new Error("network down"));
+
+    const { result } = renderHook(() => useMyAchievements());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("network down");
+    expect(result.current.achievements).toEqual([]);
+  });
+
+  it("falls back to 'Unknown error' when thrown value is not an Error", async () => {
+    mockGetMyAchievements.mockRejectedValueOnce("plain string");
+
+    const { result } = renderHook(() => useMyAchievements());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.error).toBe("Unknown error");
+  });
+
+  it("refresh re-triggers the fetch", async () => {
+    mockGetMyAchievements.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useMyAchievements());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetMyAchievements).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(mockGetMyAchievements).toHaveBeenCalledTimes(2);
+  });
+});

--- a/front-mobile/hooks/__tests__/useMyStats.test.ts
+++ b/front-mobile/hooks/__tests__/useMyStats.test.ts
@@ -1,0 +1,106 @@
+import { renderHook, waitFor, act } from "@testing-library/react-native";
+import { useMyStats } from "../useMyStats";
+import { userStatsService } from "@/services/userStatsService";
+
+jest.mock("@/services/userStatsService", () => ({
+  userStatsService: {
+    getMyStats: jest.fn(),
+  },
+}));
+
+jest.mock("expo-router", () => ({
+  useFocusEffect: (callback: () => void | (() => void)) => {
+    const React = require("react");
+    React.useEffect(() => {
+      const cleanup = callback();
+      return typeof cleanup === "function" ? cleanup : undefined;
+    }, [callback]);
+  },
+}));
+
+let mockIsAuthenticated = true;
+jest.mock("@/stores/authStore", () => ({
+  useAuthStore: (selector: (state: { isAuthenticated: boolean }) => unknown) =>
+    selector({ isAuthenticated: mockIsAuthenticated }),
+}));
+
+describe("useMyStats", () => {
+  const mockStats = {
+    totalSwipes: 100,
+    gamesPlayed: 10,
+    streak: 5,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsAuthenticated = true;
+  });
+
+  it("should fetch stats on mount", async () => {
+    (userStatsService.getMyStats as jest.Mock).mockResolvedValue(mockStats);
+
+    const { result } = renderHook(() => useMyStats());
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.stats).toEqual(mockStats);
+    expect(result.current.error).toBeNull();
+    expect(userStatsService.getMyStats).toHaveBeenCalledTimes(1);
+  });
+
+  it("should handle error during fetch", async () => {
+    (userStatsService.getMyStats as jest.Mock).mockRejectedValue(
+      new Error("Network error"),
+    );
+
+    const { result } = renderHook(() => useMyStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.stats).toBeNull();
+    expect(result.current.error).toBe(
+      "Erreur lors du chargement des statistiques",
+    );
+  });
+
+  it("does not fetch when user is not authenticated", async () => {
+    mockIsAuthenticated = false;
+
+    const { result } = renderHook(() => useMyStats());
+
+    await waitFor(() => {
+      expect(userStatsService.getMyStats).not.toHaveBeenCalled();
+    });
+    expect(result.current.loading).toBe(false);
+    expect(result.current.stats).toBeNull();
+  });
+
+  it("should retry fetching stats", async () => {
+    (userStatsService.getMyStats as jest.Mock)
+      .mockRejectedValueOnce(new Error("First fail"))
+      .mockResolvedValueOnce(mockStats);
+
+    const { result } = renderHook(() => useMyStats());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).not.toBeNull();
+
+    await act(async () => {
+      await result.current.retry();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.stats).toEqual(mockStats);
+    expect(result.current.error).toBeNull();
+    expect(userStatsService.getMyStats).toHaveBeenCalledTimes(2);
+  });
+});

--- a/front-mobile/hooks/__tests__/useSwipeMix.test.ts
+++ b/front-mobile/hooks/__tests__/useSwipeMix.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, waitFor } from "@testing-library/react-native";
 import { useSwipeMix } from "../useSwipeMix";
 import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
+import { getSwipemixFeed } from "@/services/swipemixFeedService";
 import { useAudioPlayer } from "../useAudioPlayer";
 import { deezerTracksToCardData } from "@/utils/deezer-adapter";
 import { upsertMyTrackInteraction } from "@/services/trackInteractionsService";
@@ -8,11 +9,15 @@ import { MusicCardData } from "@/components/swipe";
 
 // Mock des dépendances
 jest.mock("@/services/deezer-api");
+jest.mock("@/services/swipemixFeedService");
 jest.mock("../useAudioPlayer");
 jest.mock("@/utils/deezer-adapter");
 jest.mock("@/services/trackInteractionsService");
 
 const mockDeezerAPI = deezerAPI as jest.Mocked<typeof deezerAPI>;
+const mockGetSwipemixFeed = getSwipemixFeed as jest.MockedFunction<
+  typeof getSwipemixFeed
+>;
 const mockUseAudioPlayer = useAudioPlayer as jest.MockedFunction<
   typeof useAudioPlayer
 >;
@@ -135,6 +140,7 @@ describe("useSwipeMix", () => {
         });
       },
     );
+    mockGetSwipemixFeed.mockResolvedValue(mockTracks);
     mockDeezerAPI.getTopTracks.mockResolvedValue({
       data: mockTracks,
       total: mockTracks.length,
@@ -179,7 +185,7 @@ describe("useSwipeMix", () => {
         expect(result.current.isLoadingCards).toBe(false);
       });
 
-      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+      expect(mockGetSwipemixFeed).toHaveBeenCalledWith(10, 0);
       expect(result.current.cards).toHaveLength(10);
       expect(result.current.cards[0].id).toBe("1");
       expect(result.current.cards[0].title).toBe("Track 1");
@@ -193,11 +199,12 @@ describe("useSwipeMix", () => {
         expect(result.current.isLoadingCards).toBe(false);
       });
 
-      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(20, 0);
+      expect(mockGetSwipemixFeed).toHaveBeenCalledWith(20, 0);
     });
 
     it("should handle loading errors", async () => {
       const errorMessage = "Network error";
+      mockGetSwipemixFeed.mockRejectedValueOnce(new Error(errorMessage));
       mockDeezerAPI.getTopTracks.mockRejectedValueOnce(new Error(errorMessage));
 
       const { result } = renderHook(() => useSwipeMix());
@@ -211,6 +218,7 @@ describe("useSwipeMix", () => {
     });
 
     it("should handle non-Error exceptions", async () => {
+      mockGetSwipemixFeed.mockRejectedValueOnce("string error");
       mockDeezerAPI.getTopTracks.mockRejectedValueOnce("string error");
 
       const { result } = renderHook(() => useSwipeMix());
@@ -268,10 +276,9 @@ describe("useSwipeMix", () => {
     });
 
     it("should not trigger a background refetch if cached track already has ISRC", async () => {
-      mockDeezerAPI.getTopTracks.mockResolvedValueOnce({
-        data: mockTracks.map((t) => ({ ...t, isrc: `ISRC${t.id}` })),
-        total: mockTracks.length,
-      });
+      mockGetSwipemixFeed.mockResolvedValueOnce(
+        mockTracks.map((t) => ({ ...t, isrc: `ISRC${t.id}` })),
+      );
 
       const { result } = renderHook(() => useSwipeMix());
 
@@ -582,12 +589,12 @@ describe("useSwipeMix", () => {
         expect(result.current.cards).toHaveLength(10);
       });
 
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       result.current.handlers.onEmpty();
 
       await waitFor(() => {
-        expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+        expect(mockGetSwipemixFeed).toHaveBeenCalledWith(10, 0);
       });
     });
 
@@ -598,30 +605,30 @@ describe("useSwipeMix", () => {
         expect(result.current.cards).toHaveLength(10);
       });
 
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       let resolveLoad: (value: any) => void;
       const slowPromise = new Promise((resolve) => {
         resolveLoad = resolve;
       });
-      mockDeezerAPI.getTopTracks.mockReturnValueOnce(slowPromise as any);
+      mockGetSwipemixFeed.mockReturnValueOnce(slowPromise as any);
 
       // Trigger loadMore (sets isLoadingRef = true)
       const loadMorePromise = result.current.actions.loadMore();
 
-      // Wait for loadMore to actually start (getTopTracks called for the in-flight load)
+      // Wait for loadMore to actually start (feed called for the in-flight load)
       await waitFor(() => {
-        expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledTimes(1);
+        expect(mockGetSwipemixFeed).toHaveBeenCalledTimes(1);
       });
 
       // handleEmpty should be blocked by the lock
       result.current.handlers.onEmpty();
 
-      resolveLoad!({ data: mockTracks, total: mockTracks.length });
+      resolveLoad!(mockTracks);
       await loadMorePromise;
 
-      // getTopTracks called only once (loadMore), not twice (handleEmpty blocked)
-      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledTimes(1);
+      // feed called only once (loadMore), not twice (handleEmpty blocked)
+      expect(mockGetSwipemixFeed).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -636,18 +643,15 @@ describe("useSwipeMix", () => {
       const initialCardCount = result.current.cards.length;
 
       // Clear previous calls
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       // Setup mock for pagination call - return same tracks for simplicity
-      mockDeezerAPI.getTopTracks.mockResolvedValueOnce({
-        data: mockTracks,
-        total: mockTracks.length,
-      });
+      mockGetSwipemixFeed.mockResolvedValueOnce(mockTracks);
 
       await result.current.actions.loadMore();
 
       await waitFor(() => {
-        expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 10);
+        expect(mockGetSwipemixFeed).toHaveBeenCalledWith(10, 10);
         expect(result.current.cards).toHaveLength(initialCardCount + 10);
       });
     });
@@ -660,7 +664,7 @@ describe("useSwipeMix", () => {
       });
 
       // Clear calls from initialization
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       // Setup slow-resolving promise to simulate loading
       let resolveLoad: (value: any) => void;
@@ -668,7 +672,7 @@ describe("useSwipeMix", () => {
         resolveLoad = resolve;
       });
 
-      mockDeezerAPI.getTopTracks.mockReturnValueOnce(slowPromise as any);
+      mockGetSwipemixFeed.mockReturnValueOnce(slowPromise as any);
 
       // Trigger first load (will be slow)
       const loadPromise1 = result.current.actions.loadMore();
@@ -680,23 +684,17 @@ describe("useSwipeMix", () => {
       const loadPromise2 = result.current.actions.loadMore();
 
       // Resolve the slow promise
-      resolveLoad!({
-        data: mockTracks,
-        total: mockTracks.length,
-      });
+      resolveLoad!(mockTracks);
 
       await Promise.all([loadPromise1, loadPromise2]);
 
       // Should only be called once (second call was blocked)
-      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledTimes(1);
+      expect(mockGetSwipemixFeed).toHaveBeenCalledTimes(1);
     });
 
     it("should not load more if no more tracks", async () => {
       // Retourner moins de tracks que la limite
-      mockDeezerAPI.getTopTracks.mockResolvedValueOnce({
-        data: [mockTracks[0]],
-        total: 1,
-      });
+      mockGetSwipemixFeed.mockResolvedValueOnce([mockTracks[0]]);
 
       const { result } = renderHook(() => useSwipeMix());
 
@@ -704,11 +702,11 @@ describe("useSwipeMix", () => {
         expect(result.current.cards).toHaveLength(1);
       });
 
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
       await result.current.actions.loadMore();
 
-      expect(mockDeezerAPI.getTopTracks).not.toHaveBeenCalled();
+      expect(mockGetSwipemixFeed).not.toHaveBeenCalled();
     });
   });
 
@@ -721,19 +719,77 @@ describe("useSwipeMix", () => {
       });
 
       // Clear the mock to verify reload is called with index 0
-      mockDeezerAPI.getTopTracks.mockClear();
+      mockGetSwipemixFeed.mockClear();
 
-      mockDeezerAPI.getTopTracks.mockResolvedValueOnce({
-        data: [mockTracks[0]],
-        total: 1,
-      });
+      mockGetSwipemixFeed.mockResolvedValueOnce([mockTracks[0]]);
 
       await result.current.actions.reload();
 
       await waitFor(() => {
         expect(result.current.cards).toHaveLength(1);
-        expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+        expect(mockGetSwipemixFeed).toHaveBeenCalledWith(10, 0);
       });
+    });
+  });
+
+  describe("backend feed fallback", () => {
+    it("falls back to deezerAPI.getTopTracks when backend returns 5xx", async () => {
+      mockGetSwipemixFeed.mockRejectedValueOnce({
+        message: "Internal error",
+        statusCode: 500,
+      });
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.isLoadingCards).toBe(false);
+      });
+
+      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+      expect(result.current.cards).toHaveLength(10);
+      expect(result.current.error).toBeNull();
+    });
+
+    it("falls back to deezerAPI.getTopTracks when backend throws a network error without statusCode", async () => {
+      mockGetSwipemixFeed.mockRejectedValueOnce(new Error("Network failure"));
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.isLoadingCards).toBe(false);
+      });
+
+      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+      expect(result.current.cards).toHaveLength(10);
+    });
+
+    it("does not fall back when backend returns 401 (auth)", async () => {
+      mockGetSwipemixFeed.mockRejectedValueOnce({
+        message: "Non autorisé",
+        statusCode: 401,
+      });
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.isLoadingCards).toBe(false);
+      });
+
+      expect(mockDeezerAPI.getTopTracks).not.toHaveBeenCalled();
+      expect(result.current.error).toBe("Non autorisé");
+    });
+
+    it("falls back when backend returns an empty feed", async () => {
+      mockGetSwipemixFeed.mockResolvedValueOnce([]);
+
+      const { result } = renderHook(() => useSwipeMix());
+
+      await waitFor(() => {
+        expect(result.current.isLoadingCards).toBe(false);
+      });
+
+      expect(mockDeezerAPI.getTopTracks).toHaveBeenCalledWith(10, 0);
+      expect(result.current.cards).toHaveLength(10);
     });
   });
 });

--- a/front-mobile/hooks/useMyAchievements.ts
+++ b/front-mobile/hooks/useMyAchievements.ts
@@ -1,0 +1,60 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useFocusEffect } from "expo-router";
+import { getMyAchievements } from "@/services/achievementsService";
+import { UserAchievementWithDetails } from "@/types/achievement";
+
+export interface UseMyAchievementsResult {
+  achievements: UserAchievementWithDetails[];
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function useMyAchievements(): UseMyAchievementsResult {
+  const [achievements, setAchievements] = useState<
+    UserAchievementWithDetails[]
+  >([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isMountedRef = useRef(true);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const refresh = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
+    if (isMountedRef.current) {
+      setIsLoading(true);
+      setError(null);
+    }
+
+    try {
+      const data = await getMyAchievements();
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setAchievements(data);
+      }
+    } catch (err) {
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setError(err instanceof Error ? err.message : "Unknown error");
+      }
+    } finally {
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setIsLoading(false);
+      }
+    }
+  }, []);
+
+  useFocusEffect(
+    useCallback(() => {
+      void refresh();
+    }, [refresh]),
+  );
+
+  return { achievements, isLoading, error, refresh };
+}

--- a/front-mobile/hooks/useMyStats.ts
+++ b/front-mobile/hooks/useMyStats.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useFocusEffect } from "expo-router";
+import { userStatsService, UserStats } from "@/services/userStatsService";
+import { useAuthStore } from "@/stores/authStore";
+
+/**
+ * Hook to manage user statistics fetching and state
+ */
+export function useMyStats() {
+  const [stats, setStats] = useState<UserStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+
+  const isMountedRef = useRef(true);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const fetchStats = useCallback(async () => {
+    if (!isAuthenticated) return;
+
+    const requestId = ++requestIdRef.current;
+    if (isMountedRef.current) {
+      setLoading(true);
+      setError(null);
+    }
+
+    try {
+      const data = await userStatsService.getMyStats();
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setStats(data);
+      }
+    } catch (err: unknown) {
+      console.error("[useMyStats] Failed to fetch user stats:", err);
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setError("Erreur lors du chargement des statistiques");
+      }
+    } finally {
+      if (isMountedRef.current && requestIdRef.current === requestId) {
+        setLoading(false);
+      }
+    }
+  }, [isAuthenticated]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (isAuthenticated) {
+        void fetchStats();
+      }
+    }, [fetchStats, isAuthenticated]),
+  );
+
+  return {
+    stats,
+    loading: isAuthenticated ? loading : false,
+    error,
+    retry: fetchStats,
+  };
+}

--- a/front-mobile/hooks/useSwipeMix.ts
+++ b/front-mobile/hooks/useSwipeMix.ts
@@ -1,14 +1,50 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { deezerAPI, DeezerTrack } from "@/services/deezer-api";
 import { cacheManager } from "@/services/cache-manager";
+import { getSwipemixFeed } from "@/services/swipemixFeedService";
 import { upsertMyTrackInteraction } from "@/services/trackInteractionsService";
 import {
   InteractionAction,
   SpotifyTriggerSnapshot,
 } from "@/types/trackInteraction";
+import { ApiError } from "@/types/auth";
 import { MusicCardData } from "@/components/swipe";
 import { deezerTracksToCardData } from "@/utils/deezer-adapter";
 import { useAudioPlayer } from "./useAudioPlayer";
+
+const getApiErrorStatus = (error: unknown): number | undefined => {
+  if (typeof error !== "object" || error === null) return undefined;
+  const status = (error as ApiError).statusCode;
+  return typeof status === "number" ? status : undefined;
+};
+
+const extractErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "object" && error !== null) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") return message;
+  }
+  return "Erreur lors du chargement des musiques";
+};
+
+const shouldFallbackToDeezer = (error: unknown): boolean => {
+  const status = getApiErrorStatus(error);
+  return status === undefined || status >= 500;
+};
+
+const fetchFeedWithFallback = async (
+  limit: number,
+  offset: number,
+): Promise<DeezerTrack[]> => {
+  try {
+    const tracks = await getSwipemixFeed(limit, offset);
+    if (tracks.length > 0) return tracks;
+  } catch (error) {
+    if (!shouldFallbackToDeezer(error)) throw error;
+  }
+  const response = await deezerAPI.getTopTracks(limit, offset);
+  return response.data;
+};
 
 interface UseSwipeMixOptions {
   initialLimit?: number;
@@ -62,14 +98,17 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
         // Utiliser l'index actuel pour la pagination
         const indexToUse = append ? currentPageIndexRef.current : 0;
 
-        // Récupérer les morceaux tendances
-        const response = await deezerAPI.getTopTracks(initialLimit, indexToUse);
+        // Récupérer le feed personnalisé (avec fallback sur le top Deezer en cas d'erreur backend)
+        const feedTracks = await fetchFeedWithFallback(
+          initialLimit,
+          indexToUse,
+        );
 
         // Récupérer les genres et les détails des albums (pour avoir le genre_id) en parallèle
         // Note: deezerAPI utilise déjà le cacheManager
         const [genresResponse, ...albums] = await Promise.all([
           deezerAPI.getGenres(),
-          ...response.data.map((track) => deezerAPI.getAlbum(track.album.id)),
+          ...feedTracks.map((track) => deezerAPI.getAlbum(track.album.id)),
         ]);
 
         // Créer les mappings pour l'adapter
@@ -95,13 +134,13 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
 
         // Convertir en cartes avec les informations de genre
         const newCards = deezerTracksToCardData(
-          response.data,
+          feedTracks,
           genreMapping,
           albumGenresMapping,
         );
 
         // Vérifier s'il y a encore des musiques à charger
-        setHasMoreTracks(response.data.length === initialLimit);
+        setHasMoreTracks(feedTracks.length === initialLimit);
 
         if (append) {
           // Ajouter les nouvelles cartes à la fin
@@ -110,7 +149,7 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
           // Ajouter les nouvelles tracks à la map existante
           setTracks((prev) => {
             const newMap = new Map(prev);
-            response.data.forEach((track) => {
+            feedTracks.forEach((track) => {
               newMap.set(track.id.toString(), track);
             });
             return newMap;
@@ -121,7 +160,7 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
         } else {
           // Remplacer complètement les cartes et tracks
           const trackMap = new Map<string, DeezerTrack>();
-          response.data.forEach((track) => {
+          feedTracks.forEach((track) => {
             trackMap.set(track.id.toString(), track);
           });
 
@@ -130,11 +169,7 @@ export function useSwipeMix(options: UseSwipeMixOptions = {}) {
           currentPageIndexRef.current = initialLimit;
         }
       } catch (err) {
-        setError(
-          err instanceof Error
-            ? err.message
-            : "Erreur lors du chargement des musiques",
-        );
+        setError(extractErrorMessage(err));
       } finally {
         isLoadingRef.current = false;
         setIsLoadingCards(false);

--- a/front-mobile/services/__tests__/achievementsService.test.ts
+++ b/front-mobile/services/__tests__/achievementsService.test.ts
@@ -1,0 +1,98 @@
+import { getMyAchievements } from "../achievementsService";
+import { get } from "../api";
+import { UserAchievement } from "@/types/achievement";
+
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
+
+jest.mock("../api", () => ({
+  get: jest.fn(),
+}));
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const baseUserAchievement = (
+  override: Partial<UserAchievement> = {},
+): UserAchievement => ({
+  id: "ua-1",
+  userId: "user-1",
+  achievementId: 1,
+  currentProgress: 1,
+  requiredProgress: 1,
+  currentTier: 1,
+  unlockedAt: "2026-05-10T08:00:00Z",
+  achievement: {
+    id: 1,
+    name: "Première victoire",
+    description: "Gagner sa toute première partie multijoueur",
+    icon: "🥇",
+    type: "FirstWin",
+  },
+  ...override,
+});
+
+describe("achievementsService", () => {
+  it("GETs the user achievements endpoint", async () => {
+    mockGet.mockResolvedValueOnce({ userAchievements: [] });
+    await getMyAchievements();
+    expect(mockGet).toHaveBeenCalledWith("/api/user-achievements/me");
+  });
+
+  it("flattens the nested achievement relation into a single object", async () => {
+    const unlocked = baseUserAchievement();
+    const locked = baseUserAchievement({
+      id: "ua-2",
+      achievementId: 2,
+      currentProgress: 3,
+      requiredProgress: 10,
+      unlockedAt: null,
+      achievement: {
+        id: 2,
+        name: "Vétéran",
+        description: "Jouer 10 parties",
+        icon: "🏆",
+        type: "GamesPlayed",
+      },
+    });
+
+    mockGet.mockResolvedValueOnce({ userAchievements: [unlocked, locked] });
+
+    const result = await getMyAchievements();
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: "Première victoire",
+        description: "Gagner sa toute première partie multijoueur",
+        icon: "🥇",
+        type: "FirstWin",
+        currentProgress: 1,
+        requiredProgress: 1,
+        unlockedAt: "2026-05-10T08:00:00Z",
+      },
+      {
+        id: 2,
+        name: "Vétéran",
+        description: "Jouer 10 parties",
+        icon: "🏆",
+        type: "GamesPlayed",
+        currentProgress: 3,
+        requiredProgress: 10,
+        unlockedAt: null,
+      },
+    ]);
+  });
+
+  it("returns an empty array when no achievements are returned", async () => {
+    mockGet.mockResolvedValueOnce({ userAchievements: [] });
+    expect(await getMyAchievements()).toEqual([]);
+  });
+
+  it("propagates API errors", async () => {
+    mockGet.mockRejectedValueOnce(new Error("network down"));
+    await expect(getMyAchievements()).rejects.toThrow("network down");
+  });
+});

--- a/front-mobile/services/__tests__/swipemixFeedService.test.ts
+++ b/front-mobile/services/__tests__/swipemixFeedService.test.ts
@@ -1,0 +1,41 @@
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
+
+import { getSwipemixFeed } from "../swipemixFeedService";
+import { get } from "../api";
+import { DeezerTrack } from "../deezer-api";
+
+jest.mock("../api", () => ({
+  get: jest.fn(),
+}));
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("swipemixFeedService", () => {
+  const mockTrack = {
+    id: 1,
+    title: "Track 1",
+  } as unknown as DeezerTrack;
+
+  it("GETs /api/me/swipemix/feed with limit and offset", async () => {
+    mockGet.mockResolvedValueOnce({ tracks: [mockTrack] });
+
+    const result = await getSwipemixFeed(20, 10);
+
+    expect(mockGet).toHaveBeenCalledWith(
+      "/api/me/swipemix/feed?limit=20&offset=10",
+    );
+    expect(result).toEqual([mockTrack]);
+  });
+
+  it("returns an empty array when the response has no tracks field", async () => {
+    mockGet.mockResolvedValueOnce({} as { tracks: DeezerTrack[] });
+
+    const result = await getSwipemixFeed(10, 0);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/front-mobile/services/__tests__/userStatsService.test.ts
+++ b/front-mobile/services/__tests__/userStatsService.test.ts
@@ -1,0 +1,33 @@
+import { userStatsService } from "../userStatsService";
+import { get } from "../api";
+
+process.env.EXPO_PUBLIC_API_URL = "https://api.rythmix.test";
+
+jest.mock("../api", () => ({
+  get: jest.fn(),
+}));
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("userStatsService", () => {
+  it("getMyStats GETs /api/me/stats and returns the data field", async () => {
+    mockGet.mockResolvedValueOnce({
+      data: { totalSwipes: 12, gamesPlayed: 3, streak: 2 },
+    });
+
+    const result = await userStatsService.getMyStats();
+
+    expect(mockGet).toHaveBeenCalledWith("/api/me/stats");
+    expect(result).toEqual({ totalSwipes: 12, gamesPlayed: 3, streak: 2 });
+  });
+
+  it("propagates errors from the api layer", async () => {
+    mockGet.mockRejectedValueOnce(new Error("network down"));
+
+    await expect(userStatsService.getMyStats()).rejects.toThrow("network down");
+  });
+});

--- a/front-mobile/services/achievementsService.ts
+++ b/front-mobile/services/achievementsService.ts
@@ -1,0 +1,28 @@
+import { get } from "./api";
+import {
+  GetMyAchievementsResponse,
+  UserAchievement,
+  UserAchievementWithDetails,
+} from "@/types/achievement";
+
+function flatten(item: UserAchievement): UserAchievementWithDetails {
+  return {
+    id: item.achievement.id,
+    name: item.achievement.name,
+    description: item.achievement.description,
+    icon: item.achievement.icon,
+    type: item.achievement.type,
+    currentProgress: item.currentProgress,
+    requiredProgress: item.requiredProgress,
+    unlockedAt: item.unlockedAt,
+  };
+}
+
+export const getMyAchievements = async (): Promise<
+  UserAchievementWithDetails[]
+> => {
+  const data = await get<GetMyAchievementsResponse>(
+    "/api/user-achievements/me",
+  );
+  return data.userAchievements.map(flatten);
+};

--- a/front-mobile/services/swipemixFeedService.ts
+++ b/front-mobile/services/swipemixFeedService.ts
@@ -1,0 +1,16 @@
+import { get } from "./api";
+import { DeezerTrack } from "./deezer-api";
+
+interface SwipemixFeedResponse {
+  tracks: DeezerTrack[];
+}
+
+export const getSwipemixFeed = async (
+  limit: number,
+  offset: number,
+): Promise<DeezerTrack[]> => {
+  const data = await get<SwipemixFeedResponse>(
+    `/api/me/swipemix/feed?limit=${limit}&offset=${offset}`,
+  );
+  return data.tracks ?? [];
+};

--- a/front-mobile/services/userStatsService.ts
+++ b/front-mobile/services/userStatsService.ts
@@ -1,0 +1,17 @@
+import { get } from "./api";
+
+export interface UserStats {
+  totalSwipes: number;
+  gamesPlayed: number;
+  streak: number;
+}
+
+export const userStatsService = {
+  /**
+   * Fetch aggregated statistics for the current user
+   */
+  getMyStats: async (): Promise<UserStats> => {
+    const response = await get<{ data: UserStats }>("/api/me/stats");
+    return response.data;
+  },
+};

--- a/front-mobile/types/achievement.ts
+++ b/front-mobile/types/achievement.ts
@@ -1,0 +1,33 @@
+export interface Achievement {
+  id: number;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  type: string;
+}
+
+export interface UserAchievement {
+  id: string | null;
+  userId: string;
+  achievementId: number;
+  currentProgress: number;
+  requiredProgress: number;
+  currentTier: number;
+  unlockedAt: string | null;
+  achievement: Achievement;
+}
+
+export interface UserAchievementWithDetails {
+  id: number;
+  name: string;
+  description: string | null;
+  icon: string | null;
+  type: string;
+  currentProgress: number;
+  requiredProgress: number;
+  unlockedAt: string | null;
+}
+
+export interface GetMyAchievementsResponse {
+  userAchievements: UserAchievement[];
+}

--- a/front-mobile/utils/__tests__/relative-date.test.ts
+++ b/front-mobile/utils/__tests__/relative-date.test.ts
@@ -1,0 +1,67 @@
+import { formatRelativeDate } from "../relative-date";
+
+describe("formatRelativeDate", () => {
+  const NOW = new Date("2026-05-14T12:00:00.000Z").getTime();
+
+  beforeAll(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(NOW);
+  });
+
+  afterAll(() => {
+    jest.useRealTimers();
+  });
+
+  const offset = (ms: number) => new Date(NOW - ms).toISOString();
+
+  it("returns 'À l'instant' for under one minute", () => {
+    expect(formatRelativeDate(offset(30 * 1000))).toBe("À l'instant");
+  });
+
+  it("returns minutes for under one hour", () => {
+    expect(formatRelativeDate(offset(5 * 60_000))).toBe("Il y a 5 min");
+  });
+
+  it("returns hours for under one day", () => {
+    expect(formatRelativeDate(offset(3 * 60 * 60_000))).toBe("Il y a 3h");
+  });
+
+  it("returns 'Hier' for exactly one day", () => {
+    expect(formatRelativeDate(offset(24 * 60 * 60_000))).toBe("Hier");
+  });
+
+  it("returns days for between 2 and 6 days", () => {
+    expect(formatRelativeDate(offset(3 * 24 * 60 * 60_000))).toBe(
+      "Il y a 3 jours",
+    );
+  });
+
+  it("returns weeks for between 7 and 29 days", () => {
+    expect(formatRelativeDate(offset(14 * 24 * 60 * 60_000))).toBe(
+      "Il y a 2 sem.",
+    );
+  });
+
+  it("returns months for between 30 and 364 days", () => {
+    expect(formatRelativeDate(offset(90 * 24 * 60 * 60_000))).toBe(
+      "Il y a 3 mois",
+    );
+  });
+
+  it("returns 'Il y a 1 an' for one year", () => {
+    expect(formatRelativeDate(offset(365 * 24 * 60 * 60_000))).toBe(
+      "Il y a 1 an",
+    );
+  });
+
+  it("returns years for more than one year", () => {
+    expect(formatRelativeDate(offset(3 * 365 * 24 * 60 * 60_000))).toBe(
+      "Il y a 3 ans",
+    );
+  });
+
+  it("clamps future dates to 'À l'instant'", () => {
+    const future = new Date(NOW + 10 * 60_000).toISOString();
+    expect(formatRelativeDate(future)).toBe("À l'instant");
+  });
+});

--- a/front-mobile/utils/relative-date.ts
+++ b/front-mobile/utils/relative-date.ts
@@ -1,0 +1,23 @@
+export function formatRelativeDate(date: string): string {
+  const target = new Date(date).getTime();
+  const now = Date.now();
+  const diffMs = Math.max(0, now - target);
+  const diffMinutes = Math.floor(diffMs / 60_000);
+  if (diffMinutes < 1) return "À l'instant";
+  if (diffMinutes < 60) return `Il y a ${diffMinutes} min`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `Il y a ${diffHours}h`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays === 1) return "Hier";
+  if (diffDays < 7) return `Il y a ${diffDays} jours`;
+  if (diffDays < 30) {
+    const diffWeeks = Math.floor(diffDays / 7);
+    return `Il y a ${diffWeeks} sem.`;
+  }
+  if (diffDays < 365) {
+    const diffMonths = Math.floor(diffDays / 30);
+    return `Il y a ${diffMonths} mois`;
+  }
+  const diffYears = Math.floor(diffDays / 365);
+  return diffYears === 1 ? "Il y a 1 an" : `Il y a ${diffYears} ans`;
+}


### PR DESCRIPTION
## Résumé

Branche de release agrégeant exactement 4 tickets, chacun rebasé/cherry-picked depuis main pour respecter le workflow (staging jamais mergé dans main).

### Tickets

- **MIX-291** : Feed SwipeMix personnalisé (familiar/discovery) avec fallback Deezer
- **MIX-311** : Section Spotify dans le profil (CTA + blocs stats)
- **MIX-310** : Statistiques profil (swipes, parties jouées, streak avec timezone) — rebasé sur main via `MIX-310-clean`
- **MIX-314** : Section succès/achievements + bottom sheet détail — rebasé sur main via `MIX-314-clean` (formatRelativeDate inliné, dépendance MIX-312 retirée)

### Conflits résolus

1. **`useSwipeMix.ts`** : combine le hotfix `buildGenreMappings` (best-effort Deezer genres) et `fetchFeedWithFallback` (feed perso + fallback Deezer)
2. **`backend/start/routes.ts`** : ajout simultané de `/me/stats` et `/me/swipemix/feed`
3. **`front-mobile/app/(tabs)/profile/index.tsx`** :
   - Imports `ProfileSpotifySection` + `ProfileAchievementsSection`
   - Suppression de `MOCK_BADGES` (remplacé par `<ProfileAchievementsSection />`)
   - Suppression des mocks orphelins `MOCK_RECENT_ACTIVITIES` et `MOCK_LEVEL` (les sections JSX correspondantes étaient déjà retirées par MIX-310)
   - Cleanup des styles inutilisés (badges, activities, level)

### Notes

- `MIX-314-clean` ne contient PAS le refactor `extract formatRelativeDate` qui touchait `ProfileRecentActivities.tsx` (dépendance MIX-312, non incluse dans cette release). Le helper `formatRelativeDate` reste défini dans `utils/relative-date.ts` et n'est utilisé que par `ProfileAchievementsSection`/`AchievementDetailModal`.
- Section "Activités récentes" pas incluse dans cette release (MIX-312 non rebasé).

## Parcours de test

### Mobile — Profil
1. **Stats (MIX-310)** : ouvrir Profil → 3 cartes Swipes/Parties jouées/Streak. Streak affiche ` j` quand > 0. Forcer une erreur réseau → bouton "Réessayer".
2. **Spotify (MIX-311)** : si non lié, CTA "Connecter Spotify". Si lié, top tracks/artists/recent. Tester retour OAuth Android via `/spotify-linked`.
3. **Succès (MIX-314)** : section "Succès & Récompenses" → liste des achievements (y compris jamais débloqués avec defaults). Tap → bottom sheet détail.
4. **Ordre des sections** : Header → Stats → Spotify → Succès → Mes artistes favoris → Logout. Vérifier qu'il n'y a pas de "trou" visuel.

### Mobile — SwipeMix
5. **Feed perso (MIX-291)** : SwipeMix charge depuis `/me/swipemix/feed`. Vérifier logs réseau.
6. **Fallback Deezer** : couper le backend → cartes Deezer top apparaissent (pas de crash).
7. **Hotfix Deezer quota** : si Deezer renvoie 200 + body error → cartes s'affichent sans tags (best-effort).
8. **Pagination** : swiper jusqu'à la fin du paquet → nouveau lot.

### Backend
9. `GET /api/me/stats` avec auth → 200 + `{ totalSwipes, gamesPlayed, streak }`.
10. `GET /api/me/swipemix/feed?limit=10&offset=0` → tracks personnalisées (familiar + discovery).
11. `GET /api/me/spotify/top-tracks` / `top-artists` / `recently-played` avec compte lié → 200.
12. `GET /api/user-achievements` → liste complète avec defaults pour ceux jamais débloqués.

### CI / Qualité
13. `npm run check` sur les 3 parts (front-mobile, backend, back-office).
14. Coverage backend 100% (sinon CI fail).
15. SonarQube.

## Risques

- **useSwipeMix.ts** : conflit résolu manuellement, combine 2 fonctionnalités → fichier à tester en priorité.
- **profile/index.tsx** : 2 nouvelles sections + suppression de 3 mocks → vérifier le rendu visuel complet.
- **Section Activités récentes absente** : c'est attendu (MIX-312 non inclus). Si tu veux la rajouter, il faudra inclure aussi MIX-312 dans la release.