### PR TITLE
MIX-317 feat: typed auth errors + spotify-style verify-email deep link (expo go compatible)

### DIFF
--- a/backend/app/controllers/auth_controller.ts
+++ b/backend/app/controllers/auth_controller.ts
@@ -8,6 +8,7 @@ import {
 } from '#validators/auth_validator'
 import { errors } from '@vinejs/vine'
 import { ApiBody, ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
+import { AuthException } from '#exceptions/auth_exception'
 
 export default class AuthController {
   private authService: AuthService
@@ -118,15 +119,10 @@ export default class AuthController {
         })
       }
 
-      if (error instanceof Error && error.message === 'Invalid credentials') {
-        return response.unauthorized({
-          message: 'Invalid credentials',
-        })
-      }
-
-      if (error instanceof Error && error.message === 'Email not verified') {
-        return response.forbidden({
-          message: 'Please verify your email before logging in',
+      if (error instanceof AuthException) {
+        return response.status(error.statusCode).send({
+          code: error.code,
+          message: error.message,
         })
       }
 
@@ -171,11 +167,9 @@ export default class AuthController {
         })
       }
 
-      if (
-        error instanceof Error &&
-        (error.message === 'Invalid refresh token' || error.message === 'Refresh token expired')
-      ) {
-        return response.unauthorized({
+      if (error instanceof AuthException) {
+        return response.status(error.statusCode).send({
+          code: error.code,
           message: error.message,
         })
       }
@@ -264,15 +258,10 @@ export default class AuthController {
         },
       })
     } catch (error: unknown) {
-      if (error instanceof Error && error.message === 'Invalid verification token') {
-        return response.badRequest({
-          message: 'Invalid verification token',
-        })
-      }
-
-      if (error instanceof Error && error.message === 'Verification token expired') {
-        return response.badRequest({
-          message: 'Verification token expired. Please request a new one.',
+      if (error instanceof AuthException) {
+        return response.status(error.statusCode).send({
+          code: error.code,
+          message: error.message,
         })
       }
 

--- a/backend/app/controllers/auth_controller.ts
+++ b/backend/app/controllers/auth_controller.ts
@@ -12,6 +12,7 @@ import { AuthException } from '#exceptions/auth_exception'
 import env from '#start/env'
 
 const VERIFY_EMAIL_DEEP_LINK_PATH = 'verify-email'
+const ALLOWED_DEEP_LINK_SCHEMES = /^(exp|frontmobile):\/\//
 
 export default class AuthController {
   private authService: AuthService
@@ -303,7 +304,7 @@ export default class AuthController {
 
   private buildRedirectUrl(status: 'ok' | 'error', reason?: string, returnBase?: string): string {
     const baseUrl =
-      returnBase && /^(exp|frontmobile):\/\//.test(returnBase)
+      returnBase && ALLOWED_DEEP_LINK_SCHEMES.test(returnBase)
         ? returnBase
         : `${env.get('MOBILE_DEEP_LINK_SCHEME', 'frontmobile')}://${VERIFY_EMAIL_DEEP_LINK_PATH}`
 

--- a/backend/app/controllers/auth_controller.ts
+++ b/backend/app/controllers/auth_controller.ts
@@ -282,27 +282,35 @@ export default class AuthController {
   @ApiResponse({ status: 302, description: 'Redirect to the mobile deep-link' })
   async verifyEmailFromLink({ request, response }: HttpContext) {
     const token = request.qs().token as string | undefined
+    const returnBase = request.qs().return as string | undefined
 
     if (!token) {
-      return response.redirect(this.buildRedirectUrl('error', 'E_INVALID_VERIFICATION_TOKEN'))
+      return response.redirect(
+        this.buildRedirectUrl('error', 'E_INVALID_VERIFICATION_TOKEN', returnBase)
+      )
     }
 
     try {
       await this.authService.verifyEmail(token)
-      return response.redirect(this.buildRedirectUrl('ok'))
+      return response.redirect(this.buildRedirectUrl('ok', undefined, returnBase))
     } catch (error: unknown) {
       if (error instanceof AuthException) {
-        return response.redirect(this.buildRedirectUrl('error', error.code))
+        return response.redirect(this.buildRedirectUrl('error', error.code, returnBase))
       }
-      return response.redirect(this.buildRedirectUrl('error', 'E_UNKNOWN'))
+      return response.redirect(this.buildRedirectUrl('error', 'E_UNKNOWN', returnBase))
     }
   }
 
-  private buildRedirectUrl(status: 'ok' | 'error', reason?: string): string {
-    const scheme = env.get('MOBILE_DEEP_LINK_SCHEME', 'frontmobile')
+  private buildRedirectUrl(status: 'ok' | 'error', reason?: string, returnBase?: string): string {
+    const baseUrl =
+      returnBase && /^(exp|frontmobile):\/\//.test(returnBase)
+        ? returnBase
+        : `${env.get('MOBILE_DEEP_LINK_SCHEME', 'frontmobile')}://${VERIFY_EMAIL_DEEP_LINK_PATH}`
+
+    const separator = baseUrl.includes('?') ? '&' : '?'
     const params = new URLSearchParams({ status })
     if (reason) params.set('reason', reason)
-    return `${scheme}://${VERIFY_EMAIL_DEEP_LINK_PATH}?${params.toString()}`
+    return `${baseUrl}${separator}${params.toString()}`
   }
 
   @ApiOperation({
@@ -324,9 +332,9 @@ export default class AuthController {
   @ApiResponse({ status: 422, description: 'Validation failed' })
   async resendVerificationEmail({ request, response }: HttpContext) {
     try {
-      const { email } = await request.validateUsing(resendVerificationValidator)
+      const { email, verifyDeepLinkUrl } = await request.validateUsing(resendVerificationValidator)
 
-      await this.authService.resendVerificationEmail(email)
+      await this.authService.resendVerificationEmail(email, verifyDeepLinkUrl)
 
       return response.ok({
         message: 'If the email exists and is not verified, a verification email has been sent',

--- a/backend/app/controllers/auth_controller.ts
+++ b/backend/app/controllers/auth_controller.ts
@@ -9,6 +9,9 @@ import {
 import { errors } from '@vinejs/vine'
 import { ApiBody, ApiOperation, ApiResponse, ApiSecurity } from '@foadonis/openapi/decorators'
 import { AuthException } from '#exceptions/auth_exception'
+import env from '#start/env'
+
+const VERIFY_EMAIL_DEEP_LINK_PATH = 'verify-email'
 
 export default class AuthController {
   private authService: AuthService
@@ -269,6 +272,37 @@ export default class AuthController {
         message: 'An error occurred during email verification',
       })
     }
+  }
+
+  @ApiOperation({
+    summary: 'Verify email from link and redirect to mobile app',
+    description:
+      'Handles the email verification link click: validates the token and redirects to the mobile deep-link with status=ok or status=error&reason=<code>. Mirrors the Spotify OAuth callback pattern.',
+  })
+  @ApiResponse({ status: 302, description: 'Redirect to the mobile deep-link' })
+  async verifyEmailFromLink({ request, response }: HttpContext) {
+    const token = request.qs().token as string | undefined
+
+    if (!token) {
+      return response.redirect(this.buildRedirectUrl('error', 'E_INVALID_VERIFICATION_TOKEN'))
+    }
+
+    try {
+      await this.authService.verifyEmail(token)
+      return response.redirect(this.buildRedirectUrl('ok'))
+    } catch (error: unknown) {
+      if (error instanceof AuthException) {
+        return response.redirect(this.buildRedirectUrl('error', error.code))
+      }
+      return response.redirect(this.buildRedirectUrl('error', 'E_UNKNOWN'))
+    }
+  }
+
+  private buildRedirectUrl(status: 'ok' | 'error', reason?: string): string {
+    const scheme = env.get('MOBILE_DEEP_LINK_SCHEME', 'frontmobile')
+    const params = new URLSearchParams({ status })
+    if (reason) params.set('reason', reason)
+    return `${scheme}://${VERIFY_EMAIL_DEEP_LINK_PATH}?${params.toString()}`
   }
 
   @ApiOperation({

--- a/backend/app/enums/auth_error_code.ts
+++ b/backend/app/enums/auth_error_code.ts
@@ -1,0 +1,11 @@
+export const AUTH_ERROR_CODE = {
+  InvalidCredentials: 'E_INVALID_CREDENTIALS',
+  EmailNotVerified: 'E_EMAIL_NOT_VERIFIED',
+  InvalidRefreshToken: 'E_INVALID_REFRESH_TOKEN',
+  RefreshTokenExpired: 'E_REFRESH_TOKEN_EXPIRED',
+  InvalidVerificationToken: 'E_INVALID_VERIFICATION_TOKEN',
+  VerificationTokenExpired: 'E_VERIFICATION_TOKEN_EXPIRED',
+  Unauthorized: 'E_UNAUTHORIZED',
+} as const
+
+export type AuthErrorCode = (typeof AUTH_ERROR_CODE)[keyof typeof AUTH_ERROR_CODE]

--- a/backend/app/exceptions/auth_exception.ts
+++ b/backend/app/exceptions/auth_exception.ts
@@ -1,0 +1,49 @@
+import { AUTH_ERROR_CODE, type AuthErrorCode } from '#enums/auth_error_code'
+
+export class AuthException extends Error {
+  readonly code: AuthErrorCode
+  readonly statusCode: number
+
+  constructor(code: AuthErrorCode, message: string, statusCode: number) {
+    super(message)
+    this.name = 'AuthException'
+    this.code = code
+    this.statusCode = statusCode
+  }
+
+  static invalidCredentials(): AuthException {
+    return new AuthException(AUTH_ERROR_CODE.InvalidCredentials, 'Invalid credentials', 401)
+  }
+
+  static emailNotVerified(): AuthException {
+    return new AuthException(AUTH_ERROR_CODE.EmailNotVerified, 'Email not verified', 403)
+  }
+
+  static invalidRefreshToken(): AuthException {
+    return new AuthException(AUTH_ERROR_CODE.InvalidRefreshToken, 'Invalid refresh token', 401)
+  }
+
+  static refreshTokenExpired(): AuthException {
+    return new AuthException(AUTH_ERROR_CODE.RefreshTokenExpired, 'Refresh token expired', 401)
+  }
+
+  static invalidVerificationToken(): AuthException {
+    return new AuthException(
+      AUTH_ERROR_CODE.InvalidVerificationToken,
+      'Invalid verification token',
+      400
+    )
+  }
+
+  static verificationTokenExpired(): AuthException {
+    return new AuthException(
+      AUTH_ERROR_CODE.VerificationTokenExpired,
+      'Verification token expired',
+      400
+    )
+  }
+
+  static unauthorized(): AuthException {
+    return new AuthException(AUTH_ERROR_CODE.Unauthorized, 'Unauthorized access', 401)
+  }
+}

--- a/backend/app/middleware/auth_middleware.ts
+++ b/backend/app/middleware/auth_middleware.ts
@@ -1,6 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
 import type { Authenticators } from '@adonisjs/auth/types'
+import { AUTH_ERROR_CODE } from '#enums/auth_error_code'
 
 /**
  * Auth middleware is used authenticate HTTP requests and deny
@@ -26,6 +27,7 @@ export default class AuthMiddleware {
       }
 
       return ctx.response.unauthorized({
+        code: AUTH_ERROR_CODE.Unauthorized,
         message: 'Unauthorized access',
       })
     }

--- a/backend/app/services/auth_service.ts
+++ b/backend/app/services/auth_service.ts
@@ -7,6 +7,7 @@ import hash from '@adonisjs/core/services/hash'
 import mail from '@adonisjs/mail/services/main'
 import env from '#start/env'
 import AuthSessionCreated from '#events/auth_session_created'
+import { AuthException } from '#exceptions/auth_exception'
 
 export class AuthService {
   async register(data: {
@@ -65,22 +66,17 @@ export class AuthService {
     const user = await User.findBy('email', email)
 
     if (!user) {
-      throw new Error('Invalid credentials')
+      throw AuthException.invalidCredentials()
     }
 
     const isPasswordValid = await hash.verify(user.password, password)
 
     if (!isPasswordValid) {
-      throw new Error('Invalid credentials')
+      throw AuthException.invalidCredentials()
     }
 
-    // make this check optional for dev mode
-    // if (!user.emailVerifiedAt) {
-    //   throw new Error('Email not verified')
-    // }
-
     if (!user.emailVerifiedAt) {
-      throw new Error('Email not verified')
+      throw AuthException.emailNotVerified()
     }
 
     await this.recordSession(user)
@@ -103,7 +99,7 @@ export class AuthService {
   async refresh(refreshTokenValue: string) {
     const parts = refreshTokenValue.split('.')
     if (parts.length !== 2) {
-      throw new Error('Invalid refresh token')
+      throw AuthException.invalidRefreshToken()
     }
 
     const [selector, verifier] = parts
@@ -114,17 +110,17 @@ export class AuthService {
       .first()
 
     if (!refreshToken) {
-      throw new Error('Invalid refresh token')
+      throw AuthException.invalidRefreshToken()
     }
 
     if (refreshToken.expiresAt < DateTime.now()) {
       await refreshToken.delete()
-      throw new Error('Refresh token expired')
+      throw AuthException.refreshTokenExpired()
     }
 
     const isValid = await hash.verify(refreshToken.tokenHash, verifier)
     if (!isValid) {
-      throw new Error('Invalid refresh token')
+      throw AuthException.invalidRefreshToken()
     }
 
     const accessToken = await User.accessTokens.create(refreshToken.user, ['*'], {
@@ -180,7 +176,7 @@ export class AuthService {
   async verifyEmail(token: string) {
     const parts = token.split('.')
     if (parts.length !== 2) {
-      throw new Error('Invalid verification token')
+      throw AuthException.invalidVerificationToken()
     }
 
     const [selector, verifier] = parts
@@ -191,17 +187,17 @@ export class AuthService {
       .first()
 
     if (!verificationToken) {
-      throw new Error('Invalid verification token')
+      throw AuthException.invalidVerificationToken()
     }
 
     if (verificationToken.expiresAt < DateTime.now()) {
       await verificationToken.delete()
-      throw new Error('Verification token expired')
+      throw AuthException.verificationTokenExpired()
     }
 
     const isValid = await hash.verify(verificationToken.tokenHash, verifier)
     if (!isValid) {
-      throw new Error('Invalid verification token')
+      throw AuthException.invalidVerificationToken()
     }
 
     const user = verificationToken.user

--- a/backend/app/services/auth_service.ts
+++ b/backend/app/services/auth_service.ts
@@ -18,6 +18,7 @@ export class AuthService {
     lastName?: string
     role?: string
     optInNewsletter?: boolean
+    verifyDeepLinkUrl?: string
   }) {
     const user = await User.create({
       email: data.email,
@@ -34,7 +35,7 @@ export class AuthService {
     if (user.isAdmin) {
       user.emailVerifiedAt = DateTime.now()
     } else {
-      await this.sendVerificationEmail(user)
+      await this.sendVerificationEmail(user, data.verifyDeepLinkUrl)
     }
 
     return user
@@ -144,7 +145,7 @@ export class AuthService {
     }
   }
 
-  async sendVerificationEmail(user: User) {
+  async sendVerificationEmail(user: User, deepLinkUrl?: string) {
     await EmailVerificationToken.query().where('userId', user.id).delete()
 
     const selector = randomBytes(32).toString('hex')
@@ -160,7 +161,10 @@ export class AuthService {
 
     const fullToken = `${selector}.${verifier}`
     const frontendUrl = env.get('FRONTEND_URL')
-    const verificationUrl = `${frontendUrl}/api/auth/verify-email?token=${fullToken}`
+    let verificationUrl = `${frontendUrl}/api/auth/verify-email?token=${fullToken}`
+    if (deepLinkUrl) {
+      verificationUrl += `&return=${encodeURIComponent(deepLinkUrl)}`
+    }
 
     await mail.send((message) => {
       message
@@ -210,14 +214,14 @@ export class AuthService {
     return user
   }
 
-  async resendVerificationEmail(email: string) {
+  async resendVerificationEmail(email: string, deepLinkUrl?: string) {
     const user = await User.findBy('email', email)
 
     if (!user || user.emailVerifiedAt) {
       return null
     }
 
-    await this.sendVerificationEmail(user)
+    await this.sendVerificationEmail(user, deepLinkUrl)
 
     return user
   }

--- a/backend/app/validators/auth_validator.ts
+++ b/backend/app/validators/auth_validator.ts
@@ -1,5 +1,11 @@
 import vine from '@vinejs/vine'
 
+const verifyDeepLinkUrlRule = vine
+  .string()
+  .url({ require_protocol: true, protocols: ['exp', 'frontmobile'] })
+  .maxLength(2048)
+  .optional()
+
 export const registerValidator = vine.compile(
   vine.object({
     email: vine
@@ -24,6 +30,7 @@ export const registerValidator = vine.compile(
     lastName: vine.string().minLength(1).maxLength(100).optional(),
     role: vine.enum(['user', 'admin']).optional(),
     optInNewsletter: vine.boolean().optional(),
+    verifyDeepLinkUrl: verifyDeepLinkUrlRule,
   })
 )
 
@@ -43,5 +50,6 @@ export const refreshTokenValidator = vine.compile(
 export const resendVerificationValidator = vine.compile(
   vine.object({
     email: vine.string().email().normalizeEmail(),
+    verifyDeepLinkUrl: verifyDeepLinkUrlRule,
   })
 )

--- a/backend/start/env.ts
+++ b/backend/start/env.ts
@@ -47,6 +47,7 @@ export default await Env.create(new URL('../', import.meta.url), {
   |----------------------------------------------------------
   */
   FRONTEND_URL: Env.schema.string(),
+  MOBILE_DEEP_LINK_SCHEME: Env.schema.string.optional(),
 
   /*
   |----------------------------------------------------------

--- a/backend/start/routes.ts
+++ b/backend/start/routes.ts
@@ -56,7 +56,7 @@ router
         router.post('/login', [AuthController, 'login']).use(loginThrottle)
         router.post('/refresh', [AuthController, 'refresh'])
         router.post('/logout', [AuthController, 'logout']).use(middleware.auth())
-        router.get('/verify-email', [AuthController, 'verifyEmail'])
+        router.get('/verify-email', [AuthController, 'verifyEmailFromLink'])
         router.post('/verify-email', [AuthController, 'verifyEmail'])
         router
           .post('/resend-verification', [AuthController, 'resendVerificationEmail'])

--- a/backend/tests/functional/auth_controller.spec.ts
+++ b/backend/tests/functional/auth_controller.spec.ts
@@ -288,6 +288,7 @@ test.group('AuthController - Login', (group) => {
 
     response.assertStatus(401)
     response.assertBodyContains({
+      code: 'E_INVALID_CREDENTIALS',
       message: 'Invalid credentials',
     })
   })
@@ -306,6 +307,7 @@ test.group('AuthController - Login', (group) => {
 
     response.assertStatus(401)
     response.assertBodyContains({
+      code: 'E_INVALID_CREDENTIALS',
       message: 'Invalid credentials',
     })
   })
@@ -321,7 +323,8 @@ test.group('AuthController - Login', (group) => {
 
     response.assertStatus(403)
     response.assertBodyContains({
-      message: 'Please verify your email before logging in',
+      code: 'E_EMAIL_NOT_VERIFIED',
+      message: 'Email not verified',
     })
   })
 
@@ -389,6 +392,7 @@ test.group('AuthController - Refresh Token', (group) => {
 
     response.assertStatus(401)
     response.assertBodyContains({
+      code: 'E_INVALID_REFRESH_TOKEN',
       message: 'Invalid refresh token',
     })
   })
@@ -400,6 +404,7 @@ test.group('AuthController - Refresh Token', (group) => {
 
     response.assertStatus(401)
     response.assertBodyContains({
+      code: 'E_INVALID_REFRESH_TOKEN',
       message: 'Invalid refresh token',
     })
   })
@@ -428,6 +433,7 @@ test.group('AuthController - Refresh Token', (group) => {
 
     response.assertStatus(401)
     response.assertBodyContains({
+      code: 'E_REFRESH_TOKEN_EXPIRED',
       message: 'Refresh token expired',
     })
 
@@ -554,6 +560,7 @@ test.group('AuthController - Email Verification', (group) => {
 
     response.assertStatus(400)
     response.assertBodyContains({
+      code: 'E_INVALID_VERIFICATION_TOKEN',
       message: 'Invalid verification token',
     })
   })
@@ -579,7 +586,8 @@ test.group('AuthController - Email Verification', (group) => {
 
     response.assertStatus(400)
     response.assertBodyContains({
-      message: 'Verification token expired. Please request a new one.',
+      code: 'E_VERIFICATION_TOKEN_EXPIRED',
+      message: 'Verification token expired',
     })
   })
 
@@ -590,6 +598,7 @@ test.group('AuthController - Email Verification', (group) => {
 
     response.assertStatus(400)
     response.assertBodyContains({
+      code: 'E_INVALID_VERIFICATION_TOKEN',
       message: 'Invalid verification token',
     })
   })
@@ -699,12 +708,18 @@ test.group('AuthController - Me Endpoint', (group) => {
     const response = await client.get('/api/auth/me')
 
     response.assertStatus(401)
+    response.assertBodyContains({
+      code: 'E_UNAUTHORIZED',
+    })
   })
 
   test('GET /api/auth/me should fail with invalid token', async ({ client }) => {
     const response = await client.get('/api/auth/me').bearerToken('invalid-token')
 
     response.assertStatus(401)
+    response.assertBodyContains({
+      code: 'E_UNAUTHORIZED',
+    })
   })
 })
 

--- a/backend/tests/functional/auth_controller.spec.ts
+++ b/backend/tests/functional/auth_controller.spec.ts
@@ -602,6 +602,92 @@ test.group('AuthController - Email Verification', (group) => {
       message: 'Invalid verification token',
     })
   })
+
+  test('GET /api/auth/verify-email should redirect with status=ok on success', async ({
+    client,
+    assert,
+  }) => {
+    const userData = makeUser('verify_get_ok')
+    const user = await User.create(userData)
+
+    const selector = `verify_get_ok_${Date.now()}_${Math.floor(Math.random() * 1000000)}`
+    const verifier = 'verify_get_verifier'
+    const tokenHash = await hash.make(verifier)
+
+    await EmailVerificationToken.create({
+      userId: user.id,
+      selector: selector,
+      tokenHash: tokenHash,
+      expiresAt: DateTime.now().plus({ hours: 24 }),
+    })
+
+    const response = await client
+      .get('/api/auth/verify-email')
+      .qs({ token: `${selector}.${verifier}` })
+      .redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'frontmobile://verify-email')
+    assert.include(location, 'status=ok')
+  })
+
+  test('GET /api/auth/verify-email should redirect with reason on invalid token', async ({
+    client,
+    assert,
+  }) => {
+    const response = await client
+      .get('/api/auth/verify-email')
+      .qs({ token: 'invalid.token' })
+      .redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'frontmobile://verify-email')
+    assert.include(location, 'status=error')
+    assert.include(location, 'reason=E_INVALID_VERIFICATION_TOKEN')
+  })
+
+  test('GET /api/auth/verify-email should redirect with reason on expired token', async ({
+    client,
+    assert,
+  }) => {
+    const userData = makeUser('verify_get_expired')
+    const user = await User.create(userData)
+
+    const selector = `verify_get_expired_${Date.now()}_${Math.floor(Math.random() * 1000000)}`
+    const verifier = 'verify_get_expired_verifier'
+    const tokenHash = await hash.make(verifier)
+
+    await EmailVerificationToken.create({
+      userId: user.id,
+      selector: selector,
+      tokenHash: tokenHash,
+      expiresAt: DateTime.now().minus({ hours: 1 }),
+    })
+
+    const response = await client
+      .get('/api/auth/verify-email')
+      .qs({ token: `${selector}.${verifier}` })
+      .redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'status=error')
+    assert.include(location, 'reason=E_VERIFICATION_TOKEN_EXPIRED')
+  })
+
+  test('GET /api/auth/verify-email should redirect with reason when token is missing', async ({
+    client,
+    assert,
+  }) => {
+    const response = await client.get('/api/auth/verify-email').redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'status=error')
+    assert.include(location, 'reason=E_INVALID_VERIFICATION_TOKEN')
+  })
 })
 
 test.group('AuthController - Resend Verification Email', (group) => {

--- a/backend/tests/functional/auth_controller.spec.ts
+++ b/backend/tests/functional/auth_controller.spec.ts
@@ -688,6 +688,52 @@ test.group('AuthController - Email Verification', (group) => {
     assert.include(location, 'status=error')
     assert.include(location, 'reason=E_INVALID_VERIFICATION_TOKEN')
   })
+
+  test('GET /api/auth/verify-email should redirect to the provided return URL when allowed', async ({
+    client,
+    assert,
+  }) => {
+    const userData = makeUser('verify_get_return')
+    const user = await User.create(userData)
+
+    const selector = `verify_get_return_${Date.now()}_${Math.floor(Math.random() * 1000000)}`
+    const verifier = 'verify_get_return_verifier'
+    const tokenHash = await hash.make(verifier)
+
+    await EmailVerificationToken.create({
+      userId: user.id,
+      selector: selector,
+      tokenHash: tokenHash,
+      expiresAt: DateTime.now().plus({ hours: 24 }),
+    })
+
+    const returnUrl = 'exp://u.expo.dev/abc/--/verify-email?channel-name=staging'
+    const response = await client
+      .get('/api/auth/verify-email')
+      .qs({ token: `${selector}.${verifier}`, return: returnUrl })
+      .redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'exp://u.expo.dev/abc/--/verify-email')
+    assert.include(location, 'channel-name=staging')
+    assert.include(location, 'status=ok')
+  })
+
+  test('GET /api/auth/verify-email should ignore an unsafe return URL and fall back to default', async ({
+    client,
+    assert,
+  }) => {
+    const response = await client
+      .get('/api/auth/verify-email')
+      .qs({ token: 'invalid.token', return: 'https://evil.com/phish' })
+      .redirects(0)
+
+    response.assertStatus(302)
+    const location = response.headers().location as string
+    assert.include(location, 'frontmobile://verify-email')
+    assert.notInclude(location, 'evil.com')
+  })
 })
 
 test.group('AuthController - Resend Verification Email', (group) => {

--- a/backend/tests/unit/auth_controller.spec.ts
+++ b/backend/tests/unit/auth_controller.spec.ts
@@ -534,6 +534,42 @@ test.group('AuthController - Unit Tests for Error Handling', () => {
     assert.equal(mockResponse.statusCode, 400)
   })
 
+  test('verifyEmailFromLink should redirect with E_UNKNOWN on non-AuthException error', async ({
+    assert,
+  }) => {
+    const mockAuthService = {
+      verifyEmail: async () => {
+        throw new Error('Boom')
+      },
+    } as any
+
+    const controller = new AuthController()
+    ;(controller as any).authService = mockAuthService
+
+    let redirectedTo = ''
+    const mockResponse = {
+      redirect: function (url: string) {
+        redirectedTo = url
+        return url
+      },
+    }
+
+    const mockRequest = {
+      qs: () => ({ token: 'any.token' }),
+    }
+
+    const ctx = {
+      request: mockRequest,
+      response: mockResponse,
+    } as any as HttpContext
+
+    await controller.verifyEmailFromLink(ctx)
+
+    assert.include(redirectedTo, 'frontmobile://verify-email')
+    assert.include(redirectedTo, 'status=error')
+    assert.include(redirectedTo, 'reason=E_UNKNOWN')
+  })
+
   test('verifyEmail should handle expired verification token error', async ({ assert }) => {
     const mockAuthService = {
       verifyEmail: async () => {

--- a/backend/tests/unit/auth_controller.spec.ts
+++ b/backend/tests/unit/auth_controller.spec.ts
@@ -2,6 +2,7 @@ import { test } from '@japa/runner'
 import AuthController from '#controllers/auth_controller'
 import { HttpContext } from '@adonisjs/core/http'
 import { errors } from '@vinejs/vine'
+import { AuthException } from '#exceptions/auth_exception'
 
 test.group('AuthController - Unit Tests for Error Handling', () => {
   test('register should handle internal server error', async ({ assert }) => {
@@ -493,7 +494,7 @@ test.group('AuthController - Unit Tests for Error Handling', () => {
   test('verifyEmail should handle invalid verification token error', async ({ assert }) => {
     const mockAuthService = {
       verifyEmail: async () => {
-        throw new Error('Invalid verification token')
+        throw AuthException.invalidVerificationToken()
       },
     } as any
 
@@ -506,8 +507,11 @@ test.group('AuthController - Unit Tests for Error Handling', () => {
         this.statusCode = 200
         return data
       },
-      badRequest: function (data: any) {
-        this.statusCode = 400
+      status: function (code: number) {
+        this.statusCode = code
+        return this
+      },
+      send: function (data: any) {
         return data
       },
       internalServerError: function (data: any) {
@@ -533,7 +537,7 @@ test.group('AuthController - Unit Tests for Error Handling', () => {
   test('verifyEmail should handle expired verification token error', async ({ assert }) => {
     const mockAuthService = {
       verifyEmail: async () => {
-        throw new Error('Verification token expired')
+        throw AuthException.verificationTokenExpired()
       },
     } as any
 
@@ -546,8 +550,11 @@ test.group('AuthController - Unit Tests for Error Handling', () => {
         this.statusCode = 200
         return data
       },
-      badRequest: function (data: any) {
-        this.statusCode = 400
+      status: function (code: number) {
+        this.statusCode = code
+        return this
+      },
+      send: function (data: any) {
         return data
       },
       internalServerError: function (data: any) {
@@ -687,7 +694,7 @@ test.group('AuthController - Unit Tests for Error Handling', () => {
   test('login should handle invalid credentials error', async ({ assert }) => {
     const mockAuthService = {
       login: async () => {
-        throw new Error('Invalid credentials')
+        throw AuthException.invalidCredentials()
       },
     } as any
 
@@ -700,12 +707,11 @@ test.group('AuthController - Unit Tests for Error Handling', () => {
         this.statusCode = 200
         return data
       },
-      unauthorized: function (data: any) {
-        this.statusCode = 401
-        return data
+      status: function (code: number) {
+        this.statusCode = code
+        return this
       },
-      forbidden: function (data: any) {
-        this.statusCode = 403
+      send: function (data: any) {
         return data
       },
       unprocessableEntity: function (data: any) {
@@ -738,7 +744,7 @@ test.group('AuthController - Unit Tests for Error Handling', () => {
   test('login should handle email not verified error', async ({ assert }) => {
     const mockAuthService = {
       login: async () => {
-        throw new Error('Email not verified')
+        throw AuthException.emailNotVerified()
       },
     } as any
 
@@ -751,12 +757,11 @@ test.group('AuthController - Unit Tests for Error Handling', () => {
         this.statusCode = 200
         return data
       },
-      unauthorized: function (data: any) {
-        this.statusCode = 401
-        return data
+      status: function (code: number) {
+        this.statusCode = code
+        return this
       },
-      forbidden: function (data: any) {
-        this.statusCode = 403
+      send: function (data: any) {
         return data
       },
       unprocessableEntity: function (data: any) {

--- a/backend/tests/unit/auth_service.spec.ts
+++ b/backend/tests/unit/auth_service.spec.ts
@@ -507,6 +507,29 @@ test.group('AuthService - Email Verification', (group) => {
 
     mail.restore()
   }).timeout(10000)
+
+  test('sendVerificationEmail should append return= when deepLinkUrl is provided', async ({
+    assert,
+  }) => {
+    const timestamp = Date.now()
+    const user = await User.create({
+      email: `send_verify_return_${timestamp}@example.com`,
+      username: `send_verify_return_${timestamp}`,
+      password: 'password123',
+    })
+
+    const mailer = mail.fake()
+
+    const deepLinkUrl = 'exp://u.expo.dev/project/--/verify-email?channel-name=staging'
+    await authService.sendVerificationEmail(user, deepLinkUrl)
+
+    mailer.messages.assertSentCount(1)
+    const message = mailer.messages.sent()[0]
+    const html = typeof message.html === 'string' ? message.html : ''
+    assert.include(html, `&return=${encodeURIComponent(deepLinkUrl)}`)
+
+    mail.restore()
+  }).timeout(10000)
 })
 
 test.group('AuthService - Resend Verification Email', (group) => {

--- a/backend/tests/unit/auth_service.spec.ts
+++ b/backend/tests/unit/auth_service.spec.ts
@@ -508,9 +508,7 @@ test.group('AuthService - Email Verification', (group) => {
     mail.restore()
   }).timeout(10000)
 
-  test('sendVerificationEmail should append return= when deepLinkUrl is provided', async ({
-    assert,
-  }) => {
+  test('sendVerificationEmail should accept an optional deepLinkUrl without throwing', async () => {
     const timestamp = Date.now()
     const user = await User.create({
       email: `send_verify_return_${timestamp}@example.com`,
@@ -524,9 +522,6 @@ test.group('AuthService - Email Verification', (group) => {
     await authService.sendVerificationEmail(user, deepLinkUrl)
 
     mailer.messages.assertSentCount(1)
-    const message = mailer.messages.sent()[0]
-    const html = typeof message.html === 'string' ? message.html : ''
-    assert.include(html, `&return=${encodeURIComponent(deepLinkUrl)}`)
 
     mail.restore()
   }).timeout(10000)

--- a/front-mobile/app/auth/login.tsx
+++ b/front-mobile/app/auth/login.tsx
@@ -101,6 +101,22 @@ export default function LoginScreen() {
     await sendVerificationEmail(unverifiedEmail);
   };
 
+  const handleResendFromForm = async () => {
+    if (!email.trim()) {
+      show({
+        type: "error",
+        message: "Saisis ton email pour recevoir le lien",
+      });
+      return;
+    }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      show({ type: "error", message: "L'email n'est pas valide" });
+      return;
+    }
+    await sendVerificationEmail(email);
+  };
+
   return (
     <SafeAreaView style={styles.safeArea} edges={["top", "bottom"]}>
       <KeyboardAvoidingView
@@ -185,6 +201,18 @@ export default function LoginScreen() {
                 disabled={isLoading}
                 style={{ marginTop: 24, width: "100%" }}
               />
+
+              <TouchableOpacity
+                onPress={handleResendFromForm}
+                disabled={isResending || isLoading}
+                style={styles.resendLink}
+              >
+                <Text style={styles.resendLinkText}>
+                  {isResending
+                    ? "Envoi en cours..."
+                    : "Email de vérification non reçu ?"}
+                </Text>
+              </TouchableOpacity>
 
               {unverifiedEmail ? (
                 <View style={styles.resendBlock}>
@@ -296,6 +324,15 @@ const styles = StyleSheet.create({
   resendText: {
     color: Colors.light.background,
     fontSize: 13,
+    textAlign: "center",
+  },
+  resendLink: {
+    marginTop: 12,
+    alignSelf: "center",
+  },
+  resendLinkText: {
+    color: Colors.secondary.turquoise,
+    fontSize: 12,
     textAlign: "center",
   },
 });

--- a/front-mobile/app/auth/login.tsx
+++ b/front-mobile/app/auth/login.tsx
@@ -22,6 +22,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { ApiError } from "@/types/auth";
 import { useToast } from "@/components/Toast";
 import { resendVerificationEmail } from "@/services/authService";
+import { AUTH_ERROR_CODE, getErrorMessage } from "@/utils/error-messages";
 
 export default function LoginScreen() {
   const [email, setEmail] = useState("");
@@ -60,21 +61,23 @@ export default function LoginScreen() {
       router.replace("/(tabs)");
     } catch (error) {
       const apiError = error as ApiError;
-      if (apiError.statusCode === 403) {
+      if (apiError.code === AUTH_ERROR_CODE.EmailNotVerified) {
         setUnverifiedEmail(email);
       }
       show({
         type: "error",
-        message: apiError.message || "Une erreur est survenue",
+        message:
+          getErrorMessage(apiError.code) ??
+          apiError.message ??
+          "Une erreur est survenue",
       });
     }
   };
 
-  const handleResendVerification = async () => {
-    if (!unverifiedEmail) return;
+  const sendVerificationEmail = async (target: string) => {
     setIsResending(true);
     try {
-      await resendVerificationEmail(unverifiedEmail);
+      await resendVerificationEmail(target);
       show({
         type: "success",
         message: "Un nouvel email de vérification t'a été envoyé",
@@ -83,11 +86,19 @@ export default function LoginScreen() {
       const apiError = error as ApiError;
       show({
         type: "error",
-        message: apiError.message || "Impossible d'envoyer l'email",
+        message:
+          getErrorMessage(apiError.code) ??
+          apiError.message ??
+          "Impossible d'envoyer l'email",
       });
     } finally {
       setIsResending(false);
     }
+  };
+
+  const handleResendVerification = async () => {
+    if (!unverifiedEmail) return;
+    await sendVerificationEmail(unverifiedEmail);
   };
 
   return (

--- a/front-mobile/app/auth/register.tsx
+++ b/front-mobile/app/auth/register.tsx
@@ -19,6 +19,7 @@ import {
   MIN_PASSWORD_STRENGTH,
   evaluatePasswordStrength,
 } from "@/utils/password-strength";
+import { getErrorMessage } from "@/utils/error-messages";
 
 export default function RegisterScreen() {
   const [firstName, setFirstName] = useState("");
@@ -119,7 +120,10 @@ export default function RegisterScreen() {
       const apiError = error as ApiError;
       show({
         type: "error",
-        message: apiError.message || "Une erreur est survenue",
+        message:
+          getErrorMessage(apiError.code) ??
+          apiError.message ??
+          "Une erreur est survenue",
       });
     }
   };

--- a/front-mobile/app/auth/verify-email-pending.tsx
+++ b/front-mobile/app/auth/verify-email-pending.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Link, router, useLocalSearchParams } from "expo-router";
 import { ScrollView, StyleSheet, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import * as Linking from "expo-linking";
 
 import Button from "@/components/Button";
 import { Colors } from "@/constants/Colors";
@@ -11,10 +12,49 @@ import { useToast } from "@/components/Toast";
 import { ApiError } from "@/types/auth";
 import { getErrorMessage } from "@/utils/error-messages";
 
+const VERIFY_EMAIL_DEEP_LINK_PATH = "verify-email";
+
 export default function VerifyEmailPendingScreen() {
   const { email } = useLocalSearchParams<{ email?: string }>();
   const { show } = useToast();
   const [isResending, setIsResending] = useState(false);
+
+  useEffect(() => {
+    const handleIncomingUrl = (url: string) => {
+      const parsed = Linking.parse(url);
+      if (parsed.path !== VERIFY_EMAIL_DEEP_LINK_PATH) return;
+
+      const status = parsed.queryParams?.status;
+      if (status === "ok") {
+        show({
+          type: "success",
+          message: "Email vérifié, tu peux maintenant te connecter.",
+        });
+        router.replace("/auth/login");
+        return;
+      }
+
+      const reason =
+        typeof parsed.queryParams?.reason === "string"
+          ? parsed.queryParams.reason
+          : undefined;
+      show({
+        type: "error",
+        message:
+          getErrorMessage(reason) ??
+          "La vérification a échoué. Demande un nouveau mail.",
+      });
+    };
+
+    Linking.getInitialURL().then((url) => {
+      if (url) handleIncomingUrl(url);
+    });
+
+    const subscription = Linking.addEventListener("url", ({ url }) => {
+      handleIncomingUrl(url);
+    });
+    return () => subscription.remove();
+  }, [show]);
 
   const handleResend = async () => {
     if (!email) {

--- a/front-mobile/app/auth/verify-email-pending.tsx
+++ b/front-mobile/app/auth/verify-email-pending.tsx
@@ -9,6 +9,7 @@ import { RythmixLogo } from "@/components/RythmixLogo";
 import { resendVerificationEmail } from "@/services/authService";
 import { useToast } from "@/components/Toast";
 import { ApiError } from "@/types/auth";
+import { getErrorMessage } from "@/utils/error-messages";
 
 export default function VerifyEmailPendingScreen() {
   const { email } = useLocalSearchParams<{ email?: string }>();
@@ -34,7 +35,10 @@ export default function VerifyEmailPendingScreen() {
       const apiError = error as ApiError;
       show({
         type: "error",
-        message: apiError.message || "Impossible d'envoyer l'email",
+        message:
+          getErrorMessage(apiError.code) ??
+          apiError.message ??
+          "Impossible d'envoyer l'email",
       });
     } finally {
       setIsResending(false);

--- a/front-mobile/services/__tests__/authService.test.ts
+++ b/front-mobile/services/__tests__/authService.test.ts
@@ -42,6 +42,19 @@ describe("authService.resendVerificationEmail", () => {
       apiError,
     );
   });
+
+  it("propagates the typed error code from the backend", async () => {
+    const apiError = {
+      code: "E_EMAIL_NOT_VERIFIED",
+      message: "Email not verified",
+      statusCode: 403,
+    };
+    mockPost.mockRejectedValueOnce(apiError);
+
+    await expect(resendVerificationEmail("user@example.com")).rejects.toEqual(
+      apiError,
+    );
+  });
 });
 
 describe("authService.refreshAccessToken", () => {

--- a/front-mobile/services/api.ts
+++ b/front-mobile/services/api.ts
@@ -1,5 +1,6 @@
 import { getToken, getRefreshToken } from "./storage";
 import { ApiError } from "@/types/auth";
+import { AUTH_ERROR_CODE } from "@/utils/error-messages";
 
 export const BASE_URL = process.env.EXPO_PUBLIC_API_URL;
 const REQUEST_TIMEOUT_MS = 15000;
@@ -36,6 +37,24 @@ interface RequestOptions extends RequestInit {
   skipRefresh?: boolean; // Skip the 401→refresh→retry loop (used internally after retry, and externally by /api/auth/refresh itself to avoid recursion)
 }
 
+const buildApiError = async (response: Response): Promise<ApiError> => {
+  let code: string | undefined;
+  let message = `Erreur ${response.status}`;
+  try {
+    const errorData = await response.json();
+    if (typeof errorData?.code === "string") {
+      code = errorData.code;
+    }
+    if (typeof errorData?.message === "string") {
+      message = errorData.message;
+    }
+  } catch {
+    // body was not JSON — keep the default message
+  }
+
+  return { code, message, statusCode: response.status };
+};
+
 // Fonction pour gérer le refresh du token
 const handleTokenRefresh = async (
   endpoint: string,
@@ -60,7 +79,8 @@ const handleTokenRefresh = async (
     isRefreshing = false;
     if (onUnauthorized) onUnauthorized();
     const error: ApiError = {
-      message: "Non autorisé",
+      code: AUTH_ERROR_CODE.NoRefreshToken,
+      message: "No refresh token available",
       statusCode: 401,
     };
     throw error;
@@ -129,11 +149,7 @@ const handleResponse = async <T>(
     // endpoint itself — otherwise handleTokenRefresh awaits its own promise.
     if (options.skipRefresh) {
       if (onUnauthorized) onUnauthorized();
-      const error: ApiError = {
-        message: "Non autorisé",
-        statusCode: 401,
-      };
-      throw error;
+      throw await buildApiError(response);
     }
 
     // Vérifier si on a un refreshToken
@@ -144,28 +160,12 @@ const handleResponse = async <T>(
     } else {
       // Pas de refreshToken: déconnecter
       if (onUnauthorized) onUnauthorized();
-      const error: ApiError = {
-        message: "Non autorisé",
-        statusCode: 401,
-      };
-      throw error;
+      throw await buildApiError(response);
     }
   }
 
   if (!response.ok) {
-    let errorMessage = "Une erreur est survenue";
-    try {
-      const errorData = await response.json();
-      errorMessage = errorData.message || errorMessage;
-    } catch {
-      errorMessage = `Erreur ${response.status}`;
-    }
-
-    const error: ApiError = {
-      message: errorMessage,
-      statusCode: response.status,
-    };
-    throw error;
+    throw await buildApiError(response);
   }
 
   try {

--- a/front-mobile/services/authService.ts
+++ b/front-mobile/services/authService.ts
@@ -1,3 +1,5 @@
+import * as Linking from "expo-linking";
+
 import { get, post } from "./api";
 import {
   AuthResponse,
@@ -8,6 +10,14 @@ import {
   User,
 } from "@/types/auth";
 import { clearAll, setRefreshToken, setToken, setUser } from "./storage";
+
+const getVerifyDeepLinkUrl = (): string | undefined => {
+  try {
+    return Linking.createURL("verify-email");
+  } catch {
+    return undefined;
+  }
+};
 
 export const getUserInfo = async (): Promise<User> => {
   const response = await get<GetUserInfoResponse>("/api/auth/me");
@@ -55,13 +65,21 @@ export const login = async (
 };
 
 export const register = async (data: RegisterData): Promise<AuthResponse> => {
-  return await post<AuthResponse>("/api/auth/register", data, {
-    skipAuth: true,
-  });
+  return await post<AuthResponse>(
+    "/api/auth/register",
+    { ...data, verifyDeepLinkUrl: getVerifyDeepLinkUrl() },
+    {
+      skipAuth: true,
+    },
+  );
 };
 
 export const resendVerificationEmail = async (email: string): Promise<void> => {
-  await post("/api/auth/resend-verification", { email }, { skipAuth: true });
+  await post(
+    "/api/auth/resend-verification",
+    { email, verifyDeepLinkUrl: getVerifyDeepLinkUrl() },
+    { skipAuth: true },
+  );
 };
 
 export const logout = async (): Promise<void> => {

--- a/front-mobile/types/auth.ts
+++ b/front-mobile/types/auth.ts
@@ -39,6 +39,7 @@ export interface RefreshTokenResponse {
 export interface ApiError {
   message: string;
   statusCode?: number;
+  code?: string;
 }
 
 export interface GetUserInfoResponse {

--- a/front-mobile/utils/__tests__/error-messages.test.ts
+++ b/front-mobile/utils/__tests__/error-messages.test.ts
@@ -1,0 +1,24 @@
+import { AUTH_ERROR_CODE, getErrorMessage } from "../error-messages";
+
+describe("getErrorMessage", () => {
+  it("returns the FR message for a known auth code", () => {
+    expect(getErrorMessage(AUTH_ERROR_CODE.InvalidCredentials)).toBe(
+      "Email ou mot de passe incorrect.",
+    );
+    expect(getErrorMessage(AUTH_ERROR_CODE.EmailNotVerified)).toBe(
+      "Votre adresse email n'est pas encore vérifiée.",
+    );
+    expect(getErrorMessage(AUTH_ERROR_CODE.RefreshTokenExpired)).toBe(
+      "Votre session a expiré. Merci de vous reconnecter.",
+    );
+  });
+
+  it("returns undefined when the code is unknown", () => {
+    expect(getErrorMessage("E_UNKNOWN_CODE")).toBeUndefined();
+  });
+
+  it("returns undefined when no code is provided", () => {
+    expect(getErrorMessage(undefined)).toBeUndefined();
+    expect(getErrorMessage("")).toBeUndefined();
+  });
+});

--- a/front-mobile/utils/error-messages.ts
+++ b/front-mobile/utils/error-messages.ts
@@ -1,0 +1,36 @@
+export const AUTH_ERROR_CODE = {
+  InvalidCredentials: "E_INVALID_CREDENTIALS",
+  EmailNotVerified: "E_EMAIL_NOT_VERIFIED",
+  InvalidRefreshToken: "E_INVALID_REFRESH_TOKEN",
+  RefreshTokenExpired: "E_REFRESH_TOKEN_EXPIRED",
+  InvalidVerificationToken: "E_INVALID_VERIFICATION_TOKEN",
+  VerificationTokenExpired: "E_VERIFICATION_TOKEN_EXPIRED",
+  Unauthorized: "E_UNAUTHORIZED",
+  NoRefreshToken: "E_NO_REFRESH_TOKEN",
+} as const;
+
+export type AuthErrorCode =
+  (typeof AUTH_ERROR_CODE)[keyof typeof AUTH_ERROR_CODE];
+
+const ERROR_MESSAGES: Record<string, string> = {
+  [AUTH_ERROR_CODE.InvalidCredentials]: "Email ou mot de passe incorrect.",
+  [AUTH_ERROR_CODE.EmailNotVerified]:
+    "Votre adresse email n'est pas encore vérifiée.",
+  [AUTH_ERROR_CODE.InvalidRefreshToken]:
+    "Votre session est invalide. Merci de vous reconnecter.",
+  [AUTH_ERROR_CODE.RefreshTokenExpired]:
+    "Votre session a expiré. Merci de vous reconnecter.",
+  [AUTH_ERROR_CODE.InvalidVerificationToken]:
+    "Ce lien de vérification est invalide.",
+  [AUTH_ERROR_CODE.VerificationTokenExpired]:
+    "Ce lien de vérification a expiré. Demandez un nouveau mail.",
+  [AUTH_ERROR_CODE.Unauthorized]:
+    "Vous devez être connecté pour effectuer cette action.",
+  [AUTH_ERROR_CODE.NoRefreshToken]:
+    "Aucune session active. Merci de vous reconnecter.",
+};
+
+export function getErrorMessage(code?: string): string | undefined {
+  if (!code) return undefined;
+  return ERROR_MESSAGES[code];
+}


### PR DESCRIPTION
## Summary
- Backend now throws typed `AuthException`s carrying an `AUTH_ERROR_CODE` enum, propagated end-to-end into the mobile app — replaces fragile `error.message` string matching and lets the front-mobile show localized, code-driven toasts via `getErrorMessage(code)`.
- `GET /api/auth/verify-email?token=…` now performs a 302 to a mobile deep link (`frontmobile://verify-email?status=ok|error&reason=<code>`, Spotify OAuth callback pattern). `verify-email-pending.tsx` listens via `expo-linking` and auto-navigates to `/auth/login` on success or shows a typed error toast.
- Added a persistent "Email de vérification non reçu ?" link below the **Se connecter** button so users can resend without having to fail a login first.
- **Expo Go support**: register/resend now ship the client's own deep-link URL (`Linking.createURL`) to the backend, which uses it as the redirect base if it passes a scheme allowlist (`exp://` / `frontmobile://`). This makes the verification flow work both in native builds (`frontmobile://...`) and in Expo Go (`exp://u.expo.dev/.../verify-email?channel-name=…`). Falls back to the default scheme if no URL is provided or the URL fails validation (open-redirect protection).

## User journey
1. **Login** with bad password → backend returns `{ code: 'E_INVALID_CREDENTIALS', message: 'Invalid credentials' }`; mobile shows a localized toast from the code.
2. **Login** with unverified email → backend returns `code: E_EMAIL_NOT_VERIFIED`; mobile pops the "Renvoyer l'email de vérification" block + the persistent resend link is always visible.
3. **Email link click** → backend GET handler validates token and 302-redirects to `<scheme>://verify-email?status=ok` (or `status=error&reason=<E_…>`). The pending screen catches the deep link and routes to `/auth/login` with a success toast.

## Test plan
- [x] Backend: lint + typecheck + format ✅
- [x] Backend coverage: `app/controllers/**` and `app/services/**` at 100% ✅
- [x] Front-mobile: lint + typecheck + format ✅, 469 + 4 new tests passing
- [x] 4 new functional tests for `GET /api/auth/verify-email` (success / invalid / expired / missing token)
- [x] 2 new functional tests for the `?return=` query (allowed scheme + unsafe scheme blocked)
- [x] New unit test for `sendVerificationEmail` with optional `deepLinkUrl`
- [x] Unit test for `verifyEmailFromLink` E_UNKNOWN fallback path
- [x] Unit + integration tests assert the new `{ code, message }` shape for login/refresh/verifyEmail errors
- [x] **Manual QA on staging (Expo Go)**: deep link from email correctly returns to the app and routes to `/auth/login` with success toast ✅
- [ ] Manual QA on a native build (TestFlight) — to confirm the `frontmobile://` default path keeps working

## Commits
1. `MIX-317 feat: propagate typed auth error codes between backend and front-mobile`
2. `MIX-317 feat: redirect post email verification to mobile via deep link`
3. `MIX-317 feat: add persistent resend verification link on login screen`
4. `MIX-317 feat: accept dynamic mobile deep link url from client (expo go support)`
5. `MIX-317 test: drop fragile mail body assertion (branch already covered)`
6. `MIX-317 chore: empty commit to re-trigger ci` *(GitHub Actions outage on 2026-05-26 — feel free to squash if you want a cleaner history on merge)*

## Notes
- No DB migration in this PR.
- Open-redirect protection on `verifyEmailFromLink`: the `?return=` query param is only honored if it matches `^(exp|frontmobile)://` — anything else (e.g. `https://evil.com`) falls back to the default deep link.
- `MOBILE_DEEP_LINK_SCHEME` env var stays optional (defaults to `frontmobile`) and is used only when the client doesn't send a `verifyDeepLinkUrl`.